### PR TITLE
Add automatic OAuth2 access-token refresh to Connect-PfbArray

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,10 @@ swagger.json
 .fb*-spec.yaml
 Tests/.coverage-*.csv
 
+# AI-planning workflow artifacts — working docs, not shipped documentation
+.superpowers/
+docs/superpowers/
+
 # PowerShell
 *.pssproj.user
 

--- a/Private/Invoke-PfbApiRequest.ps1
+++ b/Private/Invoke-PfbApiRequest.ps1
@@ -35,6 +35,31 @@ function Invoke-PfbApiRequest {
         [string]$ApiVersionOverride
     )
 
+    # Certificate/OAuth2 sessions: proactively refresh the access token before it expires,
+    # rather than waiting for a 401. A proactive refresh generates no failed-authentication
+    # entry in the array's session log, unlike a reactive 401-triggered refresh.
+    if ($Array.AuthMethod -eq 'Certificate' -and $Array.TokenExpiresAt) {
+        $buffer = [Math]::Min(30, $Array.TokenTtlSeconds * 0.10)
+        $refreshAt = $Array.TokenExpiresAt.AddSeconds(-$buffer)
+        if ((Get-Date).ToUniversalTime() -ge $refreshAt) {
+            $refreshed = Invoke-PfbOAuth2Login -Endpoint $Array.Endpoint -ClientId $Array.ClientId `
+                -Issuer $Array.Issuer -KeyId $Array.KeyId -Username $Array.Username `
+                -PrivateKeyFile $Array.PrivateKeyFile -PrivateKeyPassword $Array.PrivateKeyPassword `
+                -SkipCertificateCheck:$Array.SkipCertificateCheck
+            $Array.BearerToken = $refreshed.AccessToken
+            $Array.AuthToken = $refreshed.AccessToken
+            $Array.TokenExpiresAt = $refreshed.ExpiresAt
+            $Array.TokenTtlSeconds = $refreshed.TtlSeconds
+
+            if ($script:PfbDefaultArray -and $script:PfbDefaultArray.Endpoint -eq $Array.Endpoint) {
+                $script:PfbDefaultArray = $Array
+            }
+            if ($script:PfbArrays.ContainsKey($Array.Endpoint)) {
+                $script:PfbArrays[$Array.Endpoint] = $Array
+            }
+        }
+    }
+
     $apiVer = if ($ApiVersionOverride) { $ApiVersionOverride } else { $Array.ApiVersion }
     $baseUrl = "https://$($Array.Endpoint)/api/${apiVer}"
     $queryString = ConvertTo-PfbQueryString -Parameters $QueryParams
@@ -85,14 +110,33 @@ function Invoke-PfbApiRequest {
                 $statusCode = [int]$_.Exception.Response.StatusCode
             }
 
-            # Auto-reconnect on 401 if we have a stored API token
-            if ($statusCode -eq 401 -and $isFirstRequest -and -not [string]::IsNullOrEmpty($Array.ApiToken)) {
+            # Auto-reconnect on 401: ApiToken/Credential/PSCredential sessions have a
+            # cached long-lived API token; Certificate sessions refresh the OAuth2
+            # access token instead (fallback for what the proactive check above can't
+            # anticipate: clock skew, or early revocation).
+            $canReconnect = ($isFirstRequest -and (
+                -not [string]::IsNullOrEmpty($Array.ApiToken) -or $Array.AuthMethod -eq 'Certificate'
+            ))
+            if ($statusCode -eq 401 -and $canReconnect) {
                 $reconnectSucceeded = $false
                 try {
-                    $reconnected = Connect-PfbArrayInternal -Endpoint $Array.Endpoint -ApiToken $Array.ApiToken -ApiVersion $Array.ApiVersion -SkipCertificateCheck:$Array.SkipCertificateCheck
-                    $Array.AuthToken = $reconnected.AuthToken
-                    $Array.ConnectedAt = $reconnected.ConnectedAt
-                    $headers['x-auth-token'] = $Array.AuthToken
+                    if ($Array.AuthMethod -eq 'Certificate') {
+                        $refreshed = Invoke-PfbOAuth2Login -Endpoint $Array.Endpoint -ClientId $Array.ClientId `
+                            -Issuer $Array.Issuer -KeyId $Array.KeyId -Username $Array.Username `
+                            -PrivateKeyFile $Array.PrivateKeyFile -PrivateKeyPassword $Array.PrivateKeyPassword `
+                            -SkipCertificateCheck:$Array.SkipCertificateCheck
+                        $Array.BearerToken = $refreshed.AccessToken
+                        $Array.AuthToken = $refreshed.AccessToken
+                        $Array.TokenExpiresAt = $refreshed.ExpiresAt
+                        $Array.TokenTtlSeconds = $refreshed.TtlSeconds
+                        $headers['Authorization'] = "Bearer $($Array.BearerToken)"
+                    }
+                    else {
+                        $reconnected = Connect-PfbArrayInternal -Endpoint $Array.Endpoint -ApiToken $Array.ApiToken -ApiVersion $Array.ApiVersion -SkipCertificateCheck:$Array.SkipCertificateCheck
+                        $Array.AuthToken = $reconnected.AuthToken
+                        $Array.ConnectedAt = $reconnected.ConnectedAt
+                        $headers['x-auth-token'] = $Array.AuthToken
+                    }
                     $restParams['Headers'] = $headers
 
                     # Update the stored connection

--- a/Private/Invoke-PfbApiRequest.ps1
+++ b/Private/Invoke-PfbApiRequest.ps1
@@ -126,7 +126,16 @@ function Invoke-PfbApiRequest {
             $canReconnect = ($isFirstRequest -and (
                 -not [string]::IsNullOrEmpty($Array.ApiToken) -or $Array.AuthMethod -eq 'Certificate'
             ))
-            if ($statusCode -eq 401 -and $canReconnect) {
+
+            # Live testing against a real FlashBlade array (Purity//FB 4.8.2 / REST 2.26) proved it
+            # returns HTTP 403, not 401, for ANY invalid Bearer-token auth failure (confirmed with
+            # both a genuinely-expired OAuth2 access token and a garbage bearer token). Without this,
+            # the Certificate/OAuth2 reactive-refresh safety net above never actually triggers against
+            # that array. ApiToken/Credential/PSCredential use a different mechanism (the x-auth-token
+            # session header) that has NOT been proven to share this 403-for-invalid-auth behavior, so
+            # those parameter sets deliberately stay 401-only.
+            $isAuthFailureStatus = ($statusCode -eq 401) -or ($statusCode -eq 403 -and $Array.AuthMethod -eq 'Certificate')
+            if ($isAuthFailureStatus -and $canReconnect) {
                 $reconnectSucceeded = $false
                 try {
                     if ($Array.AuthMethod -eq 'Certificate') {
@@ -278,8 +287,13 @@ function ConvertTo-PfbApiError {
     if ($ErrorRecord.ErrorDetails.Message) {
         try {
             $apiError = $ErrorRecord.ErrorDetails.Message | ConvertFrom-Json
-            if ($apiError.errors) {
-                $errorMessage = "FlashBlade API error: $($apiError.errors[0].message)"
+            # Most FlashBlade error bodies use the plural key "errors", but some real-world
+            # responses (confirmed live against Purity//FB 4.8.2 / REST 2.26) use the singular
+            # "error" instead -- same array-of-objects shape, different key name. Prefer plural
+            # if both are somehow present.
+            $errorList = if ($apiError.errors) { $apiError.errors } else { $apiError.error }
+            if ($errorList) {
+                $errorMessage = "FlashBlade API error: $($errorList[0].message)"
             }
         }
         catch { }

--- a/Private/Invoke-PfbApiRequest.ps1
+++ b/Private/Invoke-PfbApiRequest.ps1
@@ -42,20 +42,29 @@ function Invoke-PfbApiRequest {
         $buffer = [Math]::Min(30, $Array.TokenTtlSeconds * 0.10)
         $refreshAt = $Array.TokenExpiresAt.AddSeconds(-$buffer)
         if ((Get-Date).ToUniversalTime() -ge $refreshAt) {
-            $refreshed = Invoke-PfbOAuth2Login -Endpoint $Array.Endpoint -ClientId $Array.ClientId `
-                -Issuer $Array.Issuer -KeyId $Array.KeyId -Username $Array.Username `
-                -PrivateKeyFile $Array.PrivateKeyFile -PrivateKeyPassword $Array.PrivateKeyPassword `
-                -SkipCertificateCheck:$Array.SkipCertificateCheck
-            $Array.BearerToken = $refreshed.AccessToken
-            $Array.AuthToken = $refreshed.AccessToken
-            $Array.TokenExpiresAt = $refreshed.ExpiresAt
-            $Array.TokenTtlSeconds = $refreshed.TtlSeconds
+            # A failure here is NOT fatal: the current token may still be valid (we're only
+            # inside the buffer window, not past actual expiry). Warn and fall through to
+            # attempt the request with the existing token -- the reactive 401 path below is
+            # the real safety net if the token has genuinely become invalid.
+            try {
+                $refreshed = Invoke-PfbOAuth2Login -Endpoint $Array.Endpoint -ClientId $Array.ClientId `
+                    -Issuer $Array.Issuer -KeyId $Array.KeyId -Username $Array.Username `
+                    -PrivateKeyFile $Array.PrivateKeyFile -PrivateKeyPassword $Array.PrivateKeyPassword `
+                    -SkipCertificateCheck:$Array.SkipCertificateCheck
+                $Array.BearerToken = $refreshed.AccessToken
+                $Array.AuthToken = $refreshed.AccessToken
+                $Array.TokenExpiresAt = $refreshed.ExpiresAt
+                $Array.TokenTtlSeconds = $refreshed.TtlSeconds
 
-            if ($script:PfbDefaultArray -and $script:PfbDefaultArray.Endpoint -eq $Array.Endpoint) {
-                $script:PfbDefaultArray = $Array
+                if ($script:PfbDefaultArray -and $script:PfbDefaultArray.Endpoint -eq $Array.Endpoint) {
+                    $script:PfbDefaultArray = $Array
+                }
+                if ($script:PfbArrays.ContainsKey($Array.Endpoint)) {
+                    $script:PfbArrays[$Array.Endpoint] = $Array
+                }
             }
-            if ($script:PfbArrays.ContainsKey($Array.Endpoint)) {
-                $script:PfbArrays[$Array.Endpoint] = $Array
+            catch {
+                Write-Warning "FlashBlade proactive OAuth2 token refresh failed for $($Array.Endpoint): $($_.Exception.Message). Proceeding with the existing token."
             }
         }
     }

--- a/Private/Invoke-PfbOAuth2Login.ps1
+++ b/Private/Invoke-PfbOAuth2Login.ps1
@@ -1,0 +1,88 @@
+function Invoke-PfbOAuth2Login {
+    <#
+    .SYNOPSIS
+        Mints a JWT and exchanges it for an OAuth2 access token from a FlashBlade array.
+    .DESCRIPTION
+        Shared by Connect-PfbArray's initial Certificate-flow login and the automatic
+        token-refresh logic in Invoke-PfbApiRequest, so the JWT-mint-and-exchange logic
+        exists in exactly one place.
+    .PARAMETER Endpoint
+        The hostname or IP address of the FlashBlade array.
+    .PARAMETER ClientId
+        Client ID of the API client registered on the FlashBlade.
+    .PARAMETER Issuer
+        The identity provider issuer string. Used as the JWT 'iss' claim.
+    .PARAMETER KeyId
+        Key ID of the API client. Used as the JWT 'kid' header claim.
+    .PARAMETER Username
+        The array user to act as. Used as the JWT 'sub' claim.
+    .PARAMETER PrivateKeyFile
+        Path to the PEM-encoded RSA private key file.
+    .PARAMETER PrivateKeyPassword
+        Password for an encrypted private key file, if applicable.
+    .PARAMETER SkipCertificateCheck
+        Bypass SSL certificate validation for the token-exchange call.
+    #>
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Mandatory)] [string]$Endpoint,
+        [Parameter(Mandatory)] [string]$ClientId,
+        [Parameter(Mandatory)] [string]$Issuer,
+        [Parameter(Mandatory)] [string]$KeyId,
+        [Parameter(Mandatory)] [string]$Username,
+        [Parameter(Mandatory)] [string]$PrivateKeyFile,
+        [Parameter()] [System.Security.SecureString]$PrivateKeyPassword,
+        [Parameter()] [switch]$SkipCertificateCheck
+    )
+
+    $jwtParams = @{
+        KeyId          = $KeyId
+        ClientId       = $ClientId
+        Issuer         = $Issuer
+        Username       = $Username
+        PrivateKeyFile = $PrivateKeyFile
+    }
+    if ($PrivateKeyPassword) {
+        $jwtParams['PrivateKeyPassword'] = $PrivateKeyPassword
+    }
+
+    try {
+        $jwt = New-PfbJwtToken @jwtParams
+    }
+    catch {
+        throw "Failed to generate JWT for OAuth2 authentication: $($_.Exception.Message)"
+    }
+
+    $oauthBody = "grant_type=urn:ietf:params:oauth:grant-type:token-exchange&subject_token=${jwt}&subject_token_type=urn:ietf:params:oauth:token-type:jwt"
+    $oauthParams = @{
+        Method      = 'POST'
+        Uri         = "https://${Endpoint}/oauth2/1.0/token"
+        Body        = $oauthBody
+        ContentType = 'application/x-www-form-urlencoded'
+    }
+    if ($SkipCertificateCheck -and $PSVersionTable.PSVersion.Major -ge 6) {
+        $oauthParams['SkipCertificateCheck'] = $true
+    }
+
+    try {
+        $oauthResponse = Invoke-RestMethod @oauthParams -ErrorAction Stop
+    }
+    catch {
+        throw "OAuth2 token exchange failed for FlashBlade '${Endpoint}': $($_.Exception.Message)"
+    }
+
+    $bearerToken = $oauthResponse.access_token
+    if ([string]::IsNullOrEmpty($bearerToken)) {
+        throw "OAuth2 token exchange returned no access_token from FlashBlade '${Endpoint}'."
+    }
+
+    $ttlSeconds = $oauthResponse.expires_in
+    $expiresAt = (Get-Date).ToUniversalTime().AddSeconds($ttlSeconds)
+
+    return [PSCustomObject]@{
+        AccessToken = $bearerToken
+        ExpiresAt   = $expiresAt
+        TtlSeconds  = $ttlSeconds
+    }
+}

--- a/Private/New-PfbJwtToken.ps1
+++ b/Private/New-PfbJwtToken.ps1
@@ -99,11 +99,15 @@ function New-PfbJwtToken {
         if ($PSVersionTable.PSVersion.Major -ge 6) {
             $rsa = [System.Security.Cryptography.RSA]::Create()
             $bytesRead = 0
-            $plainPw = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto(
-                [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($PrivateKeyPassword)
-            )
-            $rsa.ImportEncryptedPkcs8PrivateKey([System.Text.Encoding]::UTF8.GetBytes($plainPw), $keyBytes, [ref]$bytesRead)
-            $plainPw = $null
+            $bstr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($PrivateKeyPassword)
+            try {
+                $plainPw = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($bstr)
+                $rsa.ImportEncryptedPkcs8PrivateKey([System.Text.Encoding]::UTF8.GetBytes($plainPw), $keyBytes, [ref]$bytesRead)
+            }
+            finally {
+                [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr) | Out-Null
+                $plainPw = $null
+            }
         }
         else {
             throw "Encrypted private keys require PowerShell 7+. Please use an unencrypted key or upgrade PowerShell."

--- a/Public/Connection/Connect-PfbArray.ps1
+++ b/Public/Connection/Connect-PfbArray.ps1
@@ -19,6 +19,17 @@ function Connect-PfbArray {
         The optional long-lived API token can be retrieved from /admins/api-tokens for
         future passwordless reconnects.
 
+        OAuth2/Certificate Authentication Flow:
+        When using -ClientId/-Issuer/-KeyId/-PrivateKeyFile, the cmdlet mints a
+        short-lived (5 minute) JWT and exchanges it for an OAuth2 access token. That
+        access token's lifetime (access_token_ttl_in_ms) is set per API client by an
+        admin on the array -- anywhere from 1 second to 24 hours -- and is not knowable
+        in advance. The connection automatically refreshes the access token before it
+        expires (and, as a fallback, immediately after a 401 caused by early expiry or
+        clock skew), so Certificate-authenticated sessions behave like every other
+        authentication method here: no manual reconnect required. See .NOTES for what's
+        retained in memory to make this possible.
+
         Auto-negotiates the highest supported API version unless explicitly specified.
         The connection is cached and becomes the default for subsequent cmdlet calls.
     .PARAMETER Endpoint
@@ -53,6 +64,13 @@ function Connect-PfbArray {
         Bypass SSL certificate validation. Common for lab environments with self-signed certs.
     .PARAMETER HttpTimeout
         HTTP request timeout in milliseconds. Default is 30000 (30 seconds).
+    .NOTES
+        Certificate/OAuth2 sessions retain -ClientId, -Issuer, -KeyId, -PrivateKeyFile,
+        and -PrivateKeyPassword (as a SecureString) on the connection object for the
+        session's lifetime, so the access token can be silently re-minted before or
+        immediately after it expires. This mirrors the existing precedent of retaining
+        -ApiToken for the -Credential/-Password auto-reconnect flow -- same risk class,
+        not a new category of exposure.
     .EXAMPLE
         $array = Connect-PfbArray -Endpoint fb01.example.com -ApiToken $token -IgnoreCertificateError
 

--- a/Public/Connection/Connect-PfbArray.ps1
+++ b/Public/Connection/Connect-PfbArray.ps1
@@ -186,6 +186,8 @@ function Connect-PfbArray {
     # Authenticate based on method
     $authToken = $null
     $bearerToken = $null
+    $tokenExpiresAt = $null
+    $tokenTtlSeconds = $null
 
     if ($PSCmdlet.ParameterSetName -eq 'ApiToken') {
         # Direct API token login
@@ -212,53 +214,36 @@ function Connect-PfbArray {
     }
     elseif ($PSCmdlet.ParameterSetName -eq 'Certificate') {
         # OAuth2 JWT certificate-based authentication
-        # Step 1: Generate a signed JWT
-        $jwtParams = @{
-            KeyId       = $KeyId
-            ClientId    = $ClientId
-            Issuer      = $Issuer
-            Username    = $Username
+        $oauthLoginParams = @{
+            Endpoint       = $Endpoint
+            ClientId       = $ClientId
+            Issuer         = $Issuer
+            KeyId          = $KeyId
+            Username       = $Username
             PrivateKeyFile = $PrivateKeyFile
         }
         if ($PrivateKeyPassword) {
-            $jwtParams['PrivateKeyPassword'] = $PrivateKeyPassword
-        }
-
-        try {
-            $jwt = New-PfbJwtToken @jwtParams
-        }
-        catch {
-            throw "Failed to generate JWT for OAuth2 authentication: $($_.Exception.Message)"
-        }
-
-        # Step 2: Exchange JWT for OAuth2 access token
-        $oauthBody = "grant_type=urn:ietf:params:oauth:grant-type:token-exchange&subject_token=${jwt}&subject_token_type=urn:ietf:params:oauth:token-type:jwt"
-        $oauthParams = @{
-            Method      = 'POST'
-            Uri         = "https://${Endpoint}/oauth2/1.0/token"
-            Body        = $oauthBody
-            ContentType = 'application/x-www-form-urlencoded'
+            $oauthLoginParams['PrivateKeyPassword'] = $PrivateKeyPassword
         }
         if ($IgnoreCertificateError -and $PSVersionTable.PSVersion.Major -ge 6) {
-            $oauthParams['SkipCertificateCheck'] = $true
+            $oauthLoginParams['SkipCertificateCheck'] = $true
         }
 
-        try {
-            $oauthResponse = Invoke-RestMethod @oauthParams -ErrorAction Stop
-        }
-        catch {
-            throw "OAuth2 token exchange failed for FlashBlade '${Endpoint}': $($_.Exception.Message)"
-        }
-
-        $bearerToken = $oauthResponse.access_token
-        if ([string]::IsNullOrEmpty($bearerToken)) {
-            throw "OAuth2 token exchange returned no access_token from FlashBlade '${Endpoint}'."
-        }
+        $oauthResult = Invoke-PfbOAuth2Login @oauthLoginParams
 
         # The bearer token IS the auth token for REST API calls
         # It goes in the Authorization header, not x-auth-token
+        $bearerToken = $oauthResult.AccessToken
         $authToken = $bearerToken
-        $ApiToken = $null  # No API token in Certificate flow
+        $tokenExpiresAt = $oauthResult.ExpiresAt
+        $tokenTtlSeconds = $oauthResult.TtlSeconds
+        # Deliberately NOT "$ApiToken = $null" here: $ApiToken carries
+        # [ValidateNotNullOrEmpty()] on its PSVariable, which re-validates on ANY
+        # assignment regardless of which parameter set was actually bound -- so
+        # assigning $null unconditionally throws even though this branch never
+        # received -ApiToken. $ApiToken is already $null/unbound for the Certificate
+        # parameter set; leaving it untouched fixes a live, already-shipped crash
+        # (introduced v2.0.3, still in v2.0.5) in every real Certificate/OAuth2 login.
     }
     elseif ($PSCmdlet.ParameterSetName -eq 'Credential' -or $PSCmdlet.ParameterSetName -eq 'PSCredential') {
         # Native REST 2.x username/password login — POST /api/login with JSON body.
@@ -366,6 +351,14 @@ function Connect-PfbArray {
         SkipCertificateCheck = [bool]$IgnoreCertificateError
         HttpTimeoutMs        = $HttpTimeout
         ConnectedAt          = [datetime]::UtcNow
+        # Certificate/OAuth2 refresh state — only populated when AuthMethod is 'Certificate'
+        ClientId             = $ClientId
+        Issuer               = $Issuer
+        KeyId                = $KeyId
+        PrivateKeyFile       = $PrivateKeyFile
+        PrivateKeyPassword   = $PrivateKeyPassword
+        TokenExpiresAt       = $tokenExpiresAt
+        TokenTtlSeconds      = $tokenTtlSeconds
     }
 
     # Hide secrets from default display. Sensitive fields (ApiToken, AuthToken,

--- a/Tests/Connect-PfbArray.OAuth2TokenRefresh.Tests.ps1
+++ b/Tests/Connect-PfbArray.OAuth2TokenRefresh.Tests.ps1
@@ -130,3 +130,158 @@ Describe 'Connect-PfbArray - Certificate/OAuth2 flow uses shared helper' {
             Should -Throw -ExpectedMessage '*OAuth2 token exchange failed*'
     }
 }
+
+Describe 'Invoke-PfbApiRequest - Certificate/OAuth2 token refresh' {
+    BeforeAll {
+        function New-CertificateConnection {
+            param(
+                [datetime]$TokenExpiresAt,
+                [int]$TokenTtlSeconds = 3600,
+                [string]$AuthToken = 'initial-token'
+            )
+            [PSCustomObject]@{
+                Endpoint              = 'fb.test'
+                ApiVersion            = '2.26'
+                AuthToken             = $AuthToken
+                BearerToken           = $AuthToken
+                ApiToken              = $null
+                AuthMethod            = 'Certificate'
+                ClientId              = 'client-1'
+                Issuer                = 'myapp'
+                KeyId                 = 'key-1'
+                Username              = 'pureuser'
+                PrivateKeyFile        = 'C:\keys\fake.pem'
+                PrivateKeyPassword    = $null
+                TokenExpiresAt        = $TokenExpiresAt
+                TokenTtlSeconds       = $TokenTtlSeconds
+                SkipCertificateCheck  = $false
+            }
+        }
+    }
+
+    Context 'Proactive refresh' {
+        It 'refreshes before the call when the token is already past its buffer-adjusted expiry' {
+            $array = New-CertificateConnection -TokenExpiresAt ((Get-Date).ToUniversalTime().AddMinutes(-5))
+
+            Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbOAuth2Login {
+                [PSCustomObject]@{ AccessToken = 'refreshed-token'; ExpiresAt = (Get-Date).ToUniversalTime().AddHours(1); TtlSeconds = 3600 }
+            }
+            Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
+                [PSCustomObject]@{ items = @() }
+            } -ParameterFilter { $Uri -like '*file-systems*' }
+
+            InModuleScope PureStorageFlashBladePowerShell -Parameters @{ array = $array } {
+                InModuleScope PureStorageFlashBladePowerShell -Parameters @{ array = $array } {
+                Invoke-PfbApiRequest -Array $array -Method GET -Endpoint 'file-systems' | Out-Null
+            }
+            }
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbOAuth2Login -Times 1 -Exactly
+            $array.AuthToken | Should -Be 'refreshed-token'
+        }
+
+        It 'does not refresh when the token is comfortably within its TTL' {
+            $array = New-CertificateConnection -TokenExpiresAt ((Get-Date).ToUniversalTime().AddHours(1))
+
+            Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbOAuth2Login { throw 'should not be called' }
+            Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
+                [PSCustomObject]@{ items = @() }
+            } -ParameterFilter { $Uri -like '*file-systems*' }
+
+            InModuleScope PureStorageFlashBladePowerShell -Parameters @{ array = $array } {
+                Invoke-PfbApiRequest -Array $array -Method GET -Endpoint 'file-systems' | Out-Null
+            }
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbOAuth2Login -Times 0
+            $array.AuthToken | Should -Be 'initial-token'
+        }
+    }
+
+    Context 'Buffer scaling at TTL extremes' {
+        It 'scales the buffer down for a very short (1s) TTL instead of using a fixed 30s' {
+            # buffer = min(30, 1 * 0.10) = 0.1s. An expiry 0.9s in the future should NOT
+            # trigger a refresh yet -- a fixed 30s buffer would incorrectly say it should.
+            $array = New-CertificateConnection -TokenExpiresAt ((Get-Date).ToUniversalTime().AddMilliseconds(900)) -TokenTtlSeconds 1
+
+            Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbOAuth2Login { throw 'should not be called yet' }
+            Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
+                [PSCustomObject]@{ items = @() }
+            } -ParameterFilter { $Uri -like '*file-systems*' }
+
+            InModuleScope PureStorageFlashBladePowerShell -Parameters @{ array = $array } {
+                Invoke-PfbApiRequest -Array $array -Method GET -Endpoint 'file-systems' | Out-Null
+            }
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbOAuth2Login -Times 0
+        }
+
+        It 'caps the buffer at 30s for a long (24h) TTL instead of scaling to 2.4h' {
+            $array = New-CertificateConnection -TokenExpiresAt ((Get-Date).ToUniversalTime().AddMinutes(50)) -TokenTtlSeconds 86400
+
+            Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbOAuth2Login { throw 'should not be called' }
+            Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
+                [PSCustomObject]@{ items = @() }
+            } -ParameterFilter { $Uri -like '*file-systems*' }
+
+            InModuleScope PureStorageFlashBladePowerShell -Parameters @{ array = $array } {
+                Invoke-PfbApiRequest -Array $array -Method GET -Endpoint 'file-systems' | Out-Null
+            }
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbOAuth2Login -Times 0
+        }
+    }
+
+    Context 'Reactive fallback on 401' {
+        It 'refreshes and retries once when the array returns 401 despite a locally-valid token' {
+            $array = New-CertificateConnection -TokenExpiresAt ((Get-Date).ToUniversalTime().AddHours(1))
+            $script:PfbArrays = @{ 'fb.test' = $array }
+            $script:PfbDefaultArray = $array
+
+            Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbOAuth2Login {
+                [PSCustomObject]@{ AccessToken = 'refreshed-token'; ExpiresAt = (Get-Date).ToUniversalTime().AddHours(1); TtlSeconds = 3600 }
+            }
+
+            $script:oauthCallCount = 0
+            Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
+                $script:oauthCallCount++
+                if ($script:oauthCallCount -eq 1) {
+                    throw (New-MockHttpError -StatusCode 401 -Message 'unauthorized')
+                }
+                [PSCustomObject]@{ items = @() }
+            } -ParameterFilter { $Uri -like '*file-systems*' }
+
+            InModuleScope PureStorageFlashBladePowerShell -Parameters @{ array = $array } {
+                Invoke-PfbApiRequest -Array $array -Method GET -Endpoint 'file-systems' | Out-Null
+            }
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbOAuth2Login -Times 1 -Exactly
+            $array.AuthToken | Should -Be 'refreshed-token'
+            $script:oauthCallCount | Should -Be 2
+        }
+    }
+
+    Context 'Other auth methods unaffected' {
+        It 'never calls Invoke-PfbOAuth2Login for an ApiToken-authenticated connection' {
+            $array = [PSCustomObject]@{
+                Endpoint             = 'fb.test'
+                ApiVersion           = '2.26'
+                AuthToken            = 'session-token'
+                BearerToken          = $null
+                ApiToken             = 'T-fake-token'
+                AuthMethod           = 'ApiToken'
+                SkipCertificateCheck = $false
+            }
+
+            Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbOAuth2Login { throw 'should not be called' }
+            Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
+                [PSCustomObject]@{ items = @() }
+            } -ParameterFilter { $Uri -like '*file-systems*' }
+
+            InModuleScope PureStorageFlashBladePowerShell -Parameters @{ array = $array } {
+                Invoke-PfbApiRequest -Array $array -Method GET -Endpoint 'file-systems' | Out-Null
+            }
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbOAuth2Login -Times 0
+        }
+    }
+}

--- a/Tests/Connect-PfbArray.OAuth2TokenRefresh.Tests.ps1
+++ b/Tests/Connect-PfbArray.OAuth2TokenRefresh.Tests.ps1
@@ -171,13 +171,43 @@ Describe 'Invoke-PfbApiRequest - Certificate/OAuth2 token refresh' {
             } -ParameterFilter { $Uri -like '*file-systems*' }
 
             InModuleScope PureStorageFlashBladePowerShell -Parameters @{ array = $array } {
-                InModuleScope PureStorageFlashBladePowerShell -Parameters @{ array = $array } {
                 Invoke-PfbApiRequest -Array $array -Method GET -Endpoint 'file-systems' | Out-Null
-            }
             }
 
             Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbOAuth2Login -Times 1 -Exactly
             $array.AuthToken | Should -Be 'refreshed-token'
+        }
+
+        It 'syncs $script:PfbDefaultArray and $script:PfbArrays to the refreshed connection after a proactive refresh' {
+            $array = New-CertificateConnection -TokenExpiresAt ((Get-Date).ToUniversalTime().AddMinutes(-5))
+            # A distinct object with the same Endpoint but a different identity/token stands in for
+            # whatever the module's cache held before this call. This proves the cache is genuinely
+            # re-pointed at the refreshed $array -- merely asserting on $array.AuthToken (as the
+            # sibling test above does) would pass even if the module's cache-sync code were deleted,
+            # because $array itself is a reference type mutated in place regardless of caching.
+            $staleCachedClone = New-CertificateConnection -TokenExpiresAt ((Get-Date).ToUniversalTime().AddMinutes(-5)) -AuthToken 'stale-cached-token'
+
+            Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbOAuth2Login {
+                [PSCustomObject]@{ AccessToken = 'refreshed-token'; ExpiresAt = (Get-Date).ToUniversalTime().AddHours(1); TtlSeconds = 3600 }
+            }
+            Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
+                [PSCustomObject]@{ items = @() }
+            } -ParameterFilter { $Uri -like '*file-systems*' }
+
+            InModuleScope PureStorageFlashBladePowerShell -Parameters @{ staleCachedClone = $staleCachedClone } {
+                $script:PfbArrays = @{ $staleCachedClone.Endpoint = $staleCachedClone }
+                $script:PfbDefaultArray = $staleCachedClone
+            }
+
+            InModuleScope PureStorageFlashBladePowerShell -Parameters @{ array = $array } {
+                Invoke-PfbApiRequest -Array $array -Method GET -Endpoint 'file-systems' | Out-Null
+            }
+
+            $cachedDefaultToken = InModuleScope PureStorageFlashBladePowerShell { $script:PfbDefaultArray.AuthToken }
+            $cachedArraysToken  = InModuleScope PureStorageFlashBladePowerShell -Parameters @{ array = $array } { $script:PfbArrays[$array.Endpoint].AuthToken }
+
+            $cachedDefaultToken | Should -Be 'refreshed-token'
+            $cachedArraysToken  | Should -Be 'refreshed-token'
         }
 
         It 'does not refresh when the token is comfortably within its TTL' {
@@ -234,8 +264,15 @@ Describe 'Invoke-PfbApiRequest - Certificate/OAuth2 token refresh' {
     Context 'Reactive fallback on 401' {
         It 'refreshes and retries once when the array returns 401 despite a locally-valid token' {
             $array = New-CertificateConnection -TokenExpiresAt ((Get-Date).ToUniversalTime().AddHours(1))
-            $script:PfbArrays = @{ 'fb.test' = $array }
-            $script:PfbDefaultArray = $array
+            # Seeding must happen via InModuleScope: a bare $script: assignment made directly in
+            # this It block would set a variable in this test file's own script scope, not the
+            # module's -- $script: resolves relative to where a scriptblock is defined, and this
+            # scriptblock is defined here, not inside the module. See the empirical check recorded
+            # in .superpowers/sdd/task-3-report.md for confirmation.
+            InModuleScope PureStorageFlashBladePowerShell -Parameters @{ array = $array } {
+                $script:PfbArrays = @{ 'fb.test' = $array }
+                $script:PfbDefaultArray = $array
+            }
 
             Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbOAuth2Login {
                 [PSCustomObject]@{ AccessToken = 'refreshed-token'; ExpiresAt = (Get-Date).ToUniversalTime().AddHours(1); TtlSeconds = 3600 }

--- a/Tests/Connect-PfbArray.OAuth2TokenRefresh.Tests.ps1
+++ b/Tests/Connect-PfbArray.OAuth2TokenRefresh.Tests.ps1
@@ -1,0 +1,76 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    $moduleRoot = Split-Path -Parent $PSScriptRoot
+    $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
+    Import-Module $manifest -Force
+
+    function New-MockHttpError {
+        param([int]$StatusCode, [string]$Message = 'mock http error')
+        $ex = New-Object System.Exception($Message)
+        $response = [PSCustomObject]@{ StatusCode = [System.Net.HttpStatusCode]$StatusCode }
+        Add-Member -InputObject $ex -MemberType NoteProperty -Name Response -Value $response -Force
+        return $ex
+    }
+}
+
+Describe 'Invoke-PfbOAuth2Login' {
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell New-PfbJwtToken { 'fake.jwt.token' }
+    }
+
+    It 'exchanges the JWT for an access token and computes ExpiresAt from expires_in' {
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
+            [PSCustomObject]@{ access_token = 'oauth-access-token'; expires_in = 3600 }
+        } -ParameterFilter { $Uri -eq 'https://fb.test/oauth2/1.0/token' }
+
+        $before = (Get-Date).ToUniversalTime()
+        $result = InModuleScope PureStorageFlashBladePowerShell {
+            Invoke-PfbOAuth2Login -Endpoint 'fb.test' -ClientId 'client-1' -Issuer 'myapp' `
+                -KeyId 'key-1' -Username 'pureuser' -PrivateKeyFile 'C:\keys\fake.pem'
+        }
+        $after = (Get-Date).ToUniversalTime()
+
+        $result.AccessToken | Should -Be 'oauth-access-token'
+        $result.TtlSeconds  | Should -Be 3600
+        $result.ExpiresAt   | Should -BeGreaterThan $before.AddSeconds(3599)
+        $result.ExpiresAt   | Should -BeLessThan $after.AddSeconds(3601)
+    }
+
+    It 'throws a clear error when the exchange returns no access_token' {
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
+            [PSCustomObject]@{ expires_in = 3600 }
+        } -ParameterFilter { $Uri -eq 'https://fb.test/oauth2/1.0/token' }
+
+        {
+            InModuleScope PureStorageFlashBladePowerShell {
+                Invoke-PfbOAuth2Login -Endpoint 'fb.test' -ClientId 'client-1' -Issuer 'myapp' `
+                    -KeyId 'key-1' -Username 'pureuser' -PrivateKeyFile 'C:\keys\fake.pem'
+            }
+        } | Should -Throw -ExpectedMessage '*returned no access_token*'
+    }
+
+    It 'throws a clear error when the token exchange HTTP call fails' {
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
+            throw 'connection refused'
+        } -ParameterFilter { $Uri -eq 'https://fb.test/oauth2/1.0/token' }
+
+        {
+            InModuleScope PureStorageFlashBladePowerShell {
+                Invoke-PfbOAuth2Login -Endpoint 'fb.test' -ClientId 'client-1' -Issuer 'myapp' `
+                    -KeyId 'key-1' -Username 'pureuser' -PrivateKeyFile 'C:\keys\fake.pem'
+            }
+        } | Should -Throw -ExpectedMessage '*OAuth2 token exchange failed*'
+    }
+
+    It 'throws a clear error when JWT generation fails' {
+        Mock -ModuleName PureStorageFlashBladePowerShell New-PfbJwtToken { throw 'bad private key' }
+
+        {
+            InModuleScope PureStorageFlashBladePowerShell {
+                Invoke-PfbOAuth2Login -Endpoint 'fb.test' -ClientId 'client-1' -Issuer 'myapp' `
+                    -KeyId 'key-1' -Username 'pureuser' -PrivateKeyFile 'C:\keys\fake.pem'
+            }
+        } | Should -Throw -ExpectedMessage '*Failed to generate JWT*'
+    }
+}

--- a/Tests/Connect-PfbArray.OAuth2TokenRefresh.Tests.ps1
+++ b/Tests/Connect-PfbArray.OAuth2TokenRefresh.Tests.ps1
@@ -264,14 +264,22 @@ Describe 'Invoke-PfbApiRequest - Certificate/OAuth2 token refresh' {
     Context 'Reactive fallback on 401' {
         It 'refreshes and retries once when the array returns 401 despite a locally-valid token' {
             $array = New-CertificateConnection -TokenExpiresAt ((Get-Date).ToUniversalTime().AddHours(1))
+            # A distinct object with the same Endpoint but a different identity/token stands in for
+            # whatever the module's cache held before this call (mirrors the proactive-path
+            # staleCachedClone test above). This proves the cache is genuinely re-pointed at the
+            # refreshed $array -- seeding the cache with $array itself (as a prior version of this
+            # test did) would pass even if the module's cache-sync code were deleted, because $array
+            # is a reference type mutated in place regardless of caching.
+            #
             # Seeding must happen via InModuleScope: a bare $script: assignment made directly in
             # this It block would set a variable in this test file's own script scope, not the
             # module's -- $script: resolves relative to where a scriptblock is defined, and this
             # scriptblock is defined here, not inside the module. See the empirical check recorded
             # in .superpowers/sdd/task-3-report.md for confirmation.
-            InModuleScope PureStorageFlashBladePowerShell -Parameters @{ array = $array } {
-                $script:PfbArrays = @{ 'fb.test' = $array }
-                $script:PfbDefaultArray = $array
+            $staleCachedClone = New-CertificateConnection -TokenExpiresAt ((Get-Date).ToUniversalTime().AddHours(1)) -AuthToken 'stale-cached-token'
+            InModuleScope PureStorageFlashBladePowerShell -Parameters @{ staleCachedClone = $staleCachedClone } {
+                $script:PfbArrays = @{ $staleCachedClone.Endpoint = $staleCachedClone }
+                $script:PfbDefaultArray = $staleCachedClone
             }
 
             Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbOAuth2Login {
@@ -294,6 +302,12 @@ Describe 'Invoke-PfbApiRequest - Certificate/OAuth2 token refresh' {
             Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbOAuth2Login -Times 1 -Exactly
             $array.AuthToken | Should -Be 'refreshed-token'
             $script:oauthCallCount | Should -Be 2
+
+            $cachedDefaultToken = InModuleScope PureStorageFlashBladePowerShell { $script:PfbDefaultArray.AuthToken }
+            $cachedArraysToken  = InModuleScope PureStorageFlashBladePowerShell -Parameters @{ array = $array } { $script:PfbArrays[$array.Endpoint].AuthToken }
+
+            $cachedDefaultToken | Should -Be 'refreshed-token'
+            $cachedArraysToken  | Should -Be 'refreshed-token'
         }
     }
 

--- a/Tests/Connect-PfbArray.OAuth2TokenRefresh.Tests.ps1
+++ b/Tests/Connect-PfbArray.OAuth2TokenRefresh.Tests.ps1
@@ -322,3 +322,38 @@ Describe 'Invoke-PfbApiRequest - Certificate/OAuth2 token refresh' {
         }
     }
 }
+
+Describe 'Certificate/OAuth2 refresh - PrivateKeyPassword never logged' {
+    It 'never surfaces the plaintext private key password in Write-Verbose or Write-Warning output' {
+        $plainPassword = 'super-secret-key-password'
+        $keyPassword = ConvertTo-SecureString $plainPassword -AsPlainText -Force
+
+        $script:capturedMessages = [System.Collections.Generic.List[string]]::new()
+        Mock -ModuleName PureStorageFlashBladePowerShell Write-Verbose {
+            $script:capturedMessages.Add([string]$Message)
+        }
+        Mock -ModuleName PureStorageFlashBladePowerShell Write-Warning {
+            $script:capturedMessages.Add([string]$Message)
+        }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
+            [PSCustomObject]@{ versions = @('2.26') }
+        } -ParameterFilter { $Uri -like '*api_version*' }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbOAuth2Login {
+            [PSCustomObject]@{ AccessToken = 'oauth-token'; ExpiresAt = (Get-Date).ToUniversalTime().AddSeconds(-1); TtlSeconds = 60 }
+        }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
+            [PSCustomObject]@{ items = @() }
+        } -ParameterFilter { $Uri -like '*file-systems*' }
+
+        $conn = Connect-PfbArray -Endpoint 'fb.test' -Username 'pureuser' -ClientId 'client-1' `
+            -Issuer 'myapp' -KeyId 'key-1' -PrivateKeyFile 'C:\keys\fake.pem' -PrivateKeyPassword $keyPassword
+
+        # ExpiresAt was set 1 second in the past above, so this call triggers a proactive refresh cycle too.
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ conn = $conn } {
+            Invoke-PfbApiRequest -Array $conn -Method GET -Endpoint 'file-systems' | Out-Null
+        }
+
+        $joined = $script:capturedMessages -join "`n"
+        $joined | Should -Not -Match ([regex]::Escape($plainPassword))
+    }
+}

--- a/Tests/Connect-PfbArray.OAuth2TokenRefresh.Tests.ps1
+++ b/Tests/Connect-PfbArray.OAuth2TokenRefresh.Tests.ps1
@@ -356,4 +356,46 @@ Describe 'Certificate/OAuth2 refresh - PrivateKeyPassword never logged' {
         $joined = $script:capturedMessages -join "`n"
         $joined | Should -Not -Match ([regex]::Escape($plainPassword))
     }
+
+    It 'never surfaces the plaintext private key password when New-PfbJwtToken actually decrypts a real encrypted key' {
+        # Unlike the test above, Invoke-PfbOAuth2Login is NOT mocked here -- this exercises the
+        # real Invoke-PfbOAuth2Login -> New-PfbJwtToken path, including the actual PKCS#8
+        # encrypted-private-key decryption in New-PfbJwtToken.ps1 (the only place in the codebase
+        # that marshals PrivateKeyPassword from a SecureString to plaintext). Only the network
+        # calls (version negotiation and the OAuth2 token exchange) are mocked.
+        $plainPassword = 'super-secret-real-decrypt-password'
+        $keyPassword = ConvertTo-SecureString $plainPassword -AsPlainText -Force
+
+        $rsa = [System.Security.Cryptography.RSA]::Create(2048)
+        $pbeParams = [System.Security.Cryptography.PbeParameters]::new(
+            [System.Security.Cryptography.PbeEncryptionAlgorithm]::Aes256Cbc,
+            [System.Security.Cryptography.HashAlgorithmName]::SHA256,
+            100000)
+        $keyPem = $rsa.ExportEncryptedPkcs8PrivateKeyPem($plainPassword, $pbeParams)
+        $keyPath = Join-Path $TestDrive 'encrypted-test-key.pem'
+        Set-Content -Path $keyPath -Value $keyPem -NoNewline
+
+        $script:capturedMessages = [System.Collections.Generic.List[string]]::new()
+        Mock -ModuleName PureStorageFlashBladePowerShell Write-Verbose {
+            $script:capturedMessages.Add([string]$Message)
+        }
+        Mock -ModuleName PureStorageFlashBladePowerShell Write-Warning {
+            $script:capturedMessages.Add([string]$Message)
+        }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
+            [PSCustomObject]@{ versions = @('2.26') }
+        } -ParameterFilter { $Uri -like '*api_version*' }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
+            [PSCustomObject]@{ access_token = 'oauth-token'; expires_in = 60 }
+        } -ParameterFilter { $Uri -eq 'https://fb.test/oauth2/1.0/token' }
+
+        $conn = Connect-PfbArray -Endpoint 'fb.test' -Username 'pureuser' -ClientId 'client-1' `
+            -Issuer 'myapp' -KeyId 'key-1' -PrivateKeyFile $keyPath -PrivateKeyPassword $keyPassword
+
+        # Confirms the real decryption/signing path actually succeeded (not silently short-circuited).
+        $conn.AuthToken | Should -Be 'oauth-token'
+
+        $joined = $script:capturedMessages -join "`n"
+        $joined | Should -Not -Match ([regex]::Escape($plainPassword))
+    }
 }

--- a/Tests/Connect-PfbArray.OAuth2TokenRefresh.Tests.ps1
+++ b/Tests/Connect-PfbArray.OAuth2TokenRefresh.Tests.ps1
@@ -345,6 +345,48 @@ Describe 'Invoke-PfbApiRequest - Certificate/OAuth2 token refresh' {
         }
     }
 
+    Context 'Reactive fallback on 403 (Certificate) -- real FlashBlade 4.8.2 behavior' {
+        It 'refreshes and retries once when the array returns 403 for an invalid Bearer token' {
+            # Live testing against a real FlashBlade array (Purity//FB 4.8.2 / REST 2.26) proved it
+            # returns HTTP 403, not 401, for ANY invalid Bearer-token auth failure (confirmed with
+            # both a genuinely-expired OAuth2 access token and a garbage bearer token). Certificate
+            # connections must treat 403 the same as 401 for reconnect purposes.
+            $array = New-CertificateConnection -TokenExpiresAt ((Get-Date).ToUniversalTime().AddHours(1))
+            $staleCachedClone = New-CertificateConnection -TokenExpiresAt ((Get-Date).ToUniversalTime().AddHours(1)) -AuthToken 'stale-cached-token'
+            InModuleScope PureStorageFlashBladePowerShell -Parameters @{ staleCachedClone = $staleCachedClone } {
+                $script:PfbArrays = @{ $staleCachedClone.Endpoint = $staleCachedClone }
+                $script:PfbDefaultArray = $staleCachedClone
+            }
+
+            Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbOAuth2Login {
+                [PSCustomObject]@{ AccessToken = 'refreshed-token'; ExpiresAt = (Get-Date).ToUniversalTime().AddHours(1); TtlSeconds = 3600 }
+            }
+
+            $script:oauthCallCount = 0
+            Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
+                $script:oauthCallCount++
+                if ($script:oauthCallCount -eq 1) {
+                    throw (New-MockHttpError -StatusCode 403 -Message 'Access Denied')
+                }
+                [PSCustomObject]@{ items = @() }
+            } -ParameterFilter { $Uri -like '*file-systems*' }
+
+            InModuleScope PureStorageFlashBladePowerShell -Parameters @{ array = $array } {
+                Invoke-PfbApiRequest -Array $array -Method GET -Endpoint 'file-systems' | Out-Null
+            }
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbOAuth2Login -Times 1 -Exactly
+            $array.AuthToken | Should -Be 'refreshed-token'
+            $script:oauthCallCount | Should -Be 2
+
+            $cachedDefaultToken = InModuleScope PureStorageFlashBladePowerShell { $script:PfbDefaultArray.AuthToken }
+            $cachedArraysToken  = InModuleScope PureStorageFlashBladePowerShell -Parameters @{ array = $array } { $script:PfbArrays[$array.Endpoint].AuthToken }
+
+            $cachedDefaultToken | Should -Be 'refreshed-token'
+            $cachedArraysToken  | Should -Be 'refreshed-token'
+        }
+    }
+
     Context 'Other auth methods unaffected' {
         It 'never calls Invoke-PfbOAuth2Login for an ApiToken-authenticated connection' {
             $array = [PSCustomObject]@{
@@ -367,6 +409,36 @@ Describe 'Invoke-PfbApiRequest - Certificate/OAuth2 token refresh' {
             }
 
             Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbOAuth2Login -Times 0
+        }
+
+        It 'does NOT attempt reconnect for an ApiToken-authenticated connection on 403 -- regression guard: ApiToken/Credential/PSCredential stay 401-only' {
+            # ApiToken/Credential/PSCredential use the x-auth-token session mechanism, which has NOT
+            # been proven to share the real array's 403-for-invalid-Bearer-token behavior. Widening
+            # the shared reconnect condition to include 403 for these auth methods would be an
+            # unproven, unintended behavior change -- so a 403 here must still throw immediately.
+            $array = [PSCustomObject]@{
+                Endpoint             = 'fb.test'
+                ApiVersion           = '2.26'
+                AuthToken            = 'session-token'
+                BearerToken          = $null
+                ApiToken             = 'T-fake-token'
+                AuthMethod           = 'ApiToken'
+                SkipCertificateCheck = $false
+            }
+
+            Mock -ModuleName PureStorageFlashBladePowerShell Connect-PfbArrayInternal { throw 'should not be called' }
+            Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
+                throw (New-MockHttpError -StatusCode 403 -Message 'Access Denied')
+            } -ParameterFilter { $Uri -like '*file-systems*' }
+
+            {
+                InModuleScope PureStorageFlashBladePowerShell -Parameters @{ array = $array } {
+                    Invoke-PfbApiRequest -Array $array -Method GET -Endpoint 'file-systems' | Out-Null
+                }
+            } | Should -Throw -ExpectedMessage '*FlashBlade API error*'
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Connect-PfbArrayInternal -Times 0
+            $array.AuthToken | Should -Be 'session-token'
         }
     }
 }

--- a/Tests/Connect-PfbArray.OAuth2TokenRefresh.Tests.ps1
+++ b/Tests/Connect-PfbArray.OAuth2TokenRefresh.Tests.ps1
@@ -74,3 +74,59 @@ Describe 'Invoke-PfbOAuth2Login' {
         } | Should -Throw -ExpectedMessage '*Failed to generate JWT*'
     }
 }
+
+Describe 'Connect-PfbArray - Certificate/OAuth2 flow uses shared helper' {
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
+            [PSCustomObject]@{ versions = @('2.20', '2.25', '2.26') }
+        } -ParameterFilter { $Uri -like '*api_version*' }
+    }
+
+    It 'stores the access token, expiry, ttl, and JWT-signing parameters on the connection object' {
+        $expiresAt = (Get-Date).ToUniversalTime().AddHours(1)
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbOAuth2Login {
+            [PSCustomObject]@{ AccessToken = 'oauth-token'; ExpiresAt = $expiresAt; TtlSeconds = 3600 }
+        }
+
+        $conn = Connect-PfbArray -Endpoint 'fb.test' -Username 'pureuser' -ClientId 'client-1' `
+            -Issuer 'myapp' -KeyId 'key-1' -PrivateKeyFile 'C:\keys\fake.pem'
+
+        $conn.AuthToken       | Should -Be 'oauth-token'
+        $conn.BearerToken     | Should -Be 'oauth-token'
+        $conn.TokenExpiresAt  | Should -Be $expiresAt
+        $conn.TokenTtlSeconds | Should -Be 3600
+        $conn.ClientId        | Should -Be 'client-1'
+        $conn.Issuer          | Should -Be 'myapp'
+        $conn.KeyId           | Should -Be 'key-1'
+        $conn.PrivateKeyFile  | Should -Be 'C:\keys\fake.pem'
+        $conn.ApiToken        | Should -BeNullOrEmpty
+    }
+
+    It 'hides ClientId, Issuer, KeyId, PrivateKeyFile, and PrivateKeyPassword from default display' {
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbOAuth2Login {
+            [PSCustomObject]@{ AccessToken = 'oauth-token'; ExpiresAt = (Get-Date).ToUniversalTime().AddHours(1); TtlSeconds = 3600 }
+        }
+
+        $conn = Connect-PfbArray -Endpoint 'fb.test' -Username 'pureuser' -ClientId 'client-1' `
+            -Issuer 'myapp' -KeyId 'key-1' -PrivateKeyFile 'C:\keys\fake.pem'
+
+        $defaultView = ($conn | Format-List | Out-String)
+        $defaultView | Should -Not -Match 'PrivateKeyPassword'
+        $defaultView | Should -Not -Match 'ClientId'
+        $defaultView | Should -Not -Match 'Issuer'
+        $defaultView | Should -Not -Match 'KeyId'
+        $defaultView | Should -Not -Match 'PrivateKeyFile'
+        # Sanity check: the properties still exist and are directly reachable, just hidden from default display
+        $conn.ClientId | Should -Be 'client-1'
+    }
+
+    It 'throws when Invoke-PfbOAuth2Login fails, without falling back to any other auth path' {
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbOAuth2Login {
+            throw "OAuth2 token exchange failed for FlashBlade 'fb.test': connection refused"
+        }
+
+        { Connect-PfbArray -Endpoint 'fb.test' -Username 'pureuser' -ClientId 'client-1' `
+            -Issuer 'myapp' -KeyId 'key-1' -PrivateKeyFile 'C:\keys\fake.pem' } |
+            Should -Throw -ExpectedMessage '*OAuth2 token exchange failed*'
+    }
+}

--- a/Tests/Connect-PfbArray.OAuth2TokenRefresh.Tests.ps1
+++ b/Tests/Connect-PfbArray.OAuth2TokenRefresh.Tests.ps1
@@ -225,6 +225,40 @@ Describe 'Invoke-PfbApiRequest - Certificate/OAuth2 token refresh' {
             Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbOAuth2Login -Times 0
             $array.AuthToken | Should -Be 'initial-token'
         }
+
+        It 'falls through to the current token and warns (without throwing) when the proactive refresh attempt itself throws' {
+            $originalExpiresAt = (Get-Date).ToUniversalTime().AddMinutes(-5)
+            $array = New-CertificateConnection -TokenExpiresAt $originalExpiresAt
+
+            Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbOAuth2Login {
+                throw 'transient network blip'
+            }
+            Mock -ModuleName PureStorageFlashBladePowerShell Write-Warning { }
+            Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
+                [PSCustomObject]@{ items = @() }
+            } -ParameterFilter { $Uri -like '*file-systems*' }
+
+            # (a) the call does not throw
+            {
+                InModuleScope PureStorageFlashBladePowerShell -Parameters @{ array = $array } {
+                    Invoke-PfbApiRequest -Array $array -Method GET -Endpoint 'file-systems' | Out-Null
+                }
+            } | Should -Not -Throw
+
+            # (c) it proceeds and succeeds using the original (unrefreshed) token
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod -Times 1 -Exactly `
+                -ParameterFilter { $Uri -like '*file-systems*' -and $Headers.Authorization -eq 'Bearer initial-token' }
+
+            # (b) a warning naming the failure is emitted
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Write-Warning -Times 1 -Exactly `
+                -ParameterFilter { $Message -like '*fb.test*' -and $Message -like '*transient network blip*' }
+
+            # (d) the stale-but-still-possibly-valid token is left untouched, not corrupted by the failed attempt
+            $array.AuthToken       | Should -Be 'initial-token'
+            $array.BearerToken     | Should -Be 'initial-token'
+            $array.TokenExpiresAt  | Should -Be $originalExpiresAt
+            $array.TokenTtlSeconds | Should -Be 3600
+        }
     }
 
     Context 'Buffer scaling at TTL extremes' {

--- a/Tests/ConvertTo-PfbApiError.Tests.ps1
+++ b/Tests/ConvertTo-PfbApiError.Tests.ps1
@@ -1,0 +1,55 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    $moduleRoot = Split-Path -Parent $PSScriptRoot
+    $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
+    Import-Module $manifest -Force
+
+    function New-ErrorRecordWithBody {
+        param(
+            [string]$Body,
+            [string]$Message = 'mock http error'
+        )
+        $ex = New-Object System.Exception($Message)
+        $errorRecord = New-Object System.Management.Automation.ErrorRecord(
+            $ex, 'MockError', [System.Management.Automation.ErrorCategory]::NotSpecified, $null)
+        $errorRecord.ErrorDetails = New-Object System.Management.Automation.ErrorDetails($Body)
+        return $errorRecord
+    }
+}
+
+Describe 'ConvertTo-PfbApiError' {
+    It 'extracts the message from a plural .errors[] body' {
+        $errorRecord = New-ErrorRecordWithBody -Body '{"errors":[{"code":401,"context":"/api/2.26/arrays","message":"Invalid session token."}]}'
+
+        $result = InModuleScope PureStorageFlashBladePowerShell -Parameters @{ errorRecord = $errorRecord } {
+            ConvertTo-PfbApiError -Method 'GET' -Endpoint 'arrays' -ErrorRecord $errorRecord
+        }
+
+        $result | Should -Be 'FlashBlade API error: Invalid session token.'
+    }
+
+    It 'extracts the message from a singular .error[] body (real FlashBlade 4.8.2 shape)' {
+        # Live testing against a real FlashBlade array (Purity//FB 4.8.2 / REST 2.26) proved that its
+        # error responses use the singular key "error" (still an array of objects), not the plural
+        # "errors" this function previously assumed exclusively:
+        # {"error":[{"code":403,"context":"/api/2.26/arrays","message":"Access Denied"}]}
+        $errorRecord = New-ErrorRecordWithBody -Body '{"error":[{"code":403,"context":"/api/2.26/arrays","message":"Access Denied"}]}'
+
+        $result = InModuleScope PureStorageFlashBladePowerShell -Parameters @{ errorRecord = $errorRecord } {
+            ConvertTo-PfbApiError -Method 'GET' -Endpoint 'arrays' -ErrorRecord $errorRecord
+        }
+
+        $result | Should -Be 'FlashBlade API error: Access Denied'
+    }
+
+    It 'prefers the plural .errors[] key when both .errors and .error are somehow present' {
+        $errorRecord = New-ErrorRecordWithBody -Body '{"errors":[{"code":400,"message":"plural wins"}],"error":[{"code":400,"message":"singular loses"}]}'
+
+        $result = InModuleScope PureStorageFlashBladePowerShell -Parameters @{ errorRecord = $errorRecord } {
+            ConvertTo-PfbApiError -Method 'GET' -Endpoint 'arrays' -ErrorRecord $errorRecord
+        }
+
+        $result | Should -Be 'FlashBlade API error: plural wins'
+    }
+}

--- a/Tests/New-PfbJwtToken.Tests.ps1
+++ b/Tests/New-PfbJwtToken.Tests.ps1
@@ -1,0 +1,99 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    $moduleRoot = Split-Path -Parent $PSScriptRoot
+    $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
+    Import-Module $manifest -Force
+}
+
+Describe 'New-PfbJwtToken' {
+    Context 'BEGIN ENCRYPTED PRIVATE KEY (PrivateKeyPassword decryption)' {
+        BeforeAll {
+            # Generate a real encrypted PKCS#8 key at runtime -- never committed to source control.
+            # Same technique used in Tests/Connect-PfbArray.OAuth2TokenRefresh.Tests.ps1.
+            $script:plainPassword = 'super-secret-jwt-test-password'
+            $script:rsa = [System.Security.Cryptography.RSA]::Create(2048)
+            $pbeParams = [System.Security.Cryptography.PbeParameters]::new(
+                [System.Security.Cryptography.PbeEncryptionAlgorithm]::Aes256Cbc,
+                [System.Security.Cryptography.HashAlgorithmName]::SHA256,
+                100000)
+            $keyPem = $script:rsa.ExportEncryptedPkcs8PrivateKeyPem($script:plainPassword, $pbeParams)
+            $script:keyPath = Join-Path $TestDrive 'encrypted-jwt-test-key.pem'
+            Set-Content -Path $script:keyPath -Value $keyPem -NoNewline
+        }
+
+        It 'mints a validly-signed JWT by decrypting the encrypted PKCS#8 private key' {
+            # Regression coverage for the fix that wraps the SecureStringToBSTR/PtrToStringAuto/
+            # ImportEncryptedPkcs8PrivateKey sequence in try/finally with ZeroFreeBSTR. Actually
+            # inspecting whether the unmanaged BSTR was zeroed/freed isn't practically assertable
+            # from black-box Pester -- a broken ZeroFreeBSTR usage (wrong pointer, double free)
+            # would instead throw or corrupt the RSA import, which this functional assertion
+            # would catch. So this test proves the function still mints a correct JWT end-to-end.
+            $securePassword = ConvertTo-SecureString $script:plainPassword -AsPlainText -Force
+            $keyPathParam = $script:keyPath
+
+            $jwt = InModuleScope PureStorageFlashBladePowerShell -Parameters @{
+                keyPathParam    = $keyPathParam
+                securePassword  = $securePassword
+            } {
+                New-PfbJwtToken -KeyId 'key-1' -ClientId 'client-1' -Issuer 'myapp' `
+                    -Username 'pureuser' -PrivateKeyFile $keyPathParam -PrivateKeyPassword $securePassword
+            }
+
+            $jwt | Should -Not -BeNullOrEmpty
+            $parts = $jwt -split '\.'
+            $parts.Count | Should -Be 3
+
+            # Decode header and payload to confirm the claims round-tripped correctly.
+            function ConvertFrom-Base64Url {
+                param([string]$Text)
+                $padded = $Text.Replace('-', '+').Replace('_', '/')
+                switch ($padded.Length % 4) {
+                    2 { $padded += '==' }
+                    3 { $padded += '=' }
+                }
+                [System.Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($padded))
+            }
+
+            $header  = ConvertFrom-Base64Url $parts[0] | ConvertFrom-Json
+            $payload = ConvertFrom-Base64Url $parts[1] | ConvertFrom-Json
+
+            $header.alg  | Should -Be 'RS256'
+            $header.kid  | Should -Be 'key-1'
+            $payload.aud | Should -Be 'client-1'
+            $payload.iss | Should -Be 'myapp'
+            $payload.sub | Should -Be 'pureuser'
+
+            # Verify the signature is actually valid for the unsigned header.payload against the
+            # public key -- proves the correct private key was successfully decrypted and used.
+            $unsigned = "$($parts[0]).$($parts[1])"
+            $dataBytes = [System.Text.Encoding]::UTF8.GetBytes($unsigned)
+            # Base64url-decode the signature to raw bytes directly (not via the UTF8 text helper
+            # above, which would corrupt binary signature data).
+            $padded = $parts[2].Replace('-', '+').Replace('_', '/')
+            switch ($padded.Length % 4) {
+                2 { $padded += '==' }
+                3 { $padded += '=' }
+            }
+            $signatureBytes = [Convert]::FromBase64String($padded)
+
+            $isValid = $script:rsa.VerifyData($dataBytes, $signatureBytes, `
+                [System.Security.Cryptography.HashAlgorithmName]::SHA256, `
+                [System.Security.Cryptography.RSASignaturePadding]::Pkcs1)
+            $isValid | Should -BeTrue
+        }
+
+        It 'throws when the encrypted key is provided without a PrivateKeyPassword' {
+            $keyPathParam = $script:keyPath
+
+            {
+                InModuleScope PureStorageFlashBladePowerShell -Parameters @{
+                    keyPathParam = $keyPathParam
+                } {
+                    New-PfbJwtToken -KeyId 'key-1' -ClientId 'client-1' -Issuer 'myapp' `
+                        -Username 'pureuser' -PrivateKeyFile $keyPathParam
+                }
+            } | Should -Throw -ExpectedMessage '*Provide -PrivateKeyPassword*'
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Certificate/OAuth2-authenticated `Connect-PfbArray` sessions now automatically refresh their access token before or immediately after it expires, matching the auto-reconnect behavior every other auth method (`-ApiToken`, `-Credential`, `-PSCredential`) already has. Previously, a Certificate session's access token would eventually expire and every subsequent call would fail with no recovery path short of a manual reconnect.

- New shared private helper `Invoke-PfbOAuth2Login` (JWT mint + OAuth2 token exchange), extracted from `Connect-PfbArray`'s previously-inline logic so both the initial login and the new refresh logic share one implementation.
- **Proactive refresh**: `Invoke-PfbApiRequest` checks the stored token expiry before each call and refreshes ahead of time using a TTL-scaled buffer (`min(30, TtlSeconds * 0.10)` seconds).
- **Reactive refresh**: falls back to a refresh-and-retry on an auth-failure response as a safety net for what proactive can't anticipate (clock skew, early revocation) — see "Live-verification finding" below for an important detail here.
- A proactive-refresh failure (e.g. a transient network blip) now degrades gracefully: it warns and proceeds with the current (still-possibly-valid) token instead of failing the call outright, letting the reactive path be the real backstop.

## Also fixes (found during implementation/review, in scope for this branch)

- **A live, already-shipped crash**: `Connect-PfbArray`'s `Certificate` branch did `$ApiToken = $null`, which throws because `$ApiToken` carries `[ValidateNotNullOrEmpty()]` that re-validates on *any* assignment to that variable, regardless of which parameter set was actually bound. Every real Certificate/OAuth2 connection attempt on `main` (since v2.0.3) crashed immediately. Fixed by simply never assigning to `$ApiToken` in that branch — it's already unbound/`$null` for this parameter set.
- **A decrypted-secret memory leak**: `New-PfbJwtToken` decrypted `PrivateKeyPassword` via `Marshal.SecureStringToBSTR` but never freed the resulting unmanaged buffer (unlike `Connect-PfbArray`'s `Credential` branch, which does this correctly). This branch's new refresh cadence re-mints the JWT repeatedly over a session's life instead of once per connection, amplifying the exposure — fixed by mirroring the existing correct `try`/`finally`/`ZeroFreeBSTR` pattern.
- **A live-verification-only finding**: real FlashBlade arrays return **HTTP 403**, not 401, for an invalid Bearer token. The reactive-refresh gate originally checked only for 401, so it silently never fired against a real array — a gap no mocked unit test could reveal. Fixed by treating 403 as retryable specifically for `Certificate` connections (`ApiToken`/`Credential`/`PSCredential`, which use a different session mechanism never proven to share this behavior, remain 401-only and unchanged).
- `ConvertTo-PfbApiError` now handles both a plural `.errors[]` and singular `.error[]` key in error response bodies (the real array uses the singular form, so error messages were previously falling back to a generic .NET status message instead of the array's actual "Access Denied" text).

## Not in this PR

- `ModuleVersion`/`ReleaseNotes` intentionally not bumped — this lands as part of a combined version update alongside `feature/connect-pfbarray-native-login-gate`.
- Whether the pre-existing `ApiToken`/`Credential`/`PSCredential` reconnect path (`x-auth-token` session mechanism) has the same 403-vs-401 issue was not investigated — it's a different auth mechanism from OAuth2 Bearer tokens and wasn't proven broken, so it was deliberately left untouched rather than widened without evidence.

## Test plan

- [x] Full Pester suite passing (30/30), including regression coverage for the `$ApiToken` crash fix, the BSTR-leak fix (real encrypted-key JWT signing exercised, not mocked), and both positive/negative coverage for the 403-retry scope (Certificate retries on 403; ApiToken does not).
- [x] `scripts/build.ps1` succeeds with no errors.
- [x] Manual live verification against a real FlashBlade array (Purity//FB 4.8.2 / REST 2.26) with a dedicated short-TTL (90s) OAuth2 API client:
  - Confirmed real token TTL/expiry match the configured API client.
  - Confirmed a genuine **proactive** refresh occurs before expiry (verbose logs show a clean token-exchange POST ahead of the API call, no 401/403 or retry noise, `TokenExpiresAt` advances).
  - Confirmed a genuine **reactive** refresh occurs on real token expiry when the proactive check is bypassed (verbose logs show the real 403 → token-exchange POST → successful retry sequence, zero exceptions surfaced, token state updated by the reactive path).
  - This live run is what surfaced the 403-vs-401 gap above; re-ran the same live scenario after the fix to confirm it now works end-to-end against the real array.