### PR TITLE
Fix incomplete ValidateSet on Get-PfbArrayPerformance -Protocol

### DIFF
--- a/Public/Array/Get-PfbArrayPerformance.ps1
+++ b/Public/Array/Get-PfbArrayPerformance.ps1
@@ -7,7 +7,8 @@ function Get-PfbArrayPerformance {
     .PARAMETER Array
         The FlashBlade connection object. If not specified, uses the default connection.
     .PARAMETER Protocol
-        Filter by protocol type: 'nfs', 'smb', 'http', 's3'.
+        Filter by protocol type: 'all', 'nfs', 'smb', 'http', 's3'. Defaults to 'all' (combined
+        performance of all available protocols) when omitted.
     .PARAMETER Resolution
         Time resolution for historical data in milliseconds.
     .PARAMETER StartTime
@@ -25,7 +26,7 @@ function Get-PfbArrayPerformance {
         [PSCustomObject]$Array,
 
         [Parameter()]
-        [ValidateSet('nfs', 'smb', 'http', 's3')]
+        [ValidateSet('all', 'nfs', 'smb', 'http', 's3')]
         [string]$Protocol,
 
         [Parameter()]

--- a/Tests/Get-PfbArrayPerformance.Tests.ps1
+++ b/Tests/Get-PfbArrayPerformance.Tests.ps1
@@ -1,0 +1,48 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    Import-Module "$PSScriptRoot/../PureStorageFlashBladePowerShell.psd1" -Force
+    # A throwaway connection object; Assert-PfbConnection is mocked so its contents don't matter.
+    $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
+}
+
+Describe 'Get-PfbArrayPerformance' {
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+    }
+
+    It 'ValidateSet on -Protocol includes exactly all, nfs, smb, http, s3' {
+        $command = Get-Command Get-PfbArrayPerformance
+        $validateSetAttr = $command.Parameters['Protocol'].Attributes |
+            Where-Object { $_ -is [System.Management.Automation.ValidateSetAttribute] }
+        $validateSetAttr.ValidValues | Should -Not -BeNullOrEmpty
+        ($validateSetAttr.ValidValues | Sort-Object) | Should -Be (@('all', 'http', 'nfs', 's3', 'smb') | Sort-Object)
+    }
+
+    It 'accepts -Protocol all (regression: was rejected before the ValidateSet fix) and passes it through' {
+        { Get-PfbArrayPerformance -Protocol all -Array $fakeArray } | Should -Not -Throw
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            $Endpoint -eq 'arrays/performance' -and $QueryParams['protocol'] -eq 'all'
+        }
+    }
+
+    It 'still accepts pre-existing value -Protocol nfs unchanged' {
+        { Get-PfbArrayPerformance -Protocol nfs -Array $fakeArray } | Should -Not -Throw
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            $Endpoint -eq 'arrays/performance' -and $QueryParams['protocol'] -eq 'nfs'
+        }
+    }
+
+    It 'rejects an invalid -Protocol value with zero API calls' {
+        { Get-PfbArrayPerformance -Protocol bogus -Array $fakeArray } | Should -Throw
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 0 -Exactly
+    }
+
+    It 'makes a call with no protocol query param when -Protocol is omitted' {
+        Get-PfbArrayPerformance -Array $fakeArray
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            $Endpoint -eq 'arrays/performance' -and -not $QueryParams.ContainsKey('protocol')
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- `Get-PfbArrayPerformance -Protocol` had `[ValidateSet('nfs', 'smb', 'http', 's3')]` — missing
  `all`, which the FlashBlade REST API documents as a first-class, legal value for this
  parameter (and the documented default when `-Protocol` is omitted entirely).
- Before this fix, a user who explicitly wanted `-Protocol all` was rejected client-side by
  PowerShell's own parameter binder, even though `all` is completely valid server-side and
  produces the exact same result as omitting `-Protocol`.
- Confirmed stable: the `protocol` parameter's documented value set (`all`, `HTTP`, `SMB`,
  `NFS`, `S3`) is unchanged across every cached FlashBlade OpenAPI spec version (REST 2.0–2.27)
  — inline on the operation through the older versions, refactored into a shared named
  parameter later with byte-identical description text.
- No change to the omit-for-default behavior: `-Protocol` still isn't sent on the wire at all
  when omitted (relies on the server's own default), unchanged from before this fix.

## Test plan

- [x] New `Tests/Get-PfbArrayPerformance.Tests.ps1` (no prior coverage existed for this
      cmdlet): `ValidateSet` now includes exactly `all, nfs, smb, http, s3`; `-Protocol all` is
      now accepted and passed through correctly (the actual regression test for this bug);
      pre-existing values still work unchanged; an invalid value is still rejected with zero
      API calls; omitting `-Protocol` still sends no `protocol` query parameter.
- [x] Full existing suite passes, no regressions (150 passed / 0 failed / 2 skipped).
- [x] Live-verified against a lab FlashBlade array: `-Protocol all/nfs/smb/http/s3` all return
      data; an invalid value is still rejected client-side with zero API calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)