### PR TITLE
v2.1.1: cross-platform password fix + WinPS 5.1 test hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ docs/superpowers/
 # PowerShell
 *.pssproj.user
 
+# Not yet decided whether this should be tracked -- excluded for now
+tools/
+
 # OS
 Thumbs.db
 Desktop.ini

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to `PureStorageFlashBladePowerShell` are documented in this file.
 
+## [2.1.1] - 2026-07-15
+
+Cross-platform and Windows PowerShell 5.1 fixes.
+
+### Fixed
+
+- SecureString password truncation on Linux/macOS: `Marshal.PtrToStringAuto` reads a
+  BSTR with ANSI semantics on non-Windows platforms, truncating the password to its
+  first character. Switched to `Marshal.PtrToStringBSTR` (correct and UTF-16 on every
+  platform) in `New-PfbJwtToken` (encrypted-key JWT signing) and `Connect-PfbArray`
+  (native username/password `/api/login`). Windows was never affected.
+- Windows PowerShell 5.1 test crash: the encrypted-PKCS#8 test fixtures used
+  `RSA.ExportEncryptedPkcs8PrivateKeyPem` / `PbeParameters`, which don't exist on .NET
+  Framework 4.x. Those tests are now guarded on 5.1 (with a 5.1 regression test added);
+  production code already surfaces a clear "requires PowerShell 7+" error.
+
+### Changed
+
+- Documented that `-PrivateKeyPassword` (encrypted private keys) requires PowerShell 7+
+  (README and `New-PfbJwtToken` help).
+
 ## [2.1.0] - 2026-07-07
 
 <!-- Pending merge via PR #9 (integration/justin-prs) at the time this entry was written;

--- a/Private/New-PfbJwtToken.ps1
+++ b/Private/New-PfbJwtToken.ps1
@@ -101,7 +101,12 @@ function New-PfbJwtToken {
             $bytesRead = 0
             $bstr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($PrivateKeyPassword)
             try {
-                $plainPw = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($bstr)
+                # PtrToStringAuto is ANSI on non-Windows platforms, which truncates a UTF-16
+                # BSTR at its first null byte (i.e. after the first character) -- silently
+                # mangling the password and causing decryption to fail on Linux/macOS with a
+                # misleading "password may be incorrect" error. PtrToStringBSTR reads the BSTR
+                # by its length prefix and is correct (and UTF-16) on every platform.
+                $plainPw = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($bstr)
                 $rsa.ImportEncryptedPkcs8PrivateKey([System.Text.Encoding]::UTF8.GetBytes($plainPw), $keyBytes, [ref]$bytesRead)
             }
             finally {

--- a/Private/New-PfbJwtToken.ps1
+++ b/Private/New-PfbJwtToken.ps1
@@ -5,7 +5,15 @@ function New-PfbJwtToken {
     .DESCRIPTION
         Internal helper that creates a JWT signed with an RSA private key.
         Used by Connect-PfbArray for the certificate-based authentication flow.
-        Compatible with PowerShell 5.1 (uses .NET crypto classes directly).
+        Unencrypted PKCS#1/PKCS#8 private keys are compatible with Windows PowerShell 5.1
+        (uses .NET crypto classes directly, via CNG). Encrypted private keys supplied with
+        -PrivateKeyPassword require PowerShell 7+ -- see .NOTES.
+    .NOTES
+        -PrivateKeyPassword (encrypted PKCS#8 private keys) requires PowerShell 7+.
+        RSA.ImportEncryptedPkcs8PrivateKey is a .NET Core 3.0+/.NET 5+ API with no equivalent
+        on .NET Framework 4.x, which Windows PowerShell 5.1 runs on. Under Windows PowerShell
+        5.1, supplying -PrivateKeyPassword throws "Encrypted private keys require PowerShell 7+."
+        Use an unencrypted private key, or run under PowerShell 7+, in that case.
     #>
     [CmdletBinding()]
     param(

--- a/Public/Connection/Connect-PfbArray.ps1
+++ b/Public/Connection/Connect-PfbArray.ps1
@@ -262,7 +262,12 @@ function Connect-PfbArray {
             # /api/login is unversioned and is part of REST 2.x. No SSH required.
             $bstr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($Password)
             try {
-                $plainPassword = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($bstr)
+                # PtrToStringAuto is ANSI on non-Windows platforms, which truncates a UTF-16
+                # BSTR at its first null byte (i.e. after the first character) -- silently
+                # sending a mangled password to /api/login on Linux/macOS. PtrToStringBSTR
+                # reads the BSTR by its length prefix and is correct (and UTF-16) on every
+                # platform.
+                $plainPassword = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($bstr)
                 $loginBody = @{ username = $Username; password = $plainPassword } | ConvertTo-Json -Compress
             }
             finally {

--- a/PureStorageFlashBladePowerShell.psd1
+++ b/PureStorageFlashBladePowerShell.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule        = 'PureStorageFlashBladePowerShell.psm1'
-    ModuleVersion     = '2.1.0'
+    ModuleVersion     = '2.1.1'
     GUID              = 'b25473b3-9eb7-414d-8da1-264e10f73d86'
     Author            = 'Pure Storage, Inc.'
     CompanyName       = 'Pure Storage, Inc.'
@@ -549,11 +549,14 @@
             Tags         = @('PureStorage', 'FlashBlade', 'Storage', 'REST', 'API', 'S3', 'NFS', 'SMB', 'FlashBlade2')
             ProjectUri   = 'https://github.com/PureStorage-OpenConnect/flashblade-powershell'
             LicenseUri   = 'https://github.com/PureStorage-OpenConnect/flashblade-powershell/blob/main/LICENSE'
-            # This branch is based on PR #9 (integration/justin-prs) in anticipation of its
-            # merge, so ModuleVersion/FunctionsToExport/ReleaseNotes already reflect that
-            # state. Full v2.1.0 and v2.0.5 detail lives in CHANGELOG.md; if PR #9 changes
-            # further before it actually merges, re-check this block against the real result.
+            # ReleaseNotes carries only the latest-version highlight; full history is in CHANGELOG.md.
             ReleaseNotes = @'
+v2.1.1 - Cross-platform + Windows PowerShell 5.1 fixes.
+  Fixes a SecureString password truncation on Linux/macOS (affected encrypted-key JWT
+  signing and native username/password login, which silently used only the first
+  character of the password). Guards the encrypted-PKCS#8 test fixtures on Windows
+  PowerShell 5.1 and documents that -PrivateKeyPassword requires PowerShell 7+.
+
 v2.1.0 - Auth resilience + cmdlet correctness (integrates PRs #4-8).
   Connect-PfbArray gains a Posh-SSH login fallback for arrays below REST API 2.26,
   automatic OAuth2 token refresh for the Certificate flow, and forces TLS 1.2 on

--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ $array = Connect-PfbArray -Endpoint 10.0.0.1 -Username "pureuser" `
     -PrivateKeyFile "C:\keys\fb-private.pem" -IgnoreCertificateError
 ```
 
+> **Note:** `-PrivateKeyPassword` (encrypted private keys) requires **PowerShell 7+**. Windows
+> PowerShell 5.1 can only use unencrypted (plain) private key files with this flow; supplying
+> `-PrivateKeyPassword` under Windows PowerShell 5.1 throws a clear error rather than connecting.
+
 ### The `-IgnoreCertificateError` flag
 
 Most FlashBlade arrays use self-signed SSL certificates. Pass `-IgnoreCertificateError` to bypass certificate validation. This is standard for lab and on-prem environments.

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ v2.1.0 was validated on PowerShell 7 (the module runtime supports Windows PowerS
 
 | Test Area | Result |
 |---|---|
-| **Pester tests** | 144 passed, 0 failed, 1 skipped (22 suites, pwsh 7) |
+| **Pester tests** | 145 passed, 0 failed, 2 skipped (22 suites, pwsh 7); 143 passed, 0 failed, 4 skipped on Windows PowerShell 5.1 |
 | **Module loads and exports** | 526 cmdlets confirmed |
 | **Help coverage** | 526/526 cmdlets have a Synopsis |
 | **Naming conventions** | 526/526 follow `Verb-PfbNoun` pattern, all approved verbs |

--- a/Tests/Connect-PfbArray.NativeLoginVersionGate.Tests.ps1
+++ b/Tests/Connect-PfbArray.NativeLoginVersionGate.Tests.ps1
@@ -56,6 +56,26 @@ Describe 'Connect-PfbArray - native login version gate + Posh-SSH fallback' {
             $conn.AuthToken | Should -Be 'native-token'
             Should -Invoke -ModuleName PureStorageFlashBladePowerShell Get-PfbApiTokenViaSsh -Times 0
         }
+
+        It 'sends the full, untruncated password in the /api/login request body' {
+            # Regression test for the SecureString->BSTR marshaling bug: Marshal.PtrToStringAuto
+            # is ANSI on non-Windows platforms and silently truncates a UTF-16 BSTR at its first
+            # null byte -- i.e. after only the first character -- so a naive mock that ignores
+            # $Body (like the test above) can't catch it. Assert on the actual decoded password.
+            Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
+                [PSCustomObject]@{ versions = @('2.26') }
+            } -ParameterFilter { $Uri -like '*api_version*' }
+
+            Mock -ModuleName PureStorageFlashBladePowerShell Invoke-WebRequest {
+                [PSCustomObject]@{ Headers = @{ 'x-auth-token' = 'native-token' } }
+            } -ParameterFilter { $Uri -eq 'https://fb.test/api/login' }
+
+            Connect-PfbArray -Endpoint 'fb.test' -Username 'pureuser' -Password $script:testPassword | Out-Null
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-WebRequest -Times 1 -Exactly -ParameterFilter {
+                $Uri -eq 'https://fb.test/api/login' -and ($Body | ConvertFrom-Json).password -eq 'hunter2'
+            }
+        }
     }
 
     Context 'Array does not support native login (< 2.26)' {

--- a/Tests/Connect-PfbArray.OAuth2TokenRefresh.Tests.ps1
+++ b/Tests/Connect-PfbArray.OAuth2TokenRefresh.Tests.ps1
@@ -452,12 +452,15 @@ Describe 'Certificate/OAuth2 refresh - PrivateKeyPassword never logged' {
         $joined | Should -Not -Match ([regex]::Escape($plainPassword))
     }
 
-    It 'never surfaces the plaintext private key password when New-PfbJwtToken actually decrypts a real encrypted key' {
+    It 'never surfaces the plaintext private key password when New-PfbJwtToken actually decrypts a real encrypted key' -Skip:($PSVersionTable.PSVersion.Major -lt 6) {
         # Unlike the test above, Invoke-PfbOAuth2Login is NOT mocked here -- this exercises the
         # real Invoke-PfbOAuth2Login -> New-PfbJwtToken path, including the actual PKCS#8
         # encrypted-private-key decryption in New-PfbJwtToken.ps1 (the only place in the codebase
         # that marshals PrivateKeyPassword from a SecureString to plaintext). Only the network
         # calls (version negotiation and the OAuth2 token exchange) are mocked.
+        # RSA.ExportEncryptedPkcs8PrivateKeyPem/PbeParameters are .NET Core 3.0+/.NET 5+ only --
+        # skipped on Windows PowerShell 5.1, where New-PfbJwtToken.ps1 throws before decrypting
+        # (see Tests/New-PfbJwtToken.Tests.ps1's dedicated 5.1 regression test for that path).
         $plainPassword = 'super-secret-real-decrypt-password'
         $keyPassword = ConvertTo-SecureString $plainPassword -AsPlainText -Force
 

--- a/Tests/New-PfbJwtToken.Tests.ps1
+++ b/Tests/New-PfbJwtToken.Tests.ps1
@@ -9,20 +9,27 @@ BeforeAll {
 Describe 'New-PfbJwtToken' {
     Context 'BEGIN ENCRYPTED PRIVATE KEY (PrivateKeyPassword decryption)' {
         BeforeAll {
-            # Generate a real encrypted PKCS#8 key at runtime -- never committed to source control.
-            # Same technique used in Tests/Connect-PfbArray.OAuth2TokenRefresh.Tests.ps1.
-            $script:plainPassword = 'super-secret-jwt-test-password'
-            $script:rsa = [System.Security.Cryptography.RSA]::Create(2048)
-            $pbeParams = [System.Security.Cryptography.PbeParameters]::new(
-                [System.Security.Cryptography.PbeEncryptionAlgorithm]::Aes256Cbc,
-                [System.Security.Cryptography.HashAlgorithmName]::SHA256,
-                100000)
-            $keyPem = $script:rsa.ExportEncryptedPkcs8PrivateKeyPem($script:plainPassword, $pbeParams)
-            $script:keyPath = Join-Path $TestDrive 'encrypted-jwt-test-key.pem'
-            Set-Content -Path $script:keyPath -Value $keyPem -NoNewline
+            # RSA.ExportEncryptedPkcs8PrivateKeyPem/PbeParameters are .NET Core 3.0+/.NET 5+
+            # only -- they don't exist on .NET Framework 4.x (Windows PowerShell 5.1), so this
+            # fixture can only be generated there. The tests below that consume it are skipped
+            # on 5.1 (see -Skip: guards); a separate 5.1-only test further down covers the
+            # PowerShell 7+ requirement error instead.
+            if ($PSVersionTable.PSVersion.Major -ge 6) {
+                # Generate a real encrypted PKCS#8 key at runtime -- never committed to source control.
+                # Same technique used in Tests/Connect-PfbArray.OAuth2TokenRefresh.Tests.ps1.
+                $script:plainPassword = 'super-secret-jwt-test-password'
+                $script:rsa = [System.Security.Cryptography.RSA]::Create(2048)
+                $pbeParams = [System.Security.Cryptography.PbeParameters]::new(
+                    [System.Security.Cryptography.PbeEncryptionAlgorithm]::Aes256Cbc,
+                    [System.Security.Cryptography.HashAlgorithmName]::SHA256,
+                    100000)
+                $keyPem = $script:rsa.ExportEncryptedPkcs8PrivateKeyPem($script:plainPassword, $pbeParams)
+                $script:keyPath = Join-Path $TestDrive 'encrypted-jwt-test-key.pem'
+                Set-Content -Path $script:keyPath -Value $keyPem -NoNewline
+            }
         }
 
-        It 'mints a validly-signed JWT by decrypting the encrypted PKCS#8 private key' {
+        It 'mints a validly-signed JWT by decrypting the encrypted PKCS#8 private key' -Skip:($PSVersionTable.PSVersion.Major -lt 6) {
             # Regression coverage for the fix that wraps the SecureStringToBSTR/PtrToStringAuto/
             # ImportEncryptedPkcs8PrivateKey sequence in try/finally with ZeroFreeBSTR. Actually
             # inspecting whether the unmanaged BSTR was zeroed/freed isn't practically assertable
@@ -83,7 +90,7 @@ Describe 'New-PfbJwtToken' {
             $isValid | Should -BeTrue
         }
 
-        It 'throws when the encrypted key is provided without a PrivateKeyPassword' {
+        It 'throws when the encrypted key is provided without a PrivateKeyPassword' -Skip:($PSVersionTable.PSVersion.Major -lt 6) {
             $keyPathParam = $script:keyPath
 
             {
@@ -94,6 +101,66 @@ Describe 'New-PfbJwtToken' {
                         -Username 'pureuser' -PrivateKeyFile $keyPathParam
                 }
             } | Should -Throw -ExpectedMessage '*Provide -PrivateKeyPassword*'
+        }
+    }
+
+    Context 'BEGIN ENCRYPTED PRIVATE KEY on Windows PowerShell 5.1 (unsupported)' {
+        BeforeAll {
+            # Static, throwaway encrypted PKCS#8 key committed as a fixture -- generated once via
+            # RSA.ExportEncryptedPkcs8PrivateKeyPem on PowerShell 7 (password: 'winps51-static-test-password').
+            # Windows PowerShell 5.1 cannot generate this itself (see the BeforeAll above), so a static
+            # PEM is the only way to exercise the "BEGIN ENCRYPTED PRIVATE KEY" branch there. It is never
+            # decrypted on 5.1 -- New-PfbJwtToken.ps1's PS 5.1 branch throws before any decrypt is attempted,
+            # so the PEM only needs to be valid base64 with the right header, not a live secret.
+            $script:staticEncryptedKeyPem = @'
+-----BEGIN ENCRYPTED PRIVATE KEY-----
+MIIFNjBgBgkqhkiG9w0BBQ0wUzAyBgkqhkiG9w0BBQwwJQQQl6/6NCWUf3PyE3qA
+zpcgqQIDAYagMAwGCCqGSIb3DQIJBQAwHQYJYIZIAWUDBAEqBBBZxxr7x1OFInb/
+Rk/mwl0dBIIE0Jedoi5hKGU2kByyH9yP++9cw6BZc8YXcH0Mo2Rg7lAuUPd8flWl
+Ul7C1QWlhoqZVwvAgyUzn1Bf23Nd6kzi3MPPtGzEwq6NmpZMq9gxmcJv02HBK0vq
+7f0QXYKnx8Kd2GgVP3dKhOlLCITVk89ZR/O55c2eYIE1Trnh2d7Ec428Iiw/obF4
+yeobWLWgzpojaBupBgRgvTEARTkJk2PfKTZbt3NL7UMdCoaS4f2GTitLLbZpUDBU
+jysez+N82Bl2th543zyJdcT7zgeM1EwItXvo6ZBPdKWMYozj3ZgJd8kcikYRFoTe
+0gDNT/WRAjAV6rWticjOPxdnaLYp3CdVnsDeSooa+LwV9OyLCqVLM2JNMYcccSCn
+QVwGySnmSb5K/psRaCAgYnFgBiS5RZmKpDi14Ir2rgrG09GS1xHjd/nW+m+dFnoW
+0CQOuSX7CRlwzBsV9kt4WHkd54/63Rk8292ifa3ESPVbkvZvEa2GjSIrQ4ksKsTf
+8xzrKqgCG5hVVxYhTIWDP7WaJ38MK9XnUzlZJZP0AMZgUUEr/kqNt/cDJfaozyVI
+3jJEhE8Y7eokmZyNIm/zzMzRpiVB3J3ayk6sV/vGqautw8N3KaTi6fOE55tLkB9g
+NdtGiWCHtOOVN7t9/fG+WIGW2Hd8GAVr+Y61IA3mXFjt1wXI4rM2NUP2xvRfqEff
+94/43ijbRSD3n4xgRQDh7PaLXji8+jzA1BS5svwyWQQqNu+6avNeVtVQNQ1WU7vQ
+fzFpmmaqEJHwTh5o5c1dRVEnLQdU7uQf/k0NqMYGfBSoX3nnLjAN8LYWwpo1kTIN
+W75vDvRajDDzjGBh1DMFMnk0AvuqAVv6sL/Zf5PnHALH37DoBDAFsC87djXogGz4
+C/V+vW0qOT02r5FAetOpjVz4+Ej39eemdI+d03VHB2tzW4NAlsAsW0DsgVaWGfsd
+CCx9VXGSf/myDkbpsCZmZ9ze/01VR97xaIs3noUGBFF41urSq/5Z3rEYv1sAcdBL
+1B6yOH2LPel4jdd10KzG22TY2Pnv9yfGF4ei9bAsHZOEq1Y8dpwhIb4XDSqiuiyJ
+kea3j9y4Cyv+7BHvZUjY3jGYrs6Nxdbrt58lhey67qd3XOc1OooGnDIMQE420r3J
+a+zr0Axy5kJiRnYyHAUkpQmXb8uRuUTw/utQINQ4eUTqToroNTODA0KcWZ7vKr6h
+rUpwazMEDiIKTLX952nDLifIn0yE+lSw3WzW1nrdy/mlFY2ZreKiTOAVvmfnFnNe
+3RhuKA80slrWT4PAoXC1fkf/mhR3kXcIpKCTsq/M32eq9Ubp1LUHwL2+2F0fm5mu
+Y4mqypX6UHr61GhgsuxmiIVAmVWxIV8lYBNo5VEcCu2greCwuuEA8NVpsViQmgX+
+4cLB9VQ6zxEN5kLeJbSJYe2GaebKvFVOU/ArXwC2q+awHw19koVlscXsZkOiGtgJ
+ino3txqi9mxJ9HwreqLR3k7M8lLgYoH+1k+1bh/FXL5PV9yLqzpnPFh0Fmsp4vyb
+2uPxEtMVMeJ3yICYeVwLJ37lKTMHFxw07J3vBeiL3RFOQarqd16ygKOXLo4MHFnx
+/h1snXLa+AhvStCVR+BRHyzkqhMr7FPtMNlW3Q7HpbEEJ9K7pJXlOYdj
+-----END ENCRYPTED PRIVATE KEY-----
+'@
+            $script:staticEncryptedKeyPath = Join-Path $TestDrive 'winps51-static-encrypted-key.pem'
+            Set-Content -Path $script:staticEncryptedKeyPath -Value $script:staticEncryptedKeyPem -NoNewline
+        }
+
+        It 'throws a clear PowerShell 7+ error instead of a raw RuntimeException' -Skip:($PSVersionTable.PSVersion.Major -ge 6) {
+            $securePassword = ConvertTo-SecureString 'winps51-static-test-password' -AsPlainText -Force
+            $keyPathParam = $script:staticEncryptedKeyPath
+
+            {
+                InModuleScope PureStorageFlashBladePowerShell -Parameters @{
+                    keyPathParam   = $keyPathParam
+                    securePassword = $securePassword
+                } {
+                    New-PfbJwtToken -KeyId 'key-1' -ClientId 'client-1' -Issuer 'myapp' `
+                        -Username 'pureuser' -PrivateKeyFile $keyPathParam -PrivateKeyPassword $securePassword
+                }
+            } | Should -Throw -ExpectedMessage '*PowerShell 7+*'
         }
     }
 }


### PR DESCRIPTION
Integrates Justin Emerson's two fixes.

**Fixed**
- SecureString BSTR marshaling: `PtrToStringAuto` reads ANSI on Linux/macOS, truncating the password to its first character. Switched to `PtrToStringBSTR` in `New-PfbJwtToken` (encrypted-key JWT signing) and `Connect-PfbArray` (native `/api/login`). Windows unaffected.
- WinPS 5.1 test crash: encrypted-PKCS#8 fixtures use `PbeParameters` (absent on .NET Framework 4.x); now guarded/skipped on 5.1 with a 5.1 regression test. Production code already errors clearly ("requires PowerShell 7+").

**Changed**
- Documented `-PrivateKeyPassword` requires PowerShell 7+ (README + cmdlet help).

**Validated:** 526 exports; Pester green on both runtimes — pwsh 7 145/0/2, Windows PowerShell 5.1 143/0/4 (the previously-crashing encrypted-key tests now skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)