### PR TITLE
Add demote support to Update-PfbFileSystem (-DiscardNonSnapshottedData, -RequestedPromotionState)

### DIFF
--- a/Public/FileSystem/Update-PfbFileSystem.ps1
+++ b/Public/FileSystem/Update-PfbFileSystem.ps1
@@ -30,6 +30,16 @@ function Update-PfbFileSystem {
         Enable or disable HTTP protocol access.
     .PARAMETER Destroyed
         Set to $true to destroy or $false to recover the file system.
+    .PARAMETER RequestedPromotionState
+        The requested promotion state of the file system: 'promoted' (read-write) or
+        'demoted' (read-only replication target). Demoting is only allowed when the file
+        system is in a replica-link relationship and requires -DiscardNonSnapshottedData.
+        Mutually exclusive with -Attributes (supply the field via -Attributes instead if you
+        are already passing a raw attribute hashtable).
+    .PARAMETER DiscardNonSnapshottedData
+        When demoting a file system (requested_promotion_state = 'demoted'), acknowledge and
+        discard any data written since the last replicated snapshot. Sent as the
+        discard_non_snapshotted_data=true query parameter. Has no effect on a promote.
     .PARAMETER Attributes
         A hashtable of attributes to update.
     .PARAMETER Array
@@ -38,6 +48,12 @@ function Update-PfbFileSystem {
         Update-PfbFileSystem -Name "fs1" -Provisioned 2147483648
     .EXAMPLE
         Update-PfbFileSystem -Name "fs1" -Attributes @{ provisioned = 2147483648 }
+    .EXAMPLE
+        # Demote a file system to a read-only replication target, discarding un-replicated writes
+        Update-PfbFileSystem -Name "fs1" -RequestedPromotionState demoted -DiscardNonSnapshottedData
+    .EXAMPLE
+        # Equivalent demote using a raw attribute hashtable
+        Update-PfbFileSystem -Name "fs1" -Attributes @{ requested_promotion_state = 'demoted' } -DiscardNonSnapshottedData
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
     param(
@@ -78,6 +94,13 @@ function Update-PfbFileSystem {
         [Nullable[bool]]$Destroyed,
 
         [Parameter()]
+        [ValidateSet('promoted', 'demoted')]
+        [string]$RequestedPromotionState,
+
+        [Parameter()]
+        [switch]$DiscardNonSnapshottedData,
+
+        [Parameter()]
         [hashtable]$Attributes,
 
         [Parameter()]
@@ -89,6 +112,10 @@ function Update-PfbFileSystem {
     }
 
     process {
+        if ($Attributes -and $RequestedPromotionState) {
+            throw "-Attributes and -RequestedPromotionState are mutually exclusive. Set 'requested_promotion_state' inside -Attributes, or use -RequestedPromotionState on its own."
+        }
+
         if ($Attributes) {
             $body = $Attributes
         }
@@ -113,11 +140,14 @@ function Update-PfbFileSystem {
             if ($smbBody.Count -gt 0)                         { $body['smb'] = $smbBody }
 
             if ($PSBoundParameters.ContainsKey('HttpEnabled')) { $body['http'] = @{ enabled = [bool]$HttpEnabled } }
+
+            if ($RequestedPromotionState) { $body['requested_promotion_state'] = $RequestedPromotionState }
         }
 
         $queryParams = @{}
         if ($Name) { $queryParams['names'] = $Name }
         if ($Id)   { $queryParams['ids']   = $Id }
+        if ($DiscardNonSnapshottedData) { $queryParams['discard_non_snapshotted_data'] = 'true' }
 
         $target = if ($Name) { $Name } else { $Id }
 

--- a/PureStorageFlashBladePowerShell.psd1
+++ b/PureStorageFlashBladePowerShell.psd1
@@ -1,6 +1,6 @@
 ﻿@{
     RootModule        = 'PureStorageFlashBladePowerShell.psm1'
-    ModuleVersion     = '2.0.4'
+    ModuleVersion     = '2.0.5'
     GUID              = 'b25473b3-9eb7-414d-8da1-264e10f73d86'
     Author            = 'Pure Storage, Inc.'
     CompanyName       = 'Pure Storage, Inc.'
@@ -544,6 +544,14 @@
             ProjectUri   = 'https://github.com/PureStorage-OpenConnect/flashblade-powershell-toolkit'
             LicenseUri   = 'https://github.com/PureStorage-OpenConnect/flashblade-powershell-toolkit/blob/master/LICENSE'
             ReleaseNotes = @'
+v2.0.5 - File-system demote support. See CHANGELOG.md.
+  Changed:
+  - Update-PfbFileSystem: added -DiscardNonSnapshottedData switch (sends the
+    discard_non_snapshotted_data=true query param) and a typed -RequestedPromotionState
+    ('promoted' | 'demoted') parameter to support demoting a file system to a read-only
+    replication target without dropping to raw REST. -RequestedPromotionState is mutually
+    exclusive with -Attributes (throws if both supplied). Promote was already supported.
+
 v2.0.3 - Real-AD test suite + HTML report generator. See CHANGELOG.md.
   Added:
   - Tests/SmbShareScript.AD.Tests.ps1: 8 live tests with a real AD identity as

--- a/Tests/Update-PfbFileSystem.Demote.Tests.ps1
+++ b/Tests/Update-PfbFileSystem.Demote.Tests.ps1
@@ -1,0 +1,84 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    $moduleRoot = Split-Path -Parent $PSScriptRoot
+    $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
+    Import-Module $manifest -Force
+
+    # A throwaway connection object; Assert-PfbConnection is mocked so its contents don't matter.
+    $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
+}
+
+Describe 'Update-PfbFileSystem - file-system demote support' {
+
+    BeforeEach {
+        # Isolate the REST layer: never make a real call, just capture what would be sent.
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+    }
+
+    Context '-DiscardNonSnapshottedData switch' {
+        It 'adds discard_non_snapshotted_data=true to the query params when present' {
+            Update-PfbFileSystem -Name 'fs1' `
+                -Attributes @{ requested_promotion_state = 'demoted' } `
+                -DiscardNonSnapshottedData -Confirm:$false -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                $Method -eq 'PATCH' -and
+                $Endpoint -eq 'file-systems' -and
+                $QueryParams['names'] -eq 'fs1' -and
+                $QueryParams['discard_non_snapshotted_data'] -eq 'true'
+            }
+        }
+
+        It 'does NOT add the key when the switch is absent (no regression)' {
+            Update-PfbFileSystem -Name 'fs1' -Provisioned 2147483648 -Confirm:$false -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                $QueryParams['names'] -eq 'fs1' -and
+                -not $QueryParams.ContainsKey('discard_non_snapshotted_data')
+            }
+        }
+    }
+
+    Context '-RequestedPromotionState typed parameter' {
+        It 'sets requested_promotion_state in the body' {
+            Update-PfbFileSystem -Name 'fs1' -RequestedPromotionState 'demoted' `
+                -DiscardNonSnapshottedData -Confirm:$false -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                $Body['requested_promotion_state'] -eq 'demoted' -and
+                $QueryParams['discard_non_snapshotted_data'] -eq 'true'
+            }
+        }
+
+        It 'rejects values outside the promoted/demoted set at parameter binding' {
+            { Update-PfbFileSystem -Name 'fs1' -RequestedPromotionState 'bogus' -Array $fakeArray } |
+                Should -Throw
+        }
+
+        It 'throws when both -Attributes and -RequestedPromotionState are supplied' {
+            { Update-PfbFileSystem -Name 'fs1' `
+                -Attributes @{ requested_promotion_state = 'demoted' } `
+                -RequestedPromotionState 'demoted' -Confirm:$false -Array $fakeArray } |
+                Should -Throw '*mutually exclusive*'
+        }
+    }
+
+    Context 'end-to-end demote shape (mocked)' {
+        It 'produces body { requested_promotion_state = demoted } and query { names; discard_non_snapshotted_data = true }' {
+            Update-PfbFileSystem -Name 'fs1' `
+                -Attributes @{ requested_promotion_state = 'demoted' } `
+                -DiscardNonSnapshottedData -Confirm:$false -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                $Method -eq 'PATCH' -and
+                $Endpoint -eq 'file-systems' -and
+                $Body['requested_promotion_state'] -eq 'demoted' -and
+                $Body.Keys.Count -eq 1 -and
+                $QueryParams['names'] -eq 'fs1' -and
+                $QueryParams['discard_non_snapshotted_data'] -eq 'true'
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

A file-system **demote** (set a promoted/read-write FS to a read-only replication target) previously required dropping to raw REST. This adds two parameters to `Update-PfbFileSystem`:

- `-DiscardNonSnapshottedData` (switch): sends the `discard_non_snapshotted_data=true` query param, required by the API when demoting.
- `-RequestedPromotionState` (`promoted`|`demoted`): sets `requested_promotion_state` in the request body. Mutually exclusive with `-Attributes` (throws if both are supplied — no silent precedence).

Resulting request:
```
PATCH /file-systems?names=fs1&discard_non_snapshotted_data=true
Body: { "requested_promotion_state": "demoted" }
```

Promote was already supported via `-Attributes @{ requested_promotion_state = 'promoted' }` and is unchanged. Omitting the new switch produces the identical request as before this change — no regression to existing callers.

Field names verified against `FB-2.26-openapi.json`: `discard_non_snapshotted_data` is a query boolean, `requested_promotion_state` is a writable PATCH body field with values `promoted`/`demoted`.

## Changes

- `Public/FileSystem/Update-PfbFileSystem.ps1` — new params, body/query wiring, mutual-exclusion guard, comment-based help (+2 demote examples).
- `PureStorageFlashBladePowerShell.psd1` — `ModuleVersion` `2.0.4 -> 2.0.5` + new `v2.0.5` `ReleaseNotes` entry.
- `Tests/Update-PfbFileSystem.Demote.Tests.ps1` — new Pester 5 suite (6 tests): switch present/absent, typed-param body, end-to-end demote shape, `ValidateSet` rejection, both-supplied guard.

## Test plan

- [x] `Invoke-Pester Tests/Update-PfbFileSystem.Demote.Tests.ps1` — 6/6 pass
- [x] Parser check on both modified files — clean
- [x] Full module build succeeds (520 public functions) — verified via a local workaround; **note:** `build.ps1` at repo root currently fails as committed on `main` because it resolves `$repoRoot` as if the script lived in `<repo>/scripts/` (introduced in the same `fc6d8de1` / v2.0.4 commit), but the file is still at repo root. Unrelated to this PR — happy to open a separate fix if useful.