### PR TITLE
Add ValidateSet to Get-PfbArraySpace -Type

### DIFF
--- a/Public/Array/Get-PfbArraySpace.ps1
+++ b/Public/Array/Get-PfbArraySpace.ps1
@@ -7,7 +7,8 @@ function Get-PfbArraySpace {
     .PARAMETER Array
         The FlashBlade connection object. If not specified, uses the default connection.
     .PARAMETER Type
-        Filter by space type (e.g., 'array', 'file-system', 'object-store').
+        Filter by space type. Valid values: 'array', 'file-system', 'object-store'.
+        Defaults to 'array' if not specified.
     .EXAMPLE
         Get-PfbArraySpace
     #>
@@ -17,6 +18,7 @@ function Get-PfbArraySpace {
         [PSCustomObject]$Array,
 
         [Parameter()]
+        [ValidateSet('array', 'file-system', 'object-store')]
         [string]$Type
     )
 

--- a/Tests/Get-PfbArraySpace.Tests.ps1
+++ b/Tests/Get-PfbArraySpace.Tests.ps1
@@ -1,0 +1,39 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    Import-Module "$PSScriptRoot/../PureStorageFlashBladePowerShell.psd1" -Force
+    $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
+}
+
+Describe 'Get-PfbArraySpace' {
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+    }
+
+    It 'restricts -Type to the three real spec-documented values' {
+        $attr = (Get-Command Get-PfbArraySpace).Parameters['Type'].Attributes |
+            Where-Object { $_ -is [System.Management.Automation.ValidateSetAttribute] }
+        $attr | Should -Not -BeNullOrEmpty
+        $attr.ValidValues | Should -Be @('array', 'file-system', 'object-store')
+    }
+
+    It 'rejects an invalid -Type value before making any API call' {
+        { Get-PfbArraySpace -Type 'bogus' -Array $fakeArray } | Should -Throw
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 0 -Exactly
+    }
+
+    It 'passes a valid -Type through to the query string' {
+        Get-PfbArraySpace -Type 'file-system' -Array $fakeArray
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'GET' -and $Endpoint -eq 'arrays/space' -and $QueryParams['type'] -eq 'file-system'
+        }
+    }
+
+    It 'omits -Type from the query string when not specified (server defaults to array)' {
+        Get-PfbArraySpace -Array $fakeArray
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            -not $QueryParams.ContainsKey('type')
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- `Get-PfbArraySpace -Type` had no `ValidateSet`. Live-verified against a lab array: the
  `arrays/space` REST endpoint does **not** validate this query parameter server-side — an
  unrecognized value (e.g. a typo, or `all`, which is valid for a *different*, similarly-named
  endpoint parameter but not this one) silently returns an empty `space` object instead of an
  error.
- Adds `[ValidateSet('array', 'file-system', 'object-store')]` so an invalid value now fails
  fast with a clear PowerShell error, before any HTTP call is made, instead of silently
  returning a misleading empty result. Also tightens the `.PARAMETER Type` help text to state
  the exact valid values and default.
- These are confirmed the correct, complete, and stable values: cross-checked against every
  cached FlashBlade OpenAPI spec version (REST 2.0–2.27) — the parameter's description text is
  byte-identical in all 28 versions (inline on the operation through 2.16, refactored into a
  shared named parameter at 2.17 with no textual change).

## Test plan

- [x] New `Tests/Get-PfbArraySpace.Tests.ps1` (no prior coverage existed for this cmdlet):
      `ValidateSet` attribute values, invalid value rejected with zero API calls, valid value
      passed through to the query string, `-Type` omitted from the query string when not
      specified.
- [x] Full existing suite passes, no regressions (149 passed / 0 failed / 2 skipped).
- [x] Live-verified against a lab FlashBlade array: `-Type array/file-system/object-store`
      still return real, distinct data unchanged; `-Type all` and an invalid value now throw
      immediately client-side with no HTTP call (previously silent empty response).

🤖 Generated with [Claude Code](https://claude.com/claude-code)