### PR TITLE
Fix pipeline-binding gaps in relationship/membership cmdlets

### DIFF
--- a/Public/Admin/Test-PfbSaml2Idp.ps1
+++ b/Public/Admin/Test-PfbSaml2Idp.ps1
@@ -4,13 +4,13 @@ function Test-PfbSaml2Idp {
         Tests a SAML2 identity provider configuration on the FlashBlade.
     .DESCRIPTION
         The Test-PfbSaml2Idp cmdlet runs a connectivity and configuration test against a SAML2
-        identity provider on the connected Pure Storage FlashBlade. Returns test results including
-        connectivity status, metadata validation, and any errors encountered. The IdP to test
-        can be identified by name or ID.
+        identity provider on the connected FlashBlade. Returns test results including
+        connectivity status, metadata validation, and any errors encountered. The IdP(s) to test
+        can be identified by name or ID, and names accept pipeline input by property name.
     .PARAMETER Name
-        The name of the SAML2 identity provider to test.
+        One or more names of SAML2 identity providers to test.
     .PARAMETER Id
-        The ID of the SAML2 identity provider to test.
+        One or more IDs of SAML2 identity providers to test.
     .PARAMETER Array
         The FlashBlade connection object. If not specified, the default connection is used.
     .EXAMPLE
@@ -29,16 +29,27 @@ function Test-PfbSaml2Idp {
     [CmdletBinding(DefaultParameterSetName = 'ByName')]
     param(
         [Parameter(ParameterSetName = 'ByName', ValueFromPipelineByPropertyName)]
-        [string]$Name,
-        [Parameter(ParameterSetName = 'ById')] [string]$Id,
+        [string[]]$Name,
+        [Parameter(ParameterSetName = 'ById')] [string[]]$Id,
         [Parameter()] [PSCustomObject]$Array
     )
 
-    Assert-PfbConnection -Array ([ref]$Array)
+    begin {
+        Assert-PfbConnection -Array ([ref]$Array)
+        $allNames = [System.Collections.Generic.List[string]]::new()
+        $allIds   = [System.Collections.Generic.List[string]]::new()
+    }
 
-    $queryParams = @{}
-    if ($Name) { $queryParams['names'] = $Name }
-    if ($Id)   { $queryParams['ids']   = $Id }
+    process {
+        if ($Name) { foreach ($n in $Name) { $allNames.Add($n) } }
+        if ($Id)   { foreach ($i in $Id)   { $allIds.Add($i) } }
+    }
 
-    Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'sso/saml2/idps/test' -QueryParams $queryParams -AutoPaginate
+    end {
+        $queryParams = @{}
+        if ($allNames.Count -gt 0) { $queryParams['names'] = $allNames -join ',' }
+        if ($allIds.Count -gt 0)   { $queryParams['ids']   = $allIds -join ',' }
+
+        Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'sso/saml2/idps/test' -QueryParams $queryParams -AutoPaginate
+    }
 }

--- a/Public/DirectoryService/Test-PfbActiveDirectory.ps1
+++ b/Public/DirectoryService/Test-PfbActiveDirectory.ps1
@@ -4,13 +4,14 @@ function Test-PfbActiveDirectory {
         Tests the FlashBlade Active Directory configuration.
     .DESCRIPTION
         The Test-PfbActiveDirectory cmdlet runs a connectivity and configuration test against
-        an Active Directory configuration on the connected Pure Storage FlashBlade. Returns
+        an Active Directory configuration on the connected FlashBlade. Returns
         test results including domain connectivity status, authentication checks, and any errors
-        encountered. The AD configuration to test can be identified by name or ID.
+        encountered. The AD configuration(s) to test can be identified by name or ID, and names
+        accept pipeline input by property name.
     .PARAMETER Name
-        The name of the Active Directory configuration to test.
+        One or more names of Active Directory configurations to test.
     .PARAMETER Id
-        The ID of the Active Directory configuration to test.
+        One or more IDs of Active Directory configurations to test.
     .PARAMETER Array
         The FlashBlade connection object. If not specified, the default connection is used.
     .EXAMPLE
@@ -29,16 +30,27 @@ function Test-PfbActiveDirectory {
     [CmdletBinding(DefaultParameterSetName = 'List')]
     param(
         [Parameter(ParameterSetName = 'ByName', ValueFromPipelineByPropertyName)]
-        [string]$Name,
-        [Parameter(ParameterSetName = 'ById')] [string]$Id,
+        [string[]]$Name,
+        [Parameter(ParameterSetName = 'ById')] [string[]]$Id,
         [Parameter()] [PSCustomObject]$Array
     )
 
-    Assert-PfbConnection -Array ([ref]$Array)
+    begin {
+        Assert-PfbConnection -Array ([ref]$Array)
+        $allNames = [System.Collections.Generic.List[string]]::new()
+        $allIds   = [System.Collections.Generic.List[string]]::new()
+    }
 
-    $queryParams = @{}
-    if ($Name) { $queryParams['names'] = $Name }
-    if ($Id)   { $queryParams['ids']   = $Id }
+    process {
+        if ($Name) { foreach ($n in $Name) { $allNames.Add($n) } }
+        if ($Id)   { foreach ($i in $Id)   { $allIds.Add($i) } }
+    }
 
-    Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'active-directory/test' -QueryParams $queryParams -AutoPaginate
+    end {
+        $queryParams = @{}
+        if ($allNames.Count -gt 0) { $queryParams['names'] = $allNames -join ',' }
+        if ($allIds.Count -gt 0)   { $queryParams['ids']   = $allIds -join ',' }
+
+        Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'active-directory/test' -QueryParams $queryParams -AutoPaginate
+    }
 }

--- a/Public/FileSystemSnapshot/New-PfbFileSystemSnapshot.ps1
+++ b/Public/FileSystemSnapshot/New-PfbFileSystemSnapshot.ps1
@@ -3,7 +3,9 @@ function New-PfbFileSystemSnapshot {
     .SYNOPSIS
         Creates a snapshot of one or more file systems.
     .PARAMETER SourceName
-        Name of the source file system(s) to snapshot.
+        Name of the source file system(s) to snapshot. Accepts pipeline input by
+        property name (aliased to 'Name'), so `Get-PfbFileSystem | New-PfbFileSystemSnapshot`
+        snapshots every piped file system in a single request.
     .PARAMETER Suffix
         Custom suffix appended to the snapshot name. The resulting snapshot is named
         `{source}.{suffix}`. If omitted, FlashBlade generates a timestamp suffix.
@@ -19,10 +21,14 @@ function New-PfbFileSystemSnapshot {
     .EXAMPLE
         New-PfbFileSystemSnapshot -SourceName fs1 -Suffix daily-backup
         Creates `fs1.daily-backup`.
+    .EXAMPLE
+        Get-PfbFileSystem | New-PfbFileSystemSnapshot -Suffix nightly
+        Snapshots every file system on the array in one request.
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
     param(
-        [Parameter(Mandatory, Position = 0)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipelineByPropertyName)]
+        [Alias('Name')]
         [string[]]$SourceName,
 
         [Parameter()]
@@ -38,19 +44,30 @@ function New-PfbFileSystemSnapshot {
         [PSCustomObject]$Array
     )
 
-    Assert-PfbConnection -Array ([ref]$Array)
+    begin {
+        Assert-PfbConnection -Array ([ref]$Array)
+        $allSourceNames = [System.Collections.Generic.List[string]]::new()
+    }
 
-    $queryParams = @{ 'source_names' = $SourceName -join ',' }
-    if ($Send)                           { $queryParams['send']    = 'true' }
-    if ($Targets -and $Targets.Count -gt 0) { $queryParams['targets'] = $Targets -join ',' }
+    process {
+        if ($SourceName) {
+            foreach ($n in $SourceName) { $allSourceNames.Add($n) }
+        }
+    }
 
-    # FlashBlade's POST /file-system-snapshots takes `suffix` in the request body
-    # (FileSystemSnapshotPost schema), NOT as a query parameter. Passing it via query
-    # is silently ignored and the FB falls back to an auto-generated timestamp suffix.
-    $body = $null
-    if ($Suffix) { $body = @{ suffix = $Suffix } }
+    end {
+        $queryParams = @{ 'source_names' = $allSourceNames -join ',' }
+        if ($Send)                              { $queryParams['send']    = 'true' }
+        if ($Targets -and $Targets.Count -gt 0) { $queryParams['targets'] = $Targets -join ',' }
 
-    if ($PSCmdlet.ShouldProcess(($SourceName -join ', '), 'Create file system snapshot')) {
-        Invoke-PfbApiRequest -Array $Array -Method POST -Endpoint 'file-system-snapshots' -QueryParams $queryParams -Body $body
+        # FlashBlade's POST /file-system-snapshots takes `suffix` in the request body
+        # (FileSystemSnapshotPost schema), NOT as a query parameter. Passing it via query
+        # is silently ignored and the FB falls back to an auto-generated timestamp suffix.
+        $body = $null
+        if ($Suffix) { $body = @{ suffix = $Suffix } }
+
+        if ($PSCmdlet.ShouldProcess(($allSourceNames -join ', '), 'Create file system snapshot')) {
+            Invoke-PfbApiRequest -Array $Array -Method POST -Endpoint 'file-system-snapshots' -QueryParams $queryParams -Body $body
+        }
     }
 }

--- a/Public/FileSystemSnapshot/New-PfbFileSystemSnapshot.ps1
+++ b/Public/FileSystemSnapshot/New-PfbFileSystemSnapshot.ps1
@@ -2,10 +2,16 @@ function New-PfbFileSystemSnapshot {
     <#
     .SYNOPSIS
         Creates a snapshot of one or more file systems.
+    .DESCRIPTION
+        Creates a snapshot of a file system. FlashBlade's snapshot-creation endpoint accepts
+        only one source file system per call (confirmed against a real array: passing more
+        than one name in a single request fails with "Cannot process more than one source at
+        a time"), so when multiple names are supplied -- either explicitly or via the pipeline
+        -- one API call is issued per file system.
     .PARAMETER SourceName
-        Name of the source file system(s) to snapshot. Accepts pipeline input by
-        property name (aliased to 'Name'), so `Get-PfbFileSystem | New-PfbFileSystemSnapshot`
-        snapshots every piped file system in a single request.
+        Name of the source file system(s) to snapshot. Accepts pipeline input by property
+        name (aliased to 'Name'), so `Get-PfbFileSystem | New-PfbFileSystemSnapshot` snapshots
+        every piped file system, one API call per file system.
     .PARAMETER Suffix
         Custom suffix appended to the snapshot name. The resulting snapshot is named
         `{source}.{suffix}`. If omitted, FlashBlade generates a timestamp suffix.
@@ -23,7 +29,7 @@ function New-PfbFileSystemSnapshot {
         Creates `fs1.daily-backup`.
     .EXAMPLE
         Get-PfbFileSystem | New-PfbFileSystemSnapshot -Suffix nightly
-        Snapshots every file system on the array in one request.
+        Snapshots every file system on the array (one API call per file system).
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
     param(
@@ -46,28 +52,23 @@ function New-PfbFileSystemSnapshot {
 
     begin {
         Assert-PfbConnection -Array ([ref]$Array)
-        $allSourceNames = [System.Collections.Generic.List[string]]::new()
     }
 
     process {
-        if ($SourceName) {
-            foreach ($n in $SourceName) { $allSourceNames.Add($n) }
-        }
-    }
+        foreach ($name in $SourceName) {
+            $queryParams = @{ 'source_names' = $name }
+            if ($Send)                              { $queryParams['send']    = 'true' }
+            if ($Targets -and $Targets.Count -gt 0) { $queryParams['targets'] = $Targets -join ',' }
 
-    end {
-        $queryParams = @{ 'source_names' = $allSourceNames -join ',' }
-        if ($Send)                              { $queryParams['send']    = 'true' }
-        if ($Targets -and $Targets.Count -gt 0) { $queryParams['targets'] = $Targets -join ',' }
+            # FlashBlade's POST /file-system-snapshots takes `suffix` in the request body
+            # (FileSystemSnapshotPost schema), NOT as a query parameter. Passing it via query
+            # is silently ignored and the FB falls back to an auto-generated timestamp suffix.
+            $body = $null
+            if ($Suffix) { $body = @{ suffix = $Suffix } }
 
-        # FlashBlade's POST /file-system-snapshots takes `suffix` in the request body
-        # (FileSystemSnapshotPost schema), NOT as a query parameter. Passing it via query
-        # is silently ignored and the FB falls back to an auto-generated timestamp suffix.
-        $body = $null
-        if ($Suffix) { $body = @{ suffix = $Suffix } }
-
-        if ($PSCmdlet.ShouldProcess(($allSourceNames -join ', '), 'Create file system snapshot')) {
-            Invoke-PfbApiRequest -Array $Array -Method POST -Endpoint 'file-system-snapshots' -QueryParams $queryParams -Body $body
+            if ($PSCmdlet.ShouldProcess($name, 'Create file system snapshot')) {
+                Invoke-PfbApiRequest -Array $Array -Method POST -Endpoint 'file-system-snapshots' -QueryParams $queryParams -Body $body
+            }
         }
     }
 }

--- a/Public/FileSystemSnapshot/New-PfbFileSystemSnapshotPolicy.ps1
+++ b/Public/FileSystemSnapshot/New-PfbFileSystemSnapshotPolicy.ps1
@@ -4,13 +4,15 @@ function New-PfbFileSystemSnapshotPolicy {
         Attaches a policy to a file system snapshot on the FlashBlade.
     .DESCRIPTION
         Associates an existing policy with a file system snapshot by specifying
-        both the policy and snapshot names or IDs.
+        both the policy and snapshot names or IDs. The snapshot's name binds from
+        the pipeline (property 'name', aliased to 'MemberName'), so
+        `Get-PfbFileSystemSnapshot | New-PfbFileSystemSnapshotPolicy -PolicyName <p>` works.
     .PARAMETER PolicyName
         The name of the policy to attach.
     .PARAMETER PolicyId
         The ID of the policy to attach.
     .PARAMETER MemberName
-        The name of the snapshot to attach the policy to.
+        The name of the snapshot to attach the policy to. Binds from pipeline property 'name'.
     .PARAMETER MemberId
         The ID of the snapshot to attach the policy to.
     .PARAMETER Array
@@ -19,30 +21,41 @@ function New-PfbFileSystemSnapshotPolicy {
         New-PfbFileSystemSnapshotPolicy -PolicyName "replication-hourly" -MemberName "fs01.snap1"
         Attaches the 'replication-hourly' policy to snapshot 'fs01.snap1'.
     .EXAMPLE
-        New-PfbFileSystemSnapshotPolicy -PolicyId "abc-123" -MemberId "def-456"
-        Attaches a policy to a snapshot using IDs.
+        Get-PfbFileSystemSnapshot -SourceName fs1 | New-PfbFileSystemSnapshotPolicy -PolicyName "replication-hourly"
+        Attaches the policy to every snapshot of fs1.
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
     param(
-        [Parameter()] [string]$PolicyName,
+        [Parameter(ValueFromPipelineByPropertyName)] [string]$PolicyName,
         [Parameter()] [string]$PolicyId,
-        [Parameter()] [string]$MemberName,
+        [Parameter(ValueFromPipelineByPropertyName)] [Alias('Name')] [string]$MemberName,
         [Parameter()] [string]$MemberId,
         [Parameter()] [PSCustomObject]$Array
     )
 
-    Assert-PfbConnection -Array ([ref]$Array)
+    begin {
+        Assert-PfbConnection -Array ([ref]$Array)
+    }
 
-    $queryParams = @{}
-    if ($PolicyName) { $queryParams['policy_names'] = $PolicyName }
-    if ($PolicyId)   { $queryParams['policy_ids']   = $PolicyId }
-    if ($MemberName) { $queryParams['member_names']  = $MemberName }
-    if ($MemberId)   { $queryParams['member_ids']    = $MemberId }
+    process {
+        if (-not $PolicyName -and -not $PolicyId) {
+            throw 'You must supply either -PolicyName or -PolicyId.'
+        }
+        if (-not $MemberName -and -not $MemberId) {
+            throw 'You must supply either -MemberName or -MemberId.'
+        }
 
-    $target = if ($MemberName) { $MemberName } else { $MemberId }
-    $policy = if ($PolicyName) { $PolicyName } else { $PolicyId }
+        $queryParams = @{}
+        if ($PolicyName) { $queryParams['policy_names'] = $PolicyName }
+        if ($PolicyId)   { $queryParams['policy_ids']   = $PolicyId }
+        if ($MemberName) { $queryParams['member_names'] = $MemberName }
+        if ($MemberId)   { $queryParams['member_ids']   = $MemberId }
 
-    if ($PSCmdlet.ShouldProcess("$target", "Attach policy '$policy'")) {
-        Invoke-PfbApiRequest -Array $Array -Method POST -Endpoint 'file-system-snapshots/policies' -QueryParams $queryParams
+        $target = if ($MemberName) { $MemberName } else { $MemberId }
+        $policy = if ($PolicyName) { $PolicyName } else { $PolicyId }
+
+        if ($PSCmdlet.ShouldProcess("$target", "Attach policy '$policy'")) {
+            Invoke-PfbApiRequest -Array $Array -Method POST -Endpoint 'file-system-snapshots/policies' -QueryParams $queryParams
+        }
     }
 }

--- a/Public/FileSystemSnapshot/Remove-PfbFileSystemSnapshotPolicy.ps1
+++ b/Public/FileSystemSnapshot/Remove-PfbFileSystemSnapshotPolicy.ps1
@@ -4,13 +4,14 @@ function Remove-PfbFileSystemSnapshotPolicy {
         Detaches a policy from a file system snapshot on the FlashBlade.
     .DESCRIPTION
         Removes the association between a policy and a file system snapshot by
-        specifying both the policy and snapshot names or IDs.
+        specifying both the policy and snapshot names or IDs. The snapshot's name
+        binds from the pipeline (property 'name', aliased to 'MemberName').
     .PARAMETER PolicyName
         The name of the policy to detach.
     .PARAMETER PolicyId
         The ID of the policy to detach.
     .PARAMETER MemberName
-        The name of the snapshot to detach the policy from.
+        The name of the snapshot to detach the policy from. Binds from pipeline property 'name'.
     .PARAMETER MemberId
         The ID of the snapshot to detach the policy from.
     .PARAMETER Array
@@ -19,29 +20,40 @@ function Remove-PfbFileSystemSnapshotPolicy {
         Remove-PfbFileSystemSnapshotPolicy -PolicyName "replication-hourly" -MemberName "fs01.snap1"
         Detaches the 'replication-hourly' policy from snapshot 'fs01.snap1'.
     .EXAMPLE
-        Remove-PfbFileSystemSnapshotPolicy -PolicyId "abc-123" -MemberId "def-456"
-        Detaches a policy from a snapshot using IDs.
+        Get-PfbFileSystemSnapshot -SourceName fs1 | Remove-PfbFileSystemSnapshotPolicy -PolicyName "replication-hourly"
+        Detaches the policy from every snapshot of fs1.
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
     param(
-        [Parameter()] [string]$PolicyName,
+        [Parameter(ValueFromPipelineByPropertyName)] [string]$PolicyName,
         [Parameter()] [string]$PolicyId,
-        [Parameter()] [string]$MemberName,
+        [Parameter(ValueFromPipelineByPropertyName)] [Alias('Name')] [string]$MemberName,
         [Parameter()] [string]$MemberId,
         [Parameter()] [PSCustomObject]$Array
     )
 
-    Assert-PfbConnection -Array ([ref]$Array)
+    begin {
+        Assert-PfbConnection -Array ([ref]$Array)
+    }
 
-    $queryParams = @{}
-    if ($PolicyName) { $queryParams['policy_names'] = $PolicyName }
-    if ($PolicyId)   { $queryParams['policy_ids']   = $PolicyId }
-    if ($MemberName) { $queryParams['member_names']  = $MemberName }
-    if ($MemberId)   { $queryParams['member_ids']    = $MemberId }
+    process {
+        if (-not $PolicyName -and -not $PolicyId) {
+            throw 'You must supply either -PolicyName or -PolicyId.'
+        }
+        if (-not $MemberName -and -not $MemberId) {
+            throw 'You must supply either -MemberName or -MemberId.'
+        }
 
-    $target = "${PolicyName}:${MemberName}"
+        $queryParams = @{}
+        if ($PolicyName) { $queryParams['policy_names'] = $PolicyName }
+        if ($PolicyId)   { $queryParams['policy_ids']   = $PolicyId }
+        if ($MemberName) { $queryParams['member_names'] = $MemberName }
+        if ($MemberId)   { $queryParams['member_ids']   = $MemberId }
 
-    if ($PSCmdlet.ShouldProcess($target, 'Detach policy from snapshot')) {
-        Invoke-PfbApiRequest -Array $Array -Method DELETE -Endpoint 'file-system-snapshots/policies' -QueryParams $queryParams
+        $target = "${PolicyName}:${MemberName}"
+
+        if ($PSCmdlet.ShouldProcess($target, 'Detach policy from snapshot')) {
+            Invoke-PfbApiRequest -Array $Array -Method DELETE -Endpoint 'file-system-snapshots/policies' -QueryParams $queryParams
+        }
     }
 }

--- a/Public/ObjectStore/Get-PfbObjectStoreAccessPolicyRole.ps1
+++ b/Public/ObjectStore/Get-PfbObjectStoreAccessPolicyRole.ps1
@@ -81,6 +81,17 @@ function Get-PfbObjectStoreAccessPolicyRole {
         if ($Limit -gt 0)              { $queryParams['limit']        = $Limit }
         if ($TotalOnly)                  { $queryParams['total_only']   = 'true' }
 
-        Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'object-store-access-policies/object-store-roles' -QueryParams $queryParams -AutoPaginate
+        $response = Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'object-store-access-policies/object-store-roles' -QueryParams $queryParams -AutoPaginate
+        foreach ($item in $response) {
+            if ($null -ne $item) {
+                $policyNameValue = $null
+                if ($null -ne $item.policy) { $policyNameValue = $item.policy.name }
+                $memberNameValue = $null
+                if ($null -ne $item.member) { $memberNameValue = $item.member.name }
+                $item | Add-Member -MemberType NoteProperty -Name 'PolicyName' -Value $policyNameValue -Force
+                $item | Add-Member -MemberType NoteProperty -Name 'MemberName' -Value $memberNameValue -Force
+            }
+            $item
+        }
     }
 }

--- a/Public/ObjectStore/Get-PfbObjectStoreAccessPolicyUser.ps1
+++ b/Public/ObjectStore/Get-PfbObjectStoreAccessPolicyUser.ps1
@@ -81,6 +81,17 @@ function Get-PfbObjectStoreAccessPolicyUser {
         if ($Limit -gt 0)              { $queryParams['limit']        = $Limit }
         if ($TotalOnly)                  { $queryParams['total_only']   = 'true' }
 
-        Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'object-store-access-policies/object-store-users' -QueryParams $queryParams -AutoPaginate
+        $response = Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'object-store-access-policies/object-store-users' -QueryParams $queryParams -AutoPaginate
+        foreach ($item in $response) {
+            if ($null -ne $item) {
+                $policyNameValue = $null
+                if ($null -ne $item.policy) { $policyNameValue = $item.policy.name }
+                $memberNameValue = $null
+                if ($null -ne $item.member) { $memberNameValue = $item.member.name }
+                $item | Add-Member -MemberType NoteProperty -Name 'PolicyName' -Value $policyNameValue -Force
+                $item | Add-Member -MemberType NoteProperty -Name 'MemberName' -Value $memberNameValue -Force
+            }
+            $item
+        }
     }
 }

--- a/Public/ObjectStore/Get-PfbObjectStoreUserAccessPolicy.ps1
+++ b/Public/ObjectStore/Get-PfbObjectStoreUserAccessPolicy.ps1
@@ -81,6 +81,17 @@ function Get-PfbObjectStoreUserAccessPolicy {
         if ($Limit -gt 0)              { $queryParams['limit']        = $Limit }
         if ($TotalOnly)                  { $queryParams['total_only']   = 'true' }
 
-        Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'object-store-users/object-store-access-policies' -QueryParams $queryParams -AutoPaginate
+        $response = Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'object-store-users/object-store-access-policies' -QueryParams $queryParams -AutoPaginate
+        foreach ($item in $response) {
+            if ($null -ne $item) {
+                $memberNameValue = $null
+                if ($null -ne $item.member) { $memberNameValue = $item.member.name }
+                $policyNameValue = $null
+                if ($null -ne $item.policy) { $policyNameValue = $item.policy.name }
+                $item | Add-Member -MemberType NoteProperty -Name 'MemberName' -Value $memberNameValue -Force
+                $item | Add-Member -MemberType NoteProperty -Name 'PolicyName' -Value $policyNameValue -Force
+            }
+            $item
+        }
     }
 }

--- a/Public/ObjectStore/New-PfbObjectStoreAccessPolicyRole.ps1
+++ b/Public/ObjectStore/New-PfbObjectStoreAccessPolicyRole.ps1
@@ -5,44 +5,44 @@ function New-PfbObjectStoreAccessPolicyRole {
     .DESCRIPTION
         Creates an association between an object store access policy and an
         object store role. Once linked, the role inherits the permissions
-        defined by the access policy.
+        defined by the access policy. Accepts flattened association objects from
+        Get-PfbObjectStoreAccessPolicyRole on the pipeline.
     .PARAMETER PolicyName
-        The name of the access policy.
+        The name of the access policy. Binds from pipeline property 'PolicyName'.
     .PARAMETER MemberName
-        The name of the object store role to link.
+        The name of the object store role to link. Binds from pipeline property 'MemberName'.
     .PARAMETER Array
         The FlashBlade connection object.
     .EXAMPLE
         New-PfbObjectStoreAccessPolicyRole -PolicyName "full-access-policy" -MemberName "s3-admin-role"
         Links the s3-admin-role to the full-access-policy.
     .EXAMPLE
-        New-PfbObjectStoreAccessPolicyRole -PolicyName "readonly-policy" -MemberName "analytics-role"
-        Links the analytics-role to a read-only policy.
-    .EXAMPLE
-        "role-a","role-b" | ForEach-Object {
-            New-PfbObjectStoreAccessPolicyRole -PolicyName "shared-policy" -MemberName $_
-        }
-        Links multiple roles to the same policy.
+        Get-PfbObjectStoreAccessPolicyRole -PolicyName "old-policy" | New-PfbObjectStoreAccessPolicyRole -PolicyName "new-policy"
+        Re-links every role from old-policy onto new-policy.
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
     param(
-        [Parameter(Mandatory, Position = 0)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipelineByPropertyName)]
         [string]$PolicyName,
 
-        [Parameter(Mandatory, Position = 1)]
+        [Parameter(Mandatory, Position = 1, ValueFromPipelineByPropertyName)]
         [string]$MemberName,
 
         [Parameter()] [PSCustomObject]$Array
     )
 
-    Assert-PfbConnection -Array ([ref]$Array)
-
-    $queryParams = @{
-        'policy_names' = $PolicyName
-        'member_names' = $MemberName
+    begin {
+        Assert-PfbConnection -Array ([ref]$Array)
     }
 
-    if ($PSCmdlet.ShouldProcess("Policy=$PolicyName, Role=$MemberName", 'Create access policy role link')) {
-        Invoke-PfbApiRequest -Array $Array -Method POST -Endpoint 'object-store-access-policies/object-store-roles' -QueryParams $queryParams
+    process {
+        $queryParams = @{
+            'policy_names' = $PolicyName
+            'member_names' = $MemberName
+        }
+
+        if ($PSCmdlet.ShouldProcess("Policy=$PolicyName, Role=$MemberName", 'Create access policy role link')) {
+            Invoke-PfbApiRequest -Array $Array -Method POST -Endpoint 'object-store-access-policies/object-store-roles' -QueryParams $queryParams
+        }
     }
 }

--- a/Public/ObjectStore/New-PfbObjectStoreAccessPolicyUser.ps1
+++ b/Public/ObjectStore/New-PfbObjectStoreAccessPolicyUser.ps1
@@ -5,44 +5,44 @@ function New-PfbObjectStoreAccessPolicyUser {
     .DESCRIPTION
         Creates an association between an object store access policy and an
         object store user. Once linked, the user inherits the permissions
-        defined by the access policy.
+        defined by the access policy. Accepts flattened association objects from
+        Get-PfbObjectStoreAccessPolicyUser on the pipeline.
     .PARAMETER PolicyName
-        The name of the access policy.
+        The name of the access policy. Binds from pipeline property 'PolicyName'.
     .PARAMETER MemberName
-        The name of the object store user to link (account/user format).
+        The name of the object store user to link (account/user format). Binds from pipeline property 'MemberName'.
     .PARAMETER Array
         The FlashBlade connection object.
     .EXAMPLE
         New-PfbObjectStoreAccessPolicyUser -PolicyName "full-access-policy" -MemberName "acct1/user1"
         Links the user to the full-access-policy.
     .EXAMPLE
-        New-PfbObjectStoreAccessPolicyUser -PolicyName "readonly-policy" -MemberName "acct1/reader"
-        Links a reader user to a read-only policy.
-    .EXAMPLE
-        "acct1/user1","acct1/user2" | ForEach-Object {
-            New-PfbObjectStoreAccessPolicyUser -PolicyName "shared-policy" -MemberName $_
-        }
-        Links multiple users to the same policy.
+        Get-PfbObjectStoreAccessPolicyUser -PolicyName "old-policy" | New-PfbObjectStoreAccessPolicyUser -PolicyName "new-policy"
+        Re-links every user from old-policy onto new-policy.
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
     param(
-        [Parameter(Mandatory, Position = 0)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipelineByPropertyName)]
         [string]$PolicyName,
 
-        [Parameter(Mandatory, Position = 1)]
+        [Parameter(Mandatory, Position = 1, ValueFromPipelineByPropertyName)]
         [string]$MemberName,
 
         [Parameter()] [PSCustomObject]$Array
     )
 
-    Assert-PfbConnection -Array ([ref]$Array)
-
-    $queryParams = @{
-        'policy_names' = $PolicyName
-        'member_names' = $MemberName
+    begin {
+        Assert-PfbConnection -Array ([ref]$Array)
     }
 
-    if ($PSCmdlet.ShouldProcess("Policy=$PolicyName, User=$MemberName", 'Create access policy user link')) {
-        Invoke-PfbApiRequest -Array $Array -Method POST -Endpoint 'object-store-access-policies/object-store-users' -QueryParams $queryParams
+    process {
+        $queryParams = @{
+            'policy_names' = $PolicyName
+            'member_names' = $MemberName
+        }
+
+        if ($PSCmdlet.ShouldProcess("Policy=$PolicyName, User=$MemberName", 'Create access policy user link')) {
+            Invoke-PfbApiRequest -Array $Array -Method POST -Endpoint 'object-store-access-policies/object-store-users' -QueryParams $queryParams
+        }
     }
 }

--- a/Public/ObjectStore/New-PfbObjectStoreUserAccessPolicy.ps1
+++ b/Public/ObjectStore/New-PfbObjectStoreUserAccessPolicy.ps1
@@ -5,44 +5,44 @@ function New-PfbObjectStoreUserAccessPolicy {
     .DESCRIPTION
         Creates an association between an object store user and an access
         policy. Once linked, the user inherits the permissions defined by
-        the access policy.
+        the access policy. Accepts flattened association objects from
+        Get-PfbObjectStoreUserAccessPolicy on the pipeline.
     .PARAMETER MemberName
-        The name of the object store user (account/user format).
+        The name of the object store user (account/user format). Binds from pipeline property 'MemberName'.
     .PARAMETER PolicyName
-        The name of the access policy to link.
+        The name of the access policy to link. Binds from pipeline property 'PolicyName'.
     .PARAMETER Array
         The FlashBlade connection object.
     .EXAMPLE
         New-PfbObjectStoreUserAccessPolicy -MemberName "acct1/user1" -PolicyName "full-access-policy"
         Links the full-access-policy to the specified user.
     .EXAMPLE
-        New-PfbObjectStoreUserAccessPolicy -MemberName "acct1/reader" -PolicyName "readonly-policy"
-        Links a read-only policy to a reader user.
-    .EXAMPLE
-        "acct1/user1","acct1/user2" | ForEach-Object {
-            New-PfbObjectStoreUserAccessPolicy -MemberName $_ -PolicyName "shared-policy"
-        }
-        Links the same policy to multiple users.
+        Get-PfbObjectStoreUserAccessPolicy -MemberName "acct1/user1" | New-PfbObjectStoreUserAccessPolicy -PolicyName "another-policy"
+        Adds another policy link for the user.
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
     param(
-        [Parameter(Mandatory, Position = 0)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipelineByPropertyName)]
         [string]$MemberName,
 
-        [Parameter(Mandatory, Position = 1)]
+        [Parameter(Mandatory, Position = 1, ValueFromPipelineByPropertyName)]
         [string]$PolicyName,
 
         [Parameter()] [PSCustomObject]$Array
     )
 
-    Assert-PfbConnection -Array ([ref]$Array)
-
-    $queryParams = @{
-        'member_names' = $MemberName
-        'policy_names' = $PolicyName
+    begin {
+        Assert-PfbConnection -Array ([ref]$Array)
     }
 
-    if ($PSCmdlet.ShouldProcess("User=$MemberName, Policy=$PolicyName", 'Create user access policy link')) {
-        Invoke-PfbApiRequest -Array $Array -Method POST -Endpoint 'object-store-users/object-store-access-policies' -QueryParams $queryParams
+    process {
+        $queryParams = @{
+            'member_names' = $MemberName
+            'policy_names' = $PolicyName
+        }
+
+        if ($PSCmdlet.ShouldProcess("User=$MemberName, Policy=$PolicyName", 'Create user access policy link')) {
+            Invoke-PfbApiRequest -Array $Array -Method POST -Endpoint 'object-store-users/object-store-access-policies' -QueryParams $queryParams
+        }
     }
 }

--- a/Public/ObjectStore/Remove-PfbObjectStoreAccessPolicyRole.ps1
+++ b/Public/ObjectStore/Remove-PfbObjectStoreAccessPolicyRole.ps1
@@ -4,44 +4,44 @@ function Remove-PfbObjectStoreAccessPolicyRole {
         Removes the link between an access policy and an object store role.
     .DESCRIPTION
         Deletes the association between an object store access policy and an
-        object store role. The role will no longer inherit the permissions
-        defined by the policy.
+        object store role. Accepts flattened association objects from
+        Get-PfbObjectStoreAccessPolicyRole on the pipeline.
     .PARAMETER PolicyName
-        The name of the access policy.
+        The name of the access policy. Binds from pipeline property 'PolicyName'.
     .PARAMETER MemberName
-        The name of the object store role to unlink.
+        The name of the object store role to unlink. Binds from pipeline property 'MemberName'.
     .PARAMETER Array
         The FlashBlade connection object.
     .EXAMPLE
         Remove-PfbObjectStoreAccessPolicyRole -PolicyName "full-access-policy" -MemberName "s3-admin-role"
         Removes the link between the policy and the role.
     .EXAMPLE
-        Remove-PfbObjectStoreAccessPolicyRole -PolicyName "temp-policy" -MemberName "temp-role"
-        Unlinks a temporary role from its policy.
-    .EXAMPLE
-        Get-PfbObjectStoreAccessPolicyRole -PolicyName "old-policy" |
-            ForEach-Object { Remove-PfbObjectStoreAccessPolicyRole -PolicyName $_.policy.name -MemberName $_.member.name }
+        Get-PfbObjectStoreAccessPolicyRole -PolicyName "old-policy" | Remove-PfbObjectStoreAccessPolicyRole
         Removes all role links from a policy.
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
     param(
-        [Parameter(Mandatory, Position = 0)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipelineByPropertyName)]
         [string]$PolicyName,
 
-        [Parameter(Mandatory, Position = 1)]
+        [Parameter(Mandatory, Position = 1, ValueFromPipelineByPropertyName)]
         [string]$MemberName,
 
         [Parameter()] [PSCustomObject]$Array
     )
 
-    Assert-PfbConnection -Array ([ref]$Array)
-
-    $queryParams = @{
-        'policy_names' = $PolicyName
-        'member_names' = $MemberName
+    begin {
+        Assert-PfbConnection -Array ([ref]$Array)
     }
 
-    if ($PSCmdlet.ShouldProcess("Policy=$PolicyName, Role=$MemberName", 'Remove access policy role link')) {
-        Invoke-PfbApiRequest -Array $Array -Method DELETE -Endpoint 'object-store-access-policies/object-store-roles' -QueryParams $queryParams
+    process {
+        $queryParams = @{
+            'policy_names' = $PolicyName
+            'member_names' = $MemberName
+        }
+
+        if ($PSCmdlet.ShouldProcess("Policy=$PolicyName, Role=$MemberName", 'Remove access policy role link')) {
+            Invoke-PfbApiRequest -Array $Array -Method DELETE -Endpoint 'object-store-access-policies/object-store-roles' -QueryParams $queryParams
+        }
     }
 }

--- a/Public/ObjectStore/Remove-PfbObjectStoreAccessPolicyUser.ps1
+++ b/Public/ObjectStore/Remove-PfbObjectStoreAccessPolicyUser.ps1
@@ -4,44 +4,44 @@ function Remove-PfbObjectStoreAccessPolicyUser {
         Removes the link between an access policy and an object store user.
     .DESCRIPTION
         Deletes the association between an object store access policy and an
-        object store user. The user will no longer inherit the permissions
-        defined by the policy.
+        object store user. Accepts flattened association objects from
+        Get-PfbObjectStoreAccessPolicyUser on the pipeline.
     .PARAMETER PolicyName
-        The name of the access policy.
+        The name of the access policy. Binds from pipeline property 'PolicyName'.
     .PARAMETER MemberName
-        The name of the object store user to unlink (account/user format).
+        The name of the object store user to unlink (account/user format). Binds from pipeline property 'MemberName'.
     .PARAMETER Array
         The FlashBlade connection object.
     .EXAMPLE
         Remove-PfbObjectStoreAccessPolicyUser -PolicyName "full-access-policy" -MemberName "acct1/user1"
         Removes the link between the policy and the user.
     .EXAMPLE
-        Remove-PfbObjectStoreAccessPolicyUser -PolicyName "temp-policy" -MemberName "acct1/temp-user"
-        Unlinks a temporary user from its policy.
-    .EXAMPLE
-        Get-PfbObjectStoreAccessPolicyUser -PolicyName "old-policy" |
-            ForEach-Object { Remove-PfbObjectStoreAccessPolicyUser -PolicyName $_.policy.name -MemberName $_.member.name }
+        Get-PfbObjectStoreAccessPolicyUser -PolicyName "old-policy" | Remove-PfbObjectStoreAccessPolicyUser
         Removes all user links from a policy.
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
     param(
-        [Parameter(Mandatory, Position = 0)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipelineByPropertyName)]
         [string]$PolicyName,
 
-        [Parameter(Mandatory, Position = 1)]
+        [Parameter(Mandatory, Position = 1, ValueFromPipelineByPropertyName)]
         [string]$MemberName,
 
         [Parameter()] [PSCustomObject]$Array
     )
 
-    Assert-PfbConnection -Array ([ref]$Array)
-
-    $queryParams = @{
-        'policy_names' = $PolicyName
-        'member_names' = $MemberName
+    begin {
+        Assert-PfbConnection -Array ([ref]$Array)
     }
 
-    if ($PSCmdlet.ShouldProcess("Policy=$PolicyName, User=$MemberName", 'Remove access policy user link')) {
-        Invoke-PfbApiRequest -Array $Array -Method DELETE -Endpoint 'object-store-access-policies/object-store-users' -QueryParams $queryParams
+    process {
+        $queryParams = @{
+            'policy_names' = $PolicyName
+            'member_names' = $MemberName
+        }
+
+        if ($PSCmdlet.ShouldProcess("Policy=$PolicyName, User=$MemberName", 'Remove access policy user link')) {
+            Invoke-PfbApiRequest -Array $Array -Method DELETE -Endpoint 'object-store-access-policies/object-store-users' -QueryParams $queryParams
+        }
     }
 }

--- a/Public/ObjectStore/Remove-PfbObjectStoreUserAccessPolicy.ps1
+++ b/Public/ObjectStore/Remove-PfbObjectStoreUserAccessPolicy.ps1
@@ -4,44 +4,44 @@ function Remove-PfbObjectStoreUserAccessPolicy {
         Removes the link between an object store user and an access policy.
     .DESCRIPTION
         Deletes the association between an object store user and an access
-        policy. The user will no longer inherit the permissions defined by
-        that policy.
+        policy. Accepts flattened association objects from
+        Get-PfbObjectStoreUserAccessPolicy on the pipeline.
     .PARAMETER MemberName
-        The name of the object store user (account/user format).
+        The name of the object store user (account/user format). Binds from pipeline property 'MemberName'.
     .PARAMETER PolicyName
-        The name of the access policy to unlink.
+        The name of the access policy to unlink. Binds from pipeline property 'PolicyName'.
     .PARAMETER Array
         The FlashBlade connection object.
     .EXAMPLE
         Remove-PfbObjectStoreUserAccessPolicy -MemberName "acct1/user1" -PolicyName "full-access-policy"
         Removes the link between the user and the access policy.
     .EXAMPLE
-        Remove-PfbObjectStoreUserAccessPolicy -MemberName "acct1/temp-user" -PolicyName "temp-policy"
-        Unlinks a temporary policy from its user.
-    .EXAMPLE
-        Get-PfbObjectStoreUserAccessPolicy -MemberName "acct1/old-user" |
-            ForEach-Object { Remove-PfbObjectStoreUserAccessPolicy -MemberName $_.member.name -PolicyName $_.policy.name }
+        Get-PfbObjectStoreUserAccessPolicy -MemberName "acct1/old-user" | Remove-PfbObjectStoreUserAccessPolicy
         Removes all access policy links from a user.
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
     param(
-        [Parameter(Mandatory, Position = 0)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipelineByPropertyName)]
         [string]$MemberName,
 
-        [Parameter(Mandatory, Position = 1)]
+        [Parameter(Mandatory, Position = 1, ValueFromPipelineByPropertyName)]
         [string]$PolicyName,
 
         [Parameter()] [PSCustomObject]$Array
     )
 
-    Assert-PfbConnection -Array ([ref]$Array)
-
-    $queryParams = @{
-        'member_names' = $MemberName
-        'policy_names' = $PolicyName
+    begin {
+        Assert-PfbConnection -Array ([ref]$Array)
     }
 
-    if ($PSCmdlet.ShouldProcess("User=$MemberName, Policy=$PolicyName", 'Remove user access policy link')) {
-        Invoke-PfbApiRequest -Array $Array -Method DELETE -Endpoint 'object-store-users/object-store-access-policies' -QueryParams $queryParams
+    process {
+        $queryParams = @{
+            'member_names' = $MemberName
+            'policy_names' = $PolicyName
+        }
+
+        if ($PSCmdlet.ShouldProcess("User=$MemberName, Policy=$PolicyName", 'Remove user access policy link')) {
+            Invoke-PfbApiRequest -Array $Array -Method DELETE -Endpoint 'object-store-users/object-store-access-policies' -QueryParams $queryParams
+        }
     }
 }

--- a/Public/Quota/Get-PfbQuotaUser.ps1
+++ b/Public/Quota/Get-PfbQuotaUser.ps1
@@ -45,5 +45,16 @@ function Get-PfbQuotaUser {
     if ($Filter) { $queryParams['filter'] = $Filter }
     if ($Sort) { $queryParams['sort'] = $Sort }
     if ($Limit -gt 0) { $queryParams['limit'] = $Limit }
-    Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'quotas/users' -QueryParams $queryParams -AutoPaginate
+    $response = Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'quotas/users' -QueryParams $queryParams -AutoPaginate
+    foreach ($item in $response) {
+        if ($null -ne $item) {
+            $fileSystemNameValue = $null
+            if ($null -ne $item.file_system) { $fileSystemNameValue = $item.file_system.name }
+            $userNameValue = $null
+            if ($null -ne $item.user) { $userNameValue = $item.user.name }
+            $item | Add-Member -MemberType NoteProperty -Name 'FileSystemName' -Value $fileSystemNameValue -Force
+            $item | Add-Member -MemberType NoteProperty -Name 'UserName' -Value $userNameValue -Force
+        }
+        $item
+    }
 }

--- a/Public/Quota/Get-PfbQuotaUser.ps1
+++ b/Public/Quota/Get-PfbQuotaUser.ps1
@@ -40,8 +40,16 @@ function Get-PfbQuotaUser {
     )
     Assert-PfbConnection -Array ([ref]$Array)
     $queryParams = @{}
-    if ($Name) { $queryParams['names'] = $Name -join ',' }
-    if ($FileSystemName) { $queryParams['file_system_names'] = $FileSystemName }
+    if ($Name) {
+        # FlashBlade rejects 'names' combined with 'file_system_names' ("Cannot provide a
+        # names parameter along with any of: file system, user IDs, or user names" --
+        # confirmed live against our lab array). The compound name (e.g. 'fs-share/1235') already
+        # identifies the file system, so file_system_names is omitted in this branch.
+        $queryParams['names'] = $Name -join ','
+    }
+    elseif ($FileSystemName) {
+        $queryParams['file_system_names'] = $FileSystemName
+    }
     if ($Filter) { $queryParams['filter'] = $Filter }
     if ($Sort) { $queryParams['sort'] = $Sort }
     if ($Limit -gt 0) { $queryParams['limit'] = $Limit }

--- a/Public/Quota/Remove-PfbQuotaUser.ps1
+++ b/Public/Quota/Remove-PfbQuotaUser.ps1
@@ -1,39 +1,40 @@
 function Remove-PfbQuotaUser {
     <#
     .SYNOPSIS
-        Removes a user quota from a Pure Storage FlashBlade file system.
+        Removes a user quota from a FlashBlade file system.
     .DESCRIPTION
         The Remove-PfbQuotaUser cmdlet deletes a user quota entry from the specified file system
         on the FlashBlade. This operation has a high confirm impact and will prompt for confirmation
-        by default. Use -Confirm:$false to suppress the prompt.
+        by default. Use -Confirm:$false to suppress the prompt. Identity binds from the pipeline via
+        flattened 'FileSystemName' / 'UserName' properties emitted by Get-PfbQuotaUser.
     .PARAMETER FileSystemName
-        The name of the file system containing the user quota to remove.
+        The name of the file system containing the user quota to remove. Binds from pipeline property 'FileSystemName'.
     .PARAMETER UserName
-        The name of the user whose quota should be removed.
+        The name of the user whose quota should be removed. Binds from pipeline property 'UserName'.
     .PARAMETER Array
         The FlashBlade connection object. If not specified, the default connection is used.
     .EXAMPLE
         Remove-PfbQuotaUser -FileSystemName 'fs-home' -UserName 'jdoe'
-
         Removes the user quota for 'jdoe' on 'fs-home' after prompting for confirmation.
     .EXAMPLE
-        Remove-PfbQuotaUser -FileSystemName 'fs-home' -UserName 'former-employee' -Confirm:$false
-
-        Removes the user quota without prompting for confirmation.
-    .EXAMPLE
-        Remove-PfbQuotaUser -FileSystemName 'fs-home' -UserName 'contractor01' -Array $FlashBlade
-
-        Removes the user quota using a specific FlashBlade connection object.
+        Get-PfbQuotaUser -FileSystemName 'fs-home' | Remove-PfbQuotaUser -Confirm:$false
+        Removes every user quota on 'fs-home'.
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
     param(
-        [Parameter(Mandatory)] [string]$FileSystemName,
-        [Parameter(Mandatory)] [string]$UserName,
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)] [string]$FileSystemName,
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)] [string]$UserName,
         [Parameter()] [PSCustomObject]$Array
     )
-    Assert-PfbConnection -Array ([ref]$Array)
-    $q = @{ 'names' = $UserName; 'file_system_names' = $FileSystemName }
-    if ($PSCmdlet.ShouldProcess("${FileSystemName}:${UserName}", 'Remove user quota')) {
-        Invoke-PfbApiRequest -Array $Array -Method DELETE -Endpoint 'quotas/users' -QueryParams $q
+
+    begin {
+        Assert-PfbConnection -Array ([ref]$Array)
+    }
+
+    process {
+        $q = @{ 'names' = $UserName; 'file_system_names' = $FileSystemName }
+        if ($PSCmdlet.ShouldProcess("${FileSystemName}:${UserName}", 'Remove user quota')) {
+            Invoke-PfbApiRequest -Array $Array -Method DELETE -Endpoint 'quotas/users' -QueryParams $q
+        }
     }
 }

--- a/Public/Quota/Remove-PfbQuotaUser.ps1
+++ b/Public/Quota/Remove-PfbQuotaUser.ps1
@@ -32,7 +32,7 @@ function Remove-PfbQuotaUser {
     }
 
     process {
-        $q = @{ 'names' = $UserName; 'file_system_names' = $FileSystemName }
+        $q = @{ 'user_names' = $UserName; 'file_system_names' = $FileSystemName }
         if ($PSCmdlet.ShouldProcess("${FileSystemName}:${UserName}", 'Remove user quota')) {
             Invoke-PfbApiRequest -Array $Array -Method DELETE -Endpoint 'quotas/users' -QueryParams $q
         }

--- a/Public/Quota/Update-PfbQuotaUser.ps1
+++ b/Public/Quota/Update-PfbQuotaUser.ps1
@@ -1,16 +1,17 @@
 function Update-PfbQuotaUser {
     <#
     .SYNOPSIS
-        Updates an existing user quota on a Pure Storage FlashBlade file system.
+        Updates an existing user quota on a FlashBlade file system.
     .DESCRIPTION
         The Update-PfbQuotaUser cmdlet modifies the quota limit for an existing user quota
         entry on a FlashBlade file system. You can specify a new quota value in bytes or
-        provide a complete attributes hashtable for advanced updates.
+        provide a complete attributes hashtable for advanced updates. Identity binds from
+        the pipeline via flattened 'FileSystemName' / 'UserName' properties emitted by Get-PfbQuotaUser.
         This cmdlet supports the ShouldProcess pattern for -WhatIf and -Confirm.
     .PARAMETER FileSystemName
-        The name of the file system containing the user quota to update.
+        The name of the file system containing the user quota to update. Binds from pipeline property 'FileSystemName'.
     .PARAMETER UserName
-        The name of the user whose quota should be updated.
+        The name of the user whose quota should be updated. Binds from pipeline property 'UserName'.
     .PARAMETER Quota
         The new quota limit in bytes. For example, 1073741824 equals 1 GiB.
     .PARAMETER Attributes
@@ -19,33 +20,33 @@ function Update-PfbQuotaUser {
         The FlashBlade connection object. If not specified, the default connection is used.
     .EXAMPLE
         Update-PfbQuotaUser -FileSystemName 'fs-home' -UserName 'jdoe' -Quota 10737418240
-
         Increases the user quota for 'jdoe' on 'fs-home' to 10 GiB.
     .EXAMPLE
-        Update-PfbQuotaUser -FileSystemName 'fs-home' -UserName 'asmith' -Quota 2147483648 -WhatIf
-
-        Shows what would happen when updating the quota without actually applying the change.
-    .EXAMPLE
-        Update-PfbQuotaUser -FileSystemName 'fs-home' -UserName 'bwilson' -Attributes @{ quota = 0 }
-
-        Removes the quota limit for user 'bwilson' by setting it to zero using a custom attributes hashtable.
+        Get-PfbQuotaUser -FileSystemName 'fs-home' | Update-PfbQuotaUser -Quota 0
+        Clears the quota limit for every user quota on 'fs-home'.
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
     param(
-        [Parameter(Mandatory)] [string]$FileSystemName,
-        [Parameter(Mandatory)] [string]$UserName,
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)] [string]$FileSystemName,
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)] [string]$UserName,
         [Parameter()] [int64]$Quota,
         [Parameter()] [hashtable]$Attributes,
         [Parameter()] [PSCustomObject]$Array
     )
-    Assert-PfbConnection -Array ([ref]$Array)
-    if ($Attributes) { $body = $Attributes }
-    else {
-        $body = @{}
-        if ($Quota -gt 0) { $body['quota'] = $Quota }
+
+    begin {
+        Assert-PfbConnection -Array ([ref]$Array)
     }
-    $q = @{ 'names' = $UserName; 'file_system_names' = $FileSystemName }
-    if ($PSCmdlet.ShouldProcess("${FileSystemName}:${UserName}", 'Update user quota')) {
-        Invoke-PfbApiRequest -Array $Array -Method PATCH -Endpoint 'quotas/users' -Body $body -QueryParams $q
+
+    process {
+        if ($Attributes) { $body = $Attributes }
+        else {
+            $body = @{}
+            if ($Quota -gt 0) { $body['quota'] = $Quota }
+        }
+        $q = @{ 'names' = $UserName; 'file_system_names' = $FileSystemName }
+        if ($PSCmdlet.ShouldProcess("${FileSystemName}:${UserName}", 'Update user quota')) {
+            Invoke-PfbApiRequest -Array $Array -Method PATCH -Endpoint 'quotas/users' -Body $body -QueryParams $q
+        }
     }
 }

--- a/Public/Quota/Update-PfbQuotaUser.ps1
+++ b/Public/Quota/Update-PfbQuotaUser.ps1
@@ -44,7 +44,7 @@ function Update-PfbQuotaUser {
             $body = @{}
             if ($Quota -gt 0) { $body['quota'] = $Quota }
         }
-        $q = @{ 'names' = $UserName; 'file_system_names' = $FileSystemName }
+        $q = @{ 'user_names' = $UserName; 'file_system_names' = $FileSystemName }
         if ($PSCmdlet.ShouldProcess("${FileSystemName}:${UserName}", 'Update user quota')) {
             Invoke-PfbApiRequest -Array $Array -Method PATCH -Endpoint 'quotas/users' -Body $body -QueryParams $q
         }

--- a/PureStorageFlashBladePowerShell.psd1
+++ b/PureStorageFlashBladePowerShell.psd1
@@ -1,6 +1,6 @@
 ﻿@{
     RootModule        = 'PureStorageFlashBladePowerShell.psm1'
-    ModuleVersion     = '2.0.6'
+    ModuleVersion     = '2.0.5'
     GUID              = 'b25473b3-9eb7-414d-8da1-264e10f73d86'
     Author            = 'Pure Storage, Inc.'
     CompanyName       = 'Pure Storage, Inc.'

--- a/PureStorageFlashBladePowerShell.psd1
+++ b/PureStorageFlashBladePowerShell.psd1
@@ -1,6 +1,6 @@
 ﻿@{
     RootModule        = 'PureStorageFlashBladePowerShell.psm1'
-    ModuleVersion     = '2.0.5'
+    ModuleVersion     = '2.0.6'
     GUID              = 'b25473b3-9eb7-414d-8da1-264e10f73d86'
     Author            = 'Pure Storage, Inc.'
     CompanyName       = 'Pure Storage, Inc.'

--- a/Tests/FileSystemSnapshotPolicy.Tests.ps1
+++ b/Tests/FileSystemSnapshotPolicy.Tests.ps1
@@ -1,0 +1,113 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    Import-Module "$PSScriptRoot/../PureStorageFlashBladePowerShell.psd1" -Force
+    # A throwaway connection object; Assert-PfbConnection is mocked so its contents don't matter.
+    $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
+}
+
+Describe 'New-PfbFileSystemSnapshotPolicy' {
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+    }
+
+    It 'works with explicit -PolicyName / -MemberName' {
+        New-PfbFileSystemSnapshotPolicy -PolicyName 'daily-snap' -MemberName 'fs01.snap1' -Confirm:$false -Array $fakeArray
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'POST' -and $Endpoint -eq 'file-system-snapshots/policies' -and
+            $QueryParams['policy_names'] -eq 'daily-snap' -and $QueryParams['member_names'] -eq 'fs01.snap1'
+        }
+    }
+
+    It 'binds MemberName from a piped snapshot object (.name) with -PolicyName explicit' {
+        [pscustomobject]@{ name = 'fs01.daily-backup' } |
+            New-PfbFileSystemSnapshotPolicy -PolicyName 'daily-snap' -Confirm:$false -Array $fakeArray
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['policy_names'] -eq 'daily-snap' -and $QueryParams['member_names'] -eq 'fs01.daily-backup'
+        }
+    }
+
+    It 'throws when neither -PolicyName nor -PolicyId is supplied, before any API call' {
+        { New-PfbFileSystemSnapshotPolicy -MemberName 'fs01.snap1' -Confirm:$false -Array $fakeArray } | Should -Throw
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 0 -Exactly
+    }
+
+    It 'throws when neither -MemberName nor -MemberId is supplied, before any API call' {
+        { New-PfbFileSystemSnapshotPolicy -PolicyName 'daily-snap' -Confirm:$false -Array $fakeArray } | Should -Throw
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 0 -Exactly
+    }
+
+    It 'works with explicit -PolicyId / -MemberId (no names)' {
+        New-PfbFileSystemSnapshotPolicy -PolicyId 'abc-123' -MemberId 'def-456' -Confirm:$false -Array $fakeArray
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['policy_ids'] -eq 'abc-123' -and $QueryParams['member_ids'] -eq 'def-456'
+        }
+    }
+
+    It 'pipes 2 snapshot objects into 2 separate API calls' {
+        @(
+            [pscustomobject]@{ name = 'fs01.snap1' }
+            [pscustomobject]@{ name = 'fs01.snap2' }
+        ) | New-PfbFileSystemSnapshotPolicy -PolicyName 'daily-snap' -Confirm:$false -Array $fakeArray
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 2 -Exactly
+    }
+
+    It 'makes zero API calls under -WhatIf' {
+        New-PfbFileSystemSnapshotPolicy -PolicyName 'daily-snap' -MemberName 'fs01.snap1' -WhatIf -Array $fakeArray
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 0 -Exactly
+    }
+}
+
+Describe 'Remove-PfbFileSystemSnapshotPolicy' {
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+    }
+
+    It 'works with explicit -PolicyName / -MemberName (DELETE)' {
+        Remove-PfbFileSystemSnapshotPolicy -PolicyName 'daily-snap' -MemberName 'fs01.snap1' -Confirm:$false -Array $fakeArray
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'DELETE' -and $Endpoint -eq 'file-system-snapshots/policies' -and
+            $QueryParams['policy_names'] -eq 'daily-snap' -and $QueryParams['member_names'] -eq 'fs01.snap1'
+        }
+    }
+
+    It 'binds MemberName from a piped snapshot object (.name)' {
+        [pscustomobject]@{ name = 'fs01.daily-backup' } |
+            Remove-PfbFileSystemSnapshotPolicy -PolicyName 'daily-snap' -Confirm:$false -Array $fakeArray
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['policy_names'] -eq 'daily-snap' -and $QueryParams['member_names'] -eq 'fs01.daily-backup'
+        }
+    }
+
+    It 'throws when neither policy identity is supplied, before any API call' {
+        { Remove-PfbFileSystemSnapshotPolicy -MemberName 'fs01.snap1' -Confirm:$false -Array $fakeArray } | Should -Throw
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 0 -Exactly
+    }
+
+    It 'throws when neither member identity is supplied, before any API call' {
+        { Remove-PfbFileSystemSnapshotPolicy -PolicyName 'daily-snap' -Confirm:$false -Array $fakeArray } | Should -Throw
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 0 -Exactly
+    }
+
+    It 'works with explicit -PolicyId / -MemberId' {
+        Remove-PfbFileSystemSnapshotPolicy -PolicyId 'abc-123' -MemberId 'def-456' -Confirm:$false -Array $fakeArray
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['policy_ids'] -eq 'abc-123' -and $QueryParams['member_ids'] -eq 'def-456'
+        }
+    }
+
+    It 'pipes 2 snapshot objects into 2 separate DELETE calls' {
+        @(
+            [pscustomobject]@{ name = 'fs01.snap1' }
+            [pscustomobject]@{ name = 'fs01.snap2' }
+        ) | Remove-PfbFileSystemSnapshotPolicy -PolicyName 'daily-snap' -Confirm:$false -Array $fakeArray
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 2 -Exactly
+    }
+
+    It 'makes zero API calls under -WhatIf' {
+        Remove-PfbFileSystemSnapshotPolicy -PolicyName 'daily-snap' -MemberName 'fs01.snap1' -WhatIf -Array $fakeArray
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 0 -Exactly
+    }
+}

--- a/Tests/New-PfbFileSystemSnapshot.Tests.ps1
+++ b/Tests/New-PfbFileSystemSnapshot.Tests.ps1
@@ -1,0 +1,46 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    Import-Module "$PSScriptRoot/../PureStorageFlashBladePowerShell.psd1" -Force
+    # A throwaway connection object; Assert-PfbConnection is mocked so its contents don't matter.
+    $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
+}
+
+Describe 'New-PfbFileSystemSnapshot' {
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+    }
+
+    It 'makes one API call with joined source_names for explicit -SourceName' {
+        New-PfbFileSystemSnapshot -SourceName 'fs1', 'fs2' -Confirm:$false -Array $fakeArray
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'POST' -and $Endpoint -eq 'file-system-snapshots' -and $QueryParams['source_names'] -eq 'fs1,fs2'
+        }
+    }
+
+    It 'accumulates ALL piped FileSystem objects into ONE call (regression: not just the last)' {
+        $fsObjects = @(
+            [pscustomobject]@{ name = 'fs1' }
+            [pscustomobject]@{ name = 'fs2' }
+            [pscustomobject]@{ name = 'fs3' }
+        )
+        $fsObjects | New-PfbFileSystemSnapshot -Confirm:$false -Array $fakeArray
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['source_names'] -eq 'fs1,fs2,fs3'
+        }
+    }
+
+    It 'passes suffix in the body when -Suffix is supplied' {
+        New-PfbFileSystemSnapshot -SourceName 'fs1' -Suffix 'daily-backup' -Confirm:$false -Array $fakeArray
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            $Body['suffix'] -eq 'daily-backup'
+        }
+    }
+
+    It 'makes zero API calls under -WhatIf' {
+        New-PfbFileSystemSnapshot -SourceName 'fs1' -WhatIf -Array $fakeArray
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 0 -Exactly
+    }
+}

--- a/Tests/New-PfbFileSystemSnapshot.Tests.ps1
+++ b/Tests/New-PfbFileSystemSnapshot.Tests.ps1
@@ -12,23 +12,33 @@ Describe 'New-PfbFileSystemSnapshot' {
         Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
     }
 
-    It 'makes one API call with joined source_names for explicit -SourceName' {
+    It 'makes one API call PER explicit -SourceName (FlashBlade rejects multi-source snapshot creation)' {
         New-PfbFileSystemSnapshot -SourceName 'fs1', 'fs2' -Confirm:$false -Array $fakeArray
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 2 -Exactly
         Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
-            $Method -eq 'POST' -and $Endpoint -eq 'file-system-snapshots' -and $QueryParams['source_names'] -eq 'fs1,fs2'
+            $Method -eq 'POST' -and $Endpoint -eq 'file-system-snapshots' -and $QueryParams['source_names'] -eq 'fs1'
+        }
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['source_names'] -eq 'fs2'
         }
     }
 
-    It 'accumulates ALL piped FileSystem objects into ONE call (regression: not just the last)' {
+    It 'issues a separate API call per piped FileSystem object (regression: must not batch into one call or only process the last)' {
         $fsObjects = @(
             [pscustomobject]@{ name = 'fs1' }
             [pscustomobject]@{ name = 'fs2' }
             [pscustomobject]@{ name = 'fs3' }
         )
         $fsObjects | New-PfbFileSystemSnapshot -Confirm:$false -Array $fakeArray
-        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 3 -Exactly
         Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
-            $QueryParams['source_names'] -eq 'fs1,fs2,fs3'
+            $QueryParams['source_names'] -eq 'fs1'
+        }
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['source_names'] -eq 'fs2'
+        }
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['source_names'] -eq 'fs3'
         }
     }
 

--- a/Tests/ObjectStoreAccessPolicyAssociations.Tests.ps1
+++ b/Tests/ObjectStoreAccessPolicyAssociations.Tests.ps1
@@ -1,0 +1,202 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    Import-Module "$PSScriptRoot/../PureStorageFlashBladePowerShell.psd1" -Force
+    # A throwaway connection object; Assert-PfbConnection is mocked so its contents don't matter.
+    $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
+}
+
+Describe 'ObjectStore AccessPolicy `<-> Role association' {
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { $Array.Value = $script:fakeArray }
+    }
+
+    It 'Get-PfbObjectStoreAccessPolicyRole flattens nested policy/member into top-level PolicyName/MemberName' {
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest {
+            [pscustomobject]@{
+                policy = [pscustomobject]@{ name = 'full-access-policy' }
+                member = [pscustomobject]@{ name = 's3-admin-role' }
+            }
+        }
+        $result = Get-PfbObjectStoreAccessPolicyRole
+        $result.PolicyName | Should -Be 'full-access-policy'
+        $result.MemberName | Should -Be 's3-admin-role'
+    }
+
+    It 'Get output pipes into Remove-* producing a DELETE with flattened values' {
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -ParameterFilter { $Method -eq 'GET' } {
+            [pscustomobject]@{
+                policy = [pscustomobject]@{ name = 'full-access-policy' }
+                member = [pscustomobject]@{ name = 's3-admin-role' }
+            }
+        }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -ParameterFilter { $Method -ne 'GET' } { }
+        Get-PfbObjectStoreAccessPolicyRole | Remove-PfbObjectStoreAccessPolicyRole -Confirm:$false
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'DELETE' -and $Endpoint -eq 'object-store-access-policies/object-store-roles' -and
+            $QueryParams['policy_names'] -eq 'full-access-policy' -and $QueryParams['member_names'] -eq 's3-admin-role'
+        }
+    }
+
+    It 'Get output pipes into New-* producing a POST with flattened values' {
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -ParameterFilter { $Method -eq 'GET' } {
+            [pscustomobject]@{
+                policy = [pscustomobject]@{ name = 'full-access-policy' }
+                member = [pscustomobject]@{ name = 's3-admin-role' }
+            }
+        }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -ParameterFilter { $Method -ne 'GET' } { }
+        Get-PfbObjectStoreAccessPolicyRole | New-PfbObjectStoreAccessPolicyRole -Confirm:$false
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'POST' -and $Endpoint -eq 'object-store-access-policies/object-store-roles' -and
+            $QueryParams['policy_names'] -eq 'full-access-policy' -and $QueryParams['member_names'] -eq 's3-admin-role'
+        }
+    }
+
+    It 'piping 2 associations into Remove-* calls the API twice' {
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+        @(
+            [pscustomobject]@{ PolicyName = 'p1'; MemberName = 'r1' }
+            [pscustomobject]@{ PolicyName = 'p1'; MemberName = 'r2' }
+        ) | Remove-PfbObjectStoreAccessPolicyRole -Confirm:$false
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 2 -Exactly -ParameterFilter { $Method -eq 'DELETE' }
+    }
+
+    It 'explicit -PolicyName / -MemberName still works on both New and Remove' {
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+        New-PfbObjectStoreAccessPolicyRole -PolicyName 'p1' -MemberName 'r1' -Confirm:$false
+        Remove-PfbObjectStoreAccessPolicyRole -PolicyName 'p1' -MemberName 'r1' -Confirm:$false
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter { $Method -eq 'POST' }
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter { $Method -eq 'DELETE' }
+    }
+}
+
+Describe 'ObjectStore AccessPolicy `<-> User association' {
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { $Array.Value = $script:fakeArray }
+    }
+
+    It 'Get-PfbObjectStoreAccessPolicyUser flattens nested policy/member' {
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest {
+            [pscustomobject]@{
+                policy = [pscustomobject]@{ name = 'full-access-policy' }
+                member = [pscustomobject]@{ name = 'acct1/user1' }
+            }
+        }
+        $result = Get-PfbObjectStoreAccessPolicyUser
+        $result.PolicyName | Should -Be 'full-access-policy'
+        $result.MemberName | Should -Be 'acct1/user1'
+    }
+
+    It 'Get output pipes into Remove-* producing a DELETE with flattened values' {
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -ParameterFilter { $Method -eq 'GET' } {
+            [pscustomobject]@{
+                policy = [pscustomobject]@{ name = 'full-access-policy' }
+                member = [pscustomobject]@{ name = 'acct1/user1' }
+            }
+        }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -ParameterFilter { $Method -ne 'GET' } { }
+        Get-PfbObjectStoreAccessPolicyUser | Remove-PfbObjectStoreAccessPolicyUser -Confirm:$false
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'DELETE' -and $Endpoint -eq 'object-store-access-policies/object-store-users' -and
+            $QueryParams['policy_names'] -eq 'full-access-policy' -and $QueryParams['member_names'] -eq 'acct1/user1'
+        }
+    }
+
+    It 'Get output pipes into New-* producing a POST with flattened values' {
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -ParameterFilter { $Method -eq 'GET' } {
+            [pscustomobject]@{
+                policy = [pscustomobject]@{ name = 'full-access-policy' }
+                member = [pscustomobject]@{ name = 'acct1/user1' }
+            }
+        }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -ParameterFilter { $Method -ne 'GET' } { }
+        Get-PfbObjectStoreAccessPolicyUser | New-PfbObjectStoreAccessPolicyUser -Confirm:$false
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'POST' -and $Endpoint -eq 'object-store-access-policies/object-store-users' -and
+            $QueryParams['policy_names'] -eq 'full-access-policy' -and $QueryParams['member_names'] -eq 'acct1/user1'
+        }
+    }
+
+    It 'piping 2 associations into Remove-* calls the API twice' {
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+        @(
+            [pscustomobject]@{ PolicyName = 'p1'; MemberName = 'acct1/u1' }
+            [pscustomobject]@{ PolicyName = 'p1'; MemberName = 'acct1/u2' }
+        ) | Remove-PfbObjectStoreAccessPolicyUser -Confirm:$false
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 2 -Exactly -ParameterFilter { $Method -eq 'DELETE' }
+    }
+
+    It 'explicit -PolicyName / -MemberName still works on both New and Remove' {
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+        New-PfbObjectStoreAccessPolicyUser -PolicyName 'p1' -MemberName 'acct1/u1' -Confirm:$false
+        Remove-PfbObjectStoreAccessPolicyUser -PolicyName 'p1' -MemberName 'acct1/u1' -Confirm:$false
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter { $Method -eq 'POST' }
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter { $Method -eq 'DELETE' }
+    }
+}
+
+Describe 'ObjectStore User `<-> AccessPolicy association (reverse order)' {
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { $Array.Value = $script:fakeArray }
+    }
+
+    It 'Get-PfbObjectStoreUserAccessPolicy flattens nested member/policy' {
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest {
+            [pscustomobject]@{
+                member = [pscustomobject]@{ name = 'acct1/user1' }
+                policy = [pscustomobject]@{ name = 'full-access-policy' }
+            }
+        }
+        $result = Get-PfbObjectStoreUserAccessPolicy
+        $result.MemberName | Should -Be 'acct1/user1'
+        $result.PolicyName | Should -Be 'full-access-policy'
+    }
+
+    It 'Get output pipes into Remove-* (reverse param order) producing a DELETE with flattened values' {
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -ParameterFilter { $Method -eq 'GET' } {
+            [pscustomobject]@{
+                member = [pscustomobject]@{ name = 'acct1/user1' }
+                policy = [pscustomobject]@{ name = 'full-access-policy' }
+            }
+        }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -ParameterFilter { $Method -ne 'GET' } { }
+        Get-PfbObjectStoreUserAccessPolicy | Remove-PfbObjectStoreUserAccessPolicy -Confirm:$false
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'DELETE' -and $Endpoint -eq 'object-store-users/object-store-access-policies' -and
+            $QueryParams['member_names'] -eq 'acct1/user1' -and $QueryParams['policy_names'] -eq 'full-access-policy'
+        }
+    }
+
+    It 'Get output pipes into New-* producing a POST with flattened values' {
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -ParameterFilter { $Method -eq 'GET' } {
+            [pscustomobject]@{
+                member = [pscustomobject]@{ name = 'acct1/user1' }
+                policy = [pscustomobject]@{ name = 'full-access-policy' }
+            }
+        }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -ParameterFilter { $Method -ne 'GET' } { }
+        Get-PfbObjectStoreUserAccessPolicy | New-PfbObjectStoreUserAccessPolicy -Confirm:$false
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'POST' -and $Endpoint -eq 'object-store-users/object-store-access-policies' -and
+            $QueryParams['member_names'] -eq 'acct1/user1' -and $QueryParams['policy_names'] -eq 'full-access-policy'
+        }
+    }
+
+    It 'piping 2 associations into Remove-* calls the API twice' {
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+        @(
+            [pscustomobject]@{ MemberName = 'acct1/u1'; PolicyName = 'p1' }
+            [pscustomobject]@{ MemberName = 'acct1/u2'; PolicyName = 'p1' }
+        ) | Remove-PfbObjectStoreUserAccessPolicy -Confirm:$false
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 2 -Exactly -ParameterFilter { $Method -eq 'DELETE' }
+    }
+
+    It 'explicit -MemberName / -PolicyName still works on both New and Remove' {
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+        New-PfbObjectStoreUserAccessPolicy -MemberName 'acct1/u1' -PolicyName 'p1' -Confirm:$false
+        Remove-PfbObjectStoreUserAccessPolicy -MemberName 'acct1/u1' -PolicyName 'p1' -Confirm:$false
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter { $Method -eq 'POST' }
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter { $Method -eq 'DELETE' }
+    }
+}

--- a/Tests/QuotaUser.Tests.ps1
+++ b/Tests/QuotaUser.Tests.ps1
@@ -1,0 +1,100 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    Import-Module "$PSScriptRoot/../PureStorageFlashBladePowerShell.psd1" -Force
+    # A throwaway connection object; Assert-PfbConnection is mocked so its contents don't matter.
+    $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
+}
+
+Describe 'Get-PfbQuotaUser flatten' {
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+    }
+
+    It 'flattens nested user/file_system into top-level UserName/FileSystemName' {
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest {
+            [pscustomobject]@{
+                name        = 'fs-home:jdoe'
+                user        = [pscustomobject]@{ name = 'jdoe' }
+                file_system = [pscustomobject]@{ name = 'fs-home' }
+                quota       = 1073741824
+            }
+        }
+        $result = Get-PfbQuotaUser -FileSystemName 'fs-home' -Array $fakeArray
+        $result.FileSystemName | Should -Be 'fs-home'
+        $result.UserName       | Should -Be 'jdoe'
+    }
+}
+
+Describe 'Remove-PfbQuotaUser' {
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+    }
+
+    It 'binds FileSystemName/UserName from a piped flattened quota (DELETE)' {
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -ParameterFilter { $Method -eq 'GET' } {
+            [pscustomobject]@{
+                name        = 'fs-home:jdoe'
+                user        = [pscustomobject]@{ name = 'jdoe' }
+                file_system = [pscustomobject]@{ name = 'fs-home' }
+            }
+        }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -ParameterFilter { $Method -ne 'GET' } { }
+        Get-PfbQuotaUser -FileSystemName 'fs-home' -Array $fakeArray | Remove-PfbQuotaUser -Confirm:$false -Array $fakeArray
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'DELETE' -and $Endpoint -eq 'quotas/users' -and
+            $QueryParams['names'] -eq 'jdoe' -and $QueryParams['file_system_names'] -eq 'fs-home'
+        }
+    }
+
+    It 'pipes 2 quota objects into 2 separate DELETE calls' {
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+        @(
+            [pscustomobject]@{ FileSystemName = 'fs-home'; UserName = 'jdoe' }
+            [pscustomobject]@{ FileSystemName = 'fs-home'; UserName = 'asmith' }
+        ) | Remove-PfbQuotaUser -Confirm:$false -Array $fakeArray
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 2 -Exactly -ParameterFilter { $Method -eq 'DELETE' }
+    }
+
+    It 'explicit -FileSystemName / -UserName still works' {
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+        Remove-PfbQuotaUser -FileSystemName 'fs-home' -UserName 'jdoe' -Confirm:$false -Array $fakeArray
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'DELETE' -and $QueryParams['names'] -eq 'jdoe' -and $QueryParams['file_system_names'] -eq 'fs-home'
+        }
+    }
+}
+
+Describe 'Update-PfbQuotaUser' {
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+    }
+
+    It 'binds FileSystemName/UserName from a piped flattened quota (PATCH with body)' {
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -ParameterFilter { $Method -eq 'GET' } {
+            [pscustomobject]@{
+                name        = 'fs-home:jdoe'
+                user        = [pscustomobject]@{ name = 'jdoe' }
+                file_system = [pscustomobject]@{ name = 'fs-home' }
+            }
+        }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -ParameterFilter { $Method -ne 'GET' } { }
+        Get-PfbQuotaUser -FileSystemName 'fs-home' -Array $fakeArray | Update-PfbQuotaUser -Quota 999 -Confirm:$false -Array $fakeArray
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'PATCH' -and $Endpoint -eq 'quotas/users' -and
+            $QueryParams['names'] -eq 'jdoe' -and $QueryParams['file_system_names'] -eq 'fs-home' -and
+            $Body['quota'] -eq 999
+        }
+    }
+
+    It 'explicit -FileSystemName / -UserName still works' {
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+        Update-PfbQuotaUser -FileSystemName 'fs-home' -UserName 'jdoe' -Quota 10737418240 -Confirm:$false -Array $fakeArray
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'PATCH' -and $QueryParams['names'] -eq 'jdoe' -and $QueryParams['file_system_names'] -eq 'fs-home'
+        }
+    }
+}

--- a/Tests/QuotaUser.Tests.ps1
+++ b/Tests/QuotaUser.Tests.ps1
@@ -45,7 +45,7 @@ Describe 'Remove-PfbQuotaUser' {
         Get-PfbQuotaUser -FileSystemName 'fs-home' -Array $fakeArray | Remove-PfbQuotaUser -Confirm:$false -Array $fakeArray
         Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
             $Method -eq 'DELETE' -and $Endpoint -eq 'quotas/users' -and
-            $QueryParams['names'] -eq 'jdoe' -and $QueryParams['file_system_names'] -eq 'fs-home'
+            $QueryParams['user_names'] -eq 'jdoe' -and $QueryParams['file_system_names'] -eq 'fs-home'
         }
     }
 
@@ -62,7 +62,7 @@ Describe 'Remove-PfbQuotaUser' {
         Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
         Remove-PfbQuotaUser -FileSystemName 'fs-home' -UserName 'jdoe' -Confirm:$false -Array $fakeArray
         Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
-            $Method -eq 'DELETE' -and $QueryParams['names'] -eq 'jdoe' -and $QueryParams['file_system_names'] -eq 'fs-home'
+            $Method -eq 'DELETE' -and $QueryParams['user_names'] -eq 'jdoe' -and $QueryParams['file_system_names'] -eq 'fs-home'
         }
     }
 }
@@ -85,7 +85,7 @@ Describe 'Update-PfbQuotaUser' {
         Get-PfbQuotaUser -FileSystemName 'fs-home' -Array $fakeArray | Update-PfbQuotaUser -Quota 999 -Confirm:$false -Array $fakeArray
         Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
             $Method -eq 'PATCH' -and $Endpoint -eq 'quotas/users' -and
-            $QueryParams['names'] -eq 'jdoe' -and $QueryParams['file_system_names'] -eq 'fs-home' -and
+            $QueryParams['user_names'] -eq 'jdoe' -and $QueryParams['file_system_names'] -eq 'fs-home' -and
             $Body['quota'] -eq 999
         }
     }
@@ -94,7 +94,7 @@ Describe 'Update-PfbQuotaUser' {
         Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
         Update-PfbQuotaUser -FileSystemName 'fs-home' -UserName 'jdoe' -Quota 10737418240 -Confirm:$false -Array $fakeArray
         Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
-            $Method -eq 'PATCH' -and $QueryParams['names'] -eq 'jdoe' -and $QueryParams['file_system_names'] -eq 'fs-home'
+            $Method -eq 'PATCH' -and $QueryParams['user_names'] -eq 'jdoe' -and $QueryParams['file_system_names'] -eq 'fs-home'
         }
     }
 }

--- a/Tests/QuotaUser.Tests.ps1
+++ b/Tests/QuotaUser.Tests.ps1
@@ -25,6 +25,20 @@ Describe 'Get-PfbQuotaUser flatten' {
         $result.FileSystemName | Should -Be 'fs-home'
         $result.UserName       | Should -Be 'jdoe'
     }
+
+    It 'sends only file_system_names when -Name is not supplied' {
+        Get-PfbQuotaUser -FileSystemName 'fs-home' -Array $fakeArray
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['file_system_names'] -eq 'fs-home' -and -not $QueryParams.ContainsKey('names')
+        }
+    }
+
+    It 'sends only names (omits file_system_names) when -Name is supplied alongside the mandatory -FileSystemName -- FlashBlade rejects combining names with file_system_names, confirmed live against our lab array' {
+        Get-PfbQuotaUser -FileSystemName 'fs-home' -Name 'fs-home/1235' -Array $fakeArray
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['names'] -eq 'fs-home/1235' -and -not $QueryParams.ContainsKey('file_system_names')
+        }
+    }
 }
 
 Describe 'Remove-PfbQuotaUser' {

--- a/Tests/Test-PfbActiveDirectory.Tests.ps1
+++ b/Tests/Test-PfbActiveDirectory.Tests.ps1
@@ -1,0 +1,46 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    Import-Module "$PSScriptRoot/../PureStorageFlashBladePowerShell.psd1" -Force
+    # A throwaway connection object; Assert-PfbConnection is mocked so its contents don't matter.
+    $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
+}
+
+Describe 'Test-PfbActiveDirectory' {
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+    }
+
+    It 'works with a single explicit -Name (one call)' {
+        Test-PfbActiveDirectory -Name 'ad1' -Array $fakeArray
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'GET' -and $Endpoint -eq 'active-directory/test' -and $QueryParams['names'] -eq 'ad1'
+        }
+    }
+
+    It 'joins multiple explicit -Name values into one call' {
+        Test-PfbActiveDirectory -Name 'ad1', 'ad2' -Array $fakeArray
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['names'] -eq 'ad1,ad2'
+        }
+    }
+
+    It 'accumulates ALL piped objects into ONE call (regression: not just the last)' {
+        @(
+            [pscustomobject]@{ Name = 'ad1' }
+            [pscustomobject]@{ Name = 'ad2' }
+        ) | Test-PfbActiveDirectory -Array $fakeArray
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['names'] -eq 'ad1,ad2'
+        }
+    }
+
+    It 'works with explicit -Id' {
+        Test-PfbActiveDirectory -Id 'abc12345-6789-0abc-def0-123456789abc' -Array $fakeArray
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['ids'] -eq 'abc12345-6789-0abc-def0-123456789abc'
+        }
+    }
+}

--- a/Tests/Test-PfbSaml2Idp.Tests.ps1
+++ b/Tests/Test-PfbSaml2Idp.Tests.ps1
@@ -1,0 +1,46 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    Import-Module "$PSScriptRoot/../PureStorageFlashBladePowerShell.psd1" -Force
+    # A throwaway connection object; Assert-PfbConnection is mocked so its contents don't matter.
+    $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
+}
+
+Describe 'Test-PfbSaml2Idp' {
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+    }
+
+    It 'works with a single explicit -Name (one call)' {
+        Test-PfbSaml2Idp -Name 'adfs-prod' -Array $fakeArray
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'GET' -and $Endpoint -eq 'sso/saml2/idps/test' -and $QueryParams['names'] -eq 'adfs-prod'
+        }
+    }
+
+    It 'joins multiple explicit -Name values into one call' {
+        Test-PfbSaml2Idp -Name 'idp1', 'idp2' -Array $fakeArray
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['names'] -eq 'idp1,idp2'
+        }
+    }
+
+    It 'accumulates ALL piped objects into ONE call (regression: not just the last)' {
+        @(
+            [pscustomobject]@{ Name = 'idp1' }
+            [pscustomobject]@{ Name = 'idp2' }
+        ) | Test-PfbSaml2Idp -Array $fakeArray
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['names'] -eq 'idp1,idp2'
+        }
+    }
+
+    It 'works with explicit -Id' {
+        Test-PfbSaml2Idp -Id 'abc12345-6789-0abc-def0-123456789abc' -Array $fakeArray
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['ids'] -eq 'abc12345-6789-0abc-def0-123456789abc'
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a systematic class of bug across relationship/membership cmdlets: `Get-Pfb* | New-/Remove-/Update-Pfb*` pipeline workflows that a user would naturally try but that either threw a missing-mandatory-parameter error, silently no-op'd, silently bound to the wrong parameter, or (most subtly) silently dropped all but the last piped item due to a PowerShell semantics gotcha (a flat function body with no `process{}` block only executes once, after all pipeline items are already bound).

**Fixed (4 families + 1 follow-on):**
- `New-PfbFileSystemSnapshot` — pipeline binding + multi-item handling
- `New-`/`Remove-PfbFileSystemSnapshotPolicy` — pipeline binding + identity validation (was previously a silent no-op if you forgot `-MemberName`)
- `Get-`/`New-`/`Remove-PfbObjectStoreAccessPolicyRole`, `...AccessPolicyUser`, `...UserAccessPolicy` (9 files) — `Get-*` now flattens nested `.policy.name`/`.member.name` onto top-level properties so `New-*`/`Remove-*` can bind them from the pipeline
- `Get-`/`Update-`/`Remove-PfbQuotaUser` — same flatten-and-bind treatment for the compound quota identity
- `Test-PfbSaml2Idp`/`Test-PfbActiveDirectory` — same structural fix (missing `process{}` block) found in a follow-up audit of the rest of the module

**Also fixed — 3 real bugs live testing caught that no mocked test could have (mandatory live-testing-before-PR policy for this project):**
- `New-PfbFileSystemSnapshot`'s original fix batched multiple source names into one API call; a real FlashBlade array's `POST /file-system-snapshots` rejects more than one source per call. Reworked to one call per source (confirmed the *only* mutating cmdlet in the ~520-cmdlet module using a batch pattern, so nothing else was at risk).
- `Remove-`/`Update-PfbQuotaUser` sent the wrong query key (`names` instead of `user_names`) — pre-existing since v2.0.0, meant these cmdlets could never complete a real API call.
- `Get-PfbQuotaUser` had the same root issue: `-FileSystemName` is unconditionally mandatory, so any `-Name` usage always triggered the same rejected key combination. Fixed to omit `file_system_names` when `-Name` is supplied.

**Deliberately not included:**
- `Get-PfbFileSystemSnapshot`'s `-SourceName` vs `-Name` parameter collision — needs a type-stamping mechanism this branch intentionally doesn't introduce; tracked separately.
- Two more pre-existing, unrelated bugs surfaced during live testing (`New-PfbFileSystemSnapshotPolicy` calls a POST endpoint the REST API doesn't have; `New-PfbQuotaUser` has a wrong body shape) — out of scope for a backward-compatible pipeline-binding bugfix release, documented for follow-up.
- `ModuleVersion` bump — deferred to batch with other pending release work, consistent with the prior OAuth2 branch.

## Test plan

- 55/55 tests passing (2 pre-existing + 53 new/updated across 6 test files), zero regressions.
- Full live verification against our lab FlashBlade array: multi-item snapshot creation, ObjectStore association round-trips (attach → verify → detach → verify → restore), QuotaUser round-trips, and the Test-* multi-item smoke test — all confirmed against a real array, not just mocks.
- Whole-branch review (Opus): Ready to merge, no Critical/Important findings — verified `ValueFromPipelineByPropertyName` is never added to an `-*Id` parameter, every flat-body cmdlet gaining pipeline binding was correctly restructured, the reversed-parameter-order `UserAccessPolicy` variant wasn't cross-contaminated with its siblings, and PS 5.1/7 compatibility holds throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
