### PR TITLE
Fix New-PfbAlertWatcher -MinimumSeverity ValidateSet: drop invalid 'error'

### DIFF
--- a/Public/Alert/New-PfbAlertWatcher.ps1
+++ b/Public/Alert/New-PfbAlertWatcher.ps1
@@ -5,7 +5,7 @@ function New-PfbAlertWatcher {
     .PARAMETER Name
         The email address of the watcher.
     .PARAMETER MinimumSeverity
-        Minimum severity level for notifications ('warning', 'info', 'error', 'critical').
+        Minimum severity level for notifications ('info', 'warning', 'critical').
     .PARAMETER Attributes
         A hashtable of additional attributes.
     .PARAMETER Array
@@ -19,7 +19,7 @@ function New-PfbAlertWatcher {
         [string]$Name,
 
         [Parameter()]
-        [ValidateSet('info', 'warning', 'error', 'critical')]
+        [ValidateSet('info', 'warning', 'critical')]
         [string]$MinimumSeverity,
 
         [Parameter()] [hashtable]$Attributes,


### PR DESCRIPTION
## Summary
- `New-PfbAlertWatcher -MinimumSeverity` allowed `error` as a value, but the FlashBlade API only accepts `info`/`warning`/`critical` for `minimum_notification_severity`.
- Confirmed against the OpenAPI spec and live against a test array: the array rejects `error` with `Invalid minimum notification severity specified (choose from 'info', 'warning', 'critical')`.
- The sibling `Update-PfbAlertWatcher` cmdlet already had the correct 3-value set — this brings `New-PfbAlertWatcher` in line with it and with the real API.

## Test plan
- [x] Full Pester suite passes (145 passed / 0 failed / 2 skipped) with no regressions
- [x] Live-verified against a real FlashBlade array that `error` is rejected by the API

🤖 Generated with [Claude Code](https://claude.com/claude-code)