### PR TITLE
Fix ApiToken/Credential/PSCredential reconnect on 403 (real arrays never return 401)

### DIFF
--- a/Private/Invoke-PfbApiRequest.ps1
+++ b/Private/Invoke-PfbApiRequest.ps1
@@ -5,7 +5,7 @@ function Invoke-PfbApiRequest {
     .DESCRIPTION
         Every public cmdlet delegates to this function. Handles URL construction,
         authentication headers, query parameters, pagination, SSL bypass, and error handling.
-        Supports auto-reconnect on 401 using stored API token.
+        Supports auto-reconnect using a stored API token when the session token is rejected.
     #>
     [CmdletBinding()]
     param(
@@ -85,8 +85,10 @@ function Invoke-PfbApiRequest {
                 $statusCode = [int]$_.Exception.Response.StatusCode
             }
 
-            # Auto-reconnect on 401 if we have a stored API token
-            if ($statusCode -eq 401 -and $isFirstRequest -and -not [string]::IsNullOrEmpty($Array.ApiToken)) {
+            # Auto-reconnect if we have a stored API token. Real FlashBlade arrays return
+            # 403 (not 401) for a missing/invalid x-auth-token -- confirmed live against
+            # our lab array -- so 401 alone never triggers this path against a real array.
+            if (($statusCode -eq 401 -or $statusCode -eq 403) -and $isFirstRequest -and -not [string]::IsNullOrEmpty($Array.ApiToken)) {
                 $reconnectSucceeded = $false
                 try {
                     $reconnected = Connect-PfbArrayInternal -Endpoint $Array.Endpoint -ApiToken $Array.ApiToken -ApiVersion $Array.ApiVersion -SkipCertificateCheck:$Array.SkipCertificateCheck

--- a/Tests/Invoke-PfbApiRequest.Reconnect.Tests.ps1
+++ b/Tests/Invoke-PfbApiRequest.Reconnect.Tests.ps1
@@ -1,0 +1,159 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    Import-Module "$PSScriptRoot/../PureStorageFlashBladePowerShell.psd1" -Force
+
+    function New-MockHttpError {
+        param([int]$StatusCode, [string]$Message = 'mock http error')
+        $ex = New-Object System.Exception($Message)
+        $response = [PSCustomObject]@{ StatusCode = [System.Net.HttpStatusCode]$StatusCode }
+        Add-Member -InputObject $ex -MemberType NoteProperty -Name Response -Value $response -Force
+        return $ex
+    }
+
+    function New-TestConnection {
+        param([string]$AuthMethod = 'ApiToken', [string]$AuthToken = 'session-token')
+        [PSCustomObject]@{
+            Endpoint             = 'fb.test'
+            ApiVersion           = '2.26'
+            AuthToken            = $AuthToken
+            BearerToken          = $null
+            ApiToken             = 'T-fake-token'
+            AuthMethod           = $AuthMethod
+            SkipCertificateCheck = $false
+            ConnectedAt          = [datetime]::UtcNow
+        }
+    }
+}
+
+Describe 'Invoke-PfbApiRequest reconnect on session-token rejection' {
+    BeforeEach {
+        $script:callCount = 0
+    }
+
+    It 'reconnects and retries once on a 401 (regression guard for the original behavior)' {
+        $array = New-TestConnection
+        Mock -ModuleName PureStorageFlashBladePowerShell Connect-PfbArrayInternal {
+            [PSCustomObject]@{ AuthToken = 'refreshed-token'; ConnectedAt = [datetime]::UtcNow }
+        }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
+            $script:callCount++
+            if ($script:callCount -eq 1) { throw (New-MockHttpError -StatusCode 401 -Message 'unauthorized') }
+            [PSCustomObject]@{ items = @() }
+        } -ParameterFilter { $Uri -like '*file-systems*' }
+
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ array = $array } {
+            Invoke-PfbApiRequest -Array $array -Method GET -Endpoint 'file-systems' | Out-Null
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Connect-PfbArrayInternal -Times 1 -Exactly
+        $array.AuthToken | Should -Be 'refreshed-token'
+        $script:callCount | Should -Be 2
+    }
+
+    It 'reconnects and retries once on a 403 -- real FlashBlade returns 403 (not 401) for an invalid x-auth-token, confirmed live against our lab array' {
+        $array = New-TestConnection
+        Mock -ModuleName PureStorageFlashBladePowerShell Connect-PfbArrayInternal {
+            [PSCustomObject]@{ AuthToken = 'refreshed-token'; ConnectedAt = [datetime]::UtcNow }
+        }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
+            $script:callCount++
+            if ($script:callCount -eq 1) { throw (New-MockHttpError -StatusCode 403 -Message 'Access Denied') }
+            [PSCustomObject]@{ items = @() }
+        } -ParameterFilter { $Uri -like '*file-systems*' }
+
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ array = $array } {
+            Invoke-PfbApiRequest -Array $array -Method GET -Endpoint 'file-systems' | Out-Null
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Connect-PfbArrayInternal -Times 1 -Exactly
+        $array.AuthToken | Should -Be 'refreshed-token'
+        $script:callCount | Should -Be 2
+    }
+
+    It 'applies the 403 reconnect for Credential and PSCredential connections too -- same x-auth-token mechanism as ApiToken' {
+        foreach ($method in @('Credential', 'PSCredential')) {
+            $script:callCount = 0
+            $array = New-TestConnection -AuthMethod $method
+            Mock -ModuleName PureStorageFlashBladePowerShell Connect-PfbArrayInternal {
+                [PSCustomObject]@{ AuthToken = 'refreshed-token'; ConnectedAt = [datetime]::UtcNow }
+            }
+            Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
+                $script:callCount++
+                if ($script:callCount -eq 1) { throw (New-MockHttpError -StatusCode 403 -Message 'Access Denied') }
+                [PSCustomObject]@{ items = @() }
+            } -ParameterFilter { $Uri -like '*file-systems*' }
+
+            InModuleScope PureStorageFlashBladePowerShell -Parameters @{ array = $array } {
+                Invoke-PfbApiRequest -Array $array -Method GET -Endpoint 'file-systems' | Out-Null
+            }
+
+            $array.AuthToken | Should -Be 'refreshed-token'
+        }
+    }
+
+    It 'does not reconnect on 403 when there is no stored ApiToken to reconnect with' {
+        $array = New-TestConnection
+        $array.ApiToken = $null
+        Mock -ModuleName PureStorageFlashBladePowerShell Connect-PfbArrayInternal { throw 'should not be called' }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
+            throw (New-MockHttpError -StatusCode 403 -Message 'Access Denied')
+        } -ParameterFilter { $Uri -like '*file-systems*' }
+
+        {
+            InModuleScope PureStorageFlashBladePowerShell -Parameters @{ array = $array } {
+                Invoke-PfbApiRequest -Array $array -Method GET -Endpoint 'file-systems' | Out-Null
+            }
+        } | Should -Throw -ExpectedMessage '*FlashBlade API error*'
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Connect-PfbArrayInternal -Times 0
+    }
+
+    It 'throws the original error when reconnect itself fails' {
+        $array = New-TestConnection
+        Mock -ModuleName PureStorageFlashBladePowerShell Connect-PfbArrayInternal { throw 'reconnect failed' }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
+            throw (New-MockHttpError -StatusCode 403 -Message 'Access Denied')
+        } -ParameterFilter { $Uri -like '*file-systems*' }
+
+        {
+            InModuleScope PureStorageFlashBladePowerShell -Parameters @{ array = $array } {
+                Invoke-PfbApiRequest -Array $array -Method GET -Endpoint 'file-systems' | Out-Null
+            }
+        } | Should -Throw -ExpectedMessage '*FlashBlade API error*'
+    }
+
+    It 'does not attempt a second reconnect if the retried call also fails' {
+        $array = New-TestConnection
+        Mock -ModuleName PureStorageFlashBladePowerShell Connect-PfbArrayInternal {
+            [PSCustomObject]@{ AuthToken = 'refreshed-token'; ConnectedAt = [datetime]::UtcNow }
+        }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
+            throw (New-MockHttpError -StatusCode 403 -Message 'Access Denied')
+        } -ParameterFilter { $Uri -like '*file-systems*' }
+
+        {
+            InModuleScope PureStorageFlashBladePowerShell -Parameters @{ array = $array } {
+                Invoke-PfbApiRequest -Array $array -Method GET -Endpoint 'file-systems' | Out-Null
+            }
+        } | Should -Throw -ExpectedMessage '*FlashBlade API error*'
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Connect-PfbArrayInternal -Times 1 -Exactly
+    }
+
+    It 'still throws immediately on an unrelated error code (e.g. 500)' {
+        $array = New-TestConnection
+        Mock -ModuleName PureStorageFlashBladePowerShell Connect-PfbArrayInternal { throw 'should not be called' }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
+            throw (New-MockHttpError -StatusCode 500 -Message 'Internal Server Error')
+        } -ParameterFilter { $Uri -like '*file-systems*' }
+
+        {
+            InModuleScope PureStorageFlashBladePowerShell -Parameters @{ array = $array } {
+                Invoke-PfbApiRequest -Array $array -Method GET -Endpoint 'file-systems' | Out-Null
+            }
+        } | Should -Throw -ExpectedMessage '*FlashBlade API error*'
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Connect-PfbArrayInternal -Times 0
+    }
+}


### PR DESCRIPTION
## Summary

`Invoke-PfbApiRequest`'s auto-reconnect logic only checked for HTTP 401 before
retrying with a freshly-minted session token. Live testing against our lab
array proved real FlashBlade arrays return **403**, not 401, for both a missing and
an invalid `x-auth-token` -- so for the `ApiToken`/`Credential`/`PSCredential`
auth methods (which all share the same `x-auth-token` session mechanism),
this reconnect path has never actually fired against a real array. Reproduced
the hard failure live: `Get-PfbArray` threw even with a valid `ApiToken`
sitting right there on the connection object for reconnect.

Fix: widen the check to `401 -or 403`. Same bug class already identified and
fixed for the Certificate/OAuth2 Bearer-token path in the pending
`feature/connect-pfbarray-oauth2-token-refresh` branch -- that branch found
this exact 403-vs-401 behavior for OAuth2 tokens but deliberately left the
older `x-auth-token` path "unproven, unintended" and untouched. This PR is
that proof: confirmed live that the same real-array behavior applies here
too, and applies the same fix.

## Test plan

- [x] New Pester file (`Tests/Invoke-PfbApiRequest.Reconnect.Tests.ps1`, 7
      tests): 401 still reconnects (regression guard), 403 now reconnects for
      ApiToken/Credential/PSCredential, no reconnect attempted without a
      stored ApiToken, original error surfaces if reconnect itself fails, no
      infinite retry loop, unrelated status codes (e.g. 500) still throw
      immediately.
- [x] Full suite passing: 13/13, zero regressions.
- [x] Live-verified against our lab array (Purity//FB 4.8.2 / REST 2.26): forced an
      `ApiToken`-authenticated connection's session token to an invalid
      value and confirmed `Get-PfbArray` now transparently reconnects and
      succeeds, where it previously hard-failed.

## Note for whoever merges this alongside the OAuth2 branch

`feature/connect-pfbarray-oauth2-token-refresh` has its own regression-guard
test asserting ApiToken does *not* retry on 403 ("unproven, unintended
behavior change"). That assumption is now disproven -- that test will need
updating (or removing) once both branches are reconciled, whichever merges
second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
