### PR TITLE
Add missing enum-documented query parameters (ValidateSet/ArgumentCompleter) across 7 cmdlets

### DIFF
--- a/Public/Array/Get-PfbArrayPerformanceReplication.ps1
+++ b/Public/Array/Get-PfbArrayPerformanceReplication.ps1
@@ -17,6 +17,9 @@ function Get-PfbArrayPerformanceReplication {
         End of the time range for historical data (epoch milliseconds or datetime string).
     .PARAMETER Resolution
         Time resolution for data points in milliseconds (e.g. 30000, 86400000).
+    .PARAMETER Type
+        Restricts results to replication performance for a specific object type. Valid values
+        are "all", "file-system", and "object-store".
     .PARAMETER Array
         The FlashBlade connection object. If not specified, the default connection is used.
     .EXAMPLE
@@ -37,6 +40,9 @@ function Get-PfbArrayPerformanceReplication {
         [Parameter()] [long]$StartTime,
         [Parameter()] [long]$EndTime,
         [Parameter()] [long]$Resolution,
+        [Parameter()]
+        [ValidateSet('all', 'file-system', 'object-store')]
+        [string]$Type,
         [Parameter()] [PSCustomObject]$Array
     )
 
@@ -52,6 +58,7 @@ function Get-PfbArrayPerformanceReplication {
         if ($StartTime)    { $queryParams['start_time'] = $StartTime }
         if ($EndTime)      { $queryParams['end_time']   = $EndTime }
         if ($Resolution)   { $queryParams['resolution'] = $Resolution }
+        if ($Type)         { $queryParams['type']       = $Type }
 
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'arrays/performance/replication' -QueryParams $queryParams -AutoPaginate
     }

--- a/Public/FileSystem/Get-PfbFileSystemSession.ps1
+++ b/Public/FileSystem/Get-PfbFileSystemSession.ps1
@@ -4,12 +4,12 @@ function Get-PfbFileSystemSession {
         Retrieves file system sessions from the FlashBlade.
     .DESCRIPTION
         Returns active client sessions connected to file systems on the FlashBlade.
-        Supports filtering by file system name, ID, or advanced filter expressions.
+        Supports filtering by session name, protocol, or advanced filter expressions.
         Auto-paginates by default.
     .PARAMETER Name
-        One or more file system names to retrieve sessions for. Accepts pipeline input.
-    .PARAMETER Id
-        One or more session IDs to retrieve.
+        One or more session names to filter by -- the session's own generated identifier
+        (e.g. as returned in a prior Get-PfbFileSystemSession call's Name property), NOT the
+        name of a file system. Accepts pipeline input.
     .PARAMETER Filter
         A server-side filter expression to narrow results.
     .PARAMETER Sort
@@ -27,8 +27,8 @@ function Get-PfbFileSystemSession {
         Get-PfbFileSystemSession
         Returns all file system sessions on the FlashBlade.
     .EXAMPLE
-        Get-PfbFileSystemSession -Name "fs01"
-        Returns all sessions connected to file system 'fs01'.
+        Get-PfbFileSystemSession -Name "22517998136858346-smb"
+        Returns the single session with that session name.
     .EXAMPLE
         Get-PfbFileSystemSession -Filter "protocol='NFS'" -Limit 50
         Returns up to 50 NFS sessions.
@@ -38,10 +38,6 @@ function Get-PfbFileSystemSession {
         [Parameter(ParameterSetName = 'ByName', ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [ValidateNotNullOrEmpty()]
         [string[]]$Name,
-
-        [Parameter(ParameterSetName = 'ById')]
-        [ValidateNotNullOrEmpty()]
-        [string[]]$Id,
 
         [Parameter()]
         [string]$Filter,
@@ -67,18 +63,15 @@ function Get-PfbFileSystemSession {
     begin {
         Assert-PfbConnection -Array ([ref]$Array)
         $allNames = [System.Collections.Generic.List[string]]::new()
-        $allIds = [System.Collections.Generic.List[string]]::new()
     }
 
     process {
         if ($Name) { foreach ($n in $Name) { $allNames.Add($n) } }
-        if ($Id)   { foreach ($i in $Id)   { $allIds.Add($i) } }
     }
 
     end {
         $queryParams = @{}
         if ($allNames.Count -gt 0) { $queryParams['names']      = $allNames -join ',' }
-        if ($allIds.Count -gt 0)   { $queryParams['ids']        = $allIds -join ',' }
         if ($Filter)               { $queryParams['filter']     = $Filter }
         if ($Sort)                 { $queryParams['sort']       = $Sort }
         if ($Limit -gt 0)         { $queryParams['limit']      = $Limit }

--- a/Public/FileSystem/Get-PfbFileSystemSession.ps1
+++ b/Public/FileSystem/Get-PfbFileSystemSession.ps1
@@ -18,6 +18,9 @@ function Get-PfbFileSystemSession {
         Maximum number of items to return.
     .PARAMETER TotalOnly
         Return only the total count, not the items.
+    .PARAMETER Protocol
+        Restricts results to sessions using one or more specific protocols. Valid values are
+        "nfs" and "smb".
     .PARAMETER Array
         The FlashBlade connection object. If not specified, uses the default connection.
     .EXAMPLE
@@ -54,6 +57,10 @@ function Get-PfbFileSystemSession {
         [switch]$TotalOnly,
 
         [Parameter()]
+        [ValidateSet('nfs', 'smb')]
+        [string[]]$Protocol,
+
+        [Parameter()]
         [PSCustomObject]$Array
     )
 
@@ -76,6 +83,7 @@ function Get-PfbFileSystemSession {
         if ($Sort)                 { $queryParams['sort']       = $Sort }
         if ($Limit -gt 0)         { $queryParams['limit']      = $Limit }
         if ($TotalOnly)            { $queryParams['total_only'] = 'true' }
+        if ($Protocol)             { $queryParams['protocols']  = $Protocol -join ',' }
 
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'file-systems/sessions' -QueryParams $queryParams -AutoPaginate
     }

--- a/Public/FileSystem/Remove-PfbFileSystemSession.ps1
+++ b/Public/FileSystem/Remove-PfbFileSystemSession.ps1
@@ -10,6 +10,10 @@ function Remove-PfbFileSystemSession {
         The name of the file system whose session should be terminated.
     .PARAMETER Id
         The ID of the session to terminate.
+    .PARAMETER Protocol
+        Narrows termination to sessions using one or more specific protocols, in addition to
+        the required -Name or -Id target. Valid values are "nfs" and "smb". Does not replace
+        -Name/-Id as the target selector.
     .PARAMETER Array
         The FlashBlade connection object. If not specified, uses the default connection.
     .EXAMPLE
@@ -31,6 +35,10 @@ function Remove-PfbFileSystemSession {
         [string]$Id,
 
         [Parameter()]
+        [ValidateSet('nfs', 'smb')]
+        [string[]]$Protocol,
+
+        [Parameter()]
         [PSCustomObject]$Array
     )
 
@@ -40,8 +48,9 @@ function Remove-PfbFileSystemSession {
 
     process {
         $queryParams = @{}
-        if ($Name) { $queryParams['names'] = $Name }
-        if ($Id)   { $queryParams['ids']   = $Id }
+        if ($Name)     { $queryParams['names']     = $Name }
+        if ($Id)       { $queryParams['ids']       = $Id }
+        if ($Protocol) { $queryParams['protocols'] = $Protocol -join ',' }
 
         $target = if ($Name) { $Name } else { $Id }
 

--- a/Public/FileSystem/Remove-PfbFileSystemSession.ps1
+++ b/Public/FileSystem/Remove-PfbFileSystemSession.ps1
@@ -1,29 +1,50 @@
 function Remove-PfbFileSystemSession {
     <#
     .SYNOPSIS
-        Terminates a file system session on the FlashBlade.
+        Terminates one or more file system sessions on the FlashBlade.
     .DESCRIPTION
-        Forces the termination of an active client session connected to a file system.
-        This is a disruptive operation that disconnects the client and may cause
-        in-progress operations to fail.
+        Forces the termination of active client session(s). This is a disruptive operation
+        that disconnects the client(s) and may cause in-progress operations to fail.
+
+        Two mutually exclusive modes are supported, matching the real REST endpoint's own
+        rules (live-confirmed: the server rejects combining `names` with any other query
+        parameter, including `protocols`):
+        - -Name: terminates one specific session, identified by the session's own generated
+          name (as returned in the Name property of Get-PfbFileSystemSession's output) --
+          NOT a file system name.
+        - -Protocol: bulk-terminates every active session using the given protocol(s),
+          across the entire array, regardless of file system or client. Cannot be combined
+          with -Name. The server requires an internal "disruptive" flag for this
+          single-filter bulk mode, which this cmdlet sets automatically -- there is no
+          narrower per-client/per-user filter exposed here, so any use of -Protocol affects
+          every matching session array-wide. Because of that blast radius, -Protocol also
+          requires -Force -- independent of $ConfirmPreference/-Confirm, so a caller who has
+          globally lowered their confirm preference still cannot trigger a bulk purge without
+          explicitly opting in.
     .PARAMETER Name
-        The name of the file system whose session should be terminated.
-    .PARAMETER Id
-        The ID of the session to terminate.
+        The session's own generated name to terminate (as returned by
+        Get-PfbFileSystemSession's Name property) -- NOT the name of a file system.
+        Mandatory in the ByName parameter set; cannot be combined with -Protocol.
     .PARAMETER Protocol
-        Narrows termination to sessions using one or more specific protocols, in addition to
-        the required -Name or -Id target. Valid values are "nfs" and "smb". Does not replace
-        -Name/-Id as the target selector.
+        Bulk-terminates every active session using one or more specific protocols, across
+        the entire array. Valid values are "nfs" and "smb". Cannot be combined with -Name --
+        the server rejects that combination. This is an array-wide, cross-client operation;
+        there is no narrower filter exposed by this cmdlet. Requires -Force.
+    .PARAMETER Force
+        Required alongside -Protocol to acknowledge the array-wide, cross-client blast radius
+        of that bulk-terminate mode. This check is independent of $ConfirmPreference/-Confirm
+        -- it cannot be bypassed by lowering the session's confirm preference, unlike the
+        standard SupportsShouldProcess prompt this cmdlet also honors.
     .PARAMETER Array
         The FlashBlade connection object. If not specified, uses the default connection.
     .EXAMPLE
-        Remove-PfbFileSystemSession -Name "fs01"
-        Terminates sessions on file system 'fs01'.
+        Remove-PfbFileSystemSession -Name "22517998136858346-smb"
+        Terminates the single session with that session name.
     .EXAMPLE
-        Remove-PfbFileSystemSession -Id "abc-123"
-        Terminates the session with the specified ID.
+        Remove-PfbFileSystemSession -Protocol 'smb' -Force -Confirm:$false
+        Bulk-terminates every active SMB session on the array.
     .EXAMPLE
-        Remove-PfbFileSystemSession -Name "fs01" -Confirm:$false
+        Remove-PfbFileSystemSession -Name "22517998136858346-smb" -Confirm:$false
         Terminates the session without prompting for confirmation.
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
@@ -31,12 +52,12 @@ function Remove-PfbFileSystemSession {
         [Parameter(ParameterSetName = 'ByName', Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [string]$Name,
 
-        [Parameter(ParameterSetName = 'ById', Mandatory)]
-        [string]$Id,
-
-        [Parameter()]
+        [Parameter(ParameterSetName = 'ByProtocol', Mandatory)]
         [ValidateSet('nfs', 'smb')]
         [string[]]$Protocol,
+
+        [Parameter()]
+        [switch]$Force,
 
         [Parameter()]
         [PSCustomObject]$Array
@@ -48,13 +69,23 @@ function Remove-PfbFileSystemSession {
 
     process {
         $queryParams = @{}
-        if ($Name)     { $queryParams['names']     = $Name }
-        if ($Id)       { $queryParams['ids']       = $Id }
-        if ($Protocol) { $queryParams['protocols'] = $Protocol -join ',' }
+        $action = 'Terminate file system session'
 
-        $target = if ($Name) { $Name } else { $Id }
+        if ($PSCmdlet.ParameterSetName -eq 'ByProtocol') {
+            if (-not $Force) {
+                throw "Remove-PfbFileSystemSession -Protocol bulk-terminates EVERY active session using that protocol, across the entire array, for every client -- pass -Force to acknowledge this before it will run (independent of `$ConfirmPreference/-Confirm)."
+            }
+            $queryParams['protocols'] = $Protocol -join ','
+            $queryParams['disruptive'] = 'true'
+            $target = $Protocol -join ', '
+            $action = 'Bulk-terminate ALL file system sessions using protocol(s)'
+        }
+        else {
+            $queryParams['names'] = $Name
+            $target = $Name
+        }
 
-        if ($PSCmdlet.ShouldProcess($target, 'Terminate file system session')) {
+        if ($PSCmdlet.ShouldProcess($target, $action)) {
             Invoke-PfbApiRequest -Array $Array -Method DELETE -Endpoint 'file-systems/sessions' -QueryParams $queryParams
         }
     }

--- a/Public/Network/Invoke-PfbNetworkTrace.ps1
+++ b/Public/Network/Invoke-PfbNetworkTrace.ps1
@@ -10,6 +10,8 @@ function Invoke-PfbNetworkTrace {
         The hostname or IP address to trace the route to. This parameter is mandatory.
     .PARAMETER SourceName
         The name of the network interface to use as the source of the trace.
+    .PARAMETER Method
+        The trace protocol to use. Valid values are "icmp", "tcp", and "udp".
     .PARAMETER Array
         The FlashBlade connection object. If not specified, the default connection is used.
     .EXAMPLE
@@ -29,12 +31,16 @@ function Invoke-PfbNetworkTrace {
     param(
         [Parameter(Mandatory, Position = 0)] [string]$Destination,
         [Parameter()] [string]$SourceName,
+        [Parameter()]
+        [ValidateSet('icmp', 'tcp', 'udp')]
+        [string]$Method,
         [Parameter()] [PSCustomObject]$Array
     )
     begin { Assert-PfbConnection -Array ([ref]$Array) }
     process {
         $queryParams = @{ 'destination' = $Destination }
         if ($SourceName) { $queryParams['source.name'] = $SourceName }
+        if ($Method)     { $queryParams['method']       = $Method }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'network-interfaces/trace' -QueryParams $queryParams
     }
 }

--- a/Public/Policy/Get-PfbPolicyAllMember.ps1
+++ b/Public/Policy/Get-PfbPolicyAllMember.ps1
@@ -13,6 +13,11 @@ function Get-PfbPolicyAllMember {
         One or more member names to filter by.
     .PARAMETER MemberId
         One or more member IDs to filter by.
+    .PARAMETER MemberType
+        One or more member types to filter by (e.g. "file-systems", "object-store-users").
+        Tab-completes the values documented as of this module's release, but the server's
+        accepted set has grown across REST versions and may include newer values not offered
+        here — any value is passed through as-is, not validated client-side.
     .PARAMETER Filter
         A server-side filter expression to narrow results.
     .PARAMETER Limit
@@ -38,6 +43,18 @@ function Get-PfbPolicyAllMember {
         [Parameter()] [string[]]$PolicyId,
         [Parameter()] [string[]]$MemberName,
         [Parameter()] [string[]]$MemberId,
+        [Parameter()]
+        [ArgumentCompleter({
+            param($CommandName, $ParameterName, $WordToComplete, $CommandAst, $FakeBoundParameters)
+            @(
+                'file-systems',
+                'file-system-snapshots',
+                'file-system-replica-links',
+                'object-store-users',
+                'object-store-accounts'
+            ) | Where-Object { $_ -like "$WordToComplete*" }
+        })]
+        [string[]]$MemberType,
         [Parameter()] [string]$Filter, [Parameter()] [int]$Limit,
         [Parameter()] [PSCustomObject]$Array
     )
@@ -49,6 +66,7 @@ function Get-PfbPolicyAllMember {
     if ($PolicyId) { $queryParams['policy_ids'] = $PolicyId -join ',' }
     if ($MemberName) { $queryParams['member_names'] = $MemberName -join ',' }
     if ($MemberId) { $queryParams['member_ids'] = $MemberId -join ',' }
+    if ($MemberType) { $queryParams['member_types'] = $MemberType -join ',' }
     if ($Filter) { $queryParams['filter'] = $Filter }
     if ($Limit -gt 0) { $queryParams['limit'] = $Limit }
 

--- a/Public/Replication/Get-PfbArrayConnectionPerformanceReplication.ps1
+++ b/Public/Replication/Get-PfbArrayConnectionPerformanceReplication.ps1
@@ -19,6 +19,9 @@ function Get-PfbArrayConnectionPerformanceReplication {
         End of the time range for historical data (epoch milliseconds).
     .PARAMETER Resolution
         Time resolution for data points in milliseconds (e.g., 30000, 86400000).
+    .PARAMETER Type
+        Restricts results to replication performance for a specific object type. Valid values
+        are "all", "file-system", and "object-store".
     .PARAMETER Array
         The FlashBlade connection object. If not specified, the default connection is used.
     .EXAMPLE
@@ -41,6 +44,9 @@ function Get-PfbArrayConnectionPerformanceReplication {
         [Parameter()] [long]$StartTime,
         [Parameter()] [long]$EndTime,
         [Parameter()] [long]$Resolution,
+        [Parameter()]
+        [ValidateSet('all', 'file-system', 'object-store')]
+        [string]$Type,
         [Parameter()] [PSCustomObject]$Array
     )
     begin {
@@ -61,6 +67,7 @@ function Get-PfbArrayConnectionPerformanceReplication {
         if ($StartTime) { $queryParams['start_time'] = $StartTime }
         if ($EndTime) { $queryParams['end_time'] = $EndTime }
         if ($Resolution) { $queryParams['resolution'] = $Resolution }
+        if ($Type) { $queryParams['type'] = $Type }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'array-connections/performance/replication' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Support/Test-PfbSupport.ps1
+++ b/Public/Support/Test-PfbSupport.ps1
@@ -6,12 +6,19 @@ function Test-PfbSupport {
         The Test-PfbSupport cmdlet tests the support connectivity of the connected Pure Storage
         FlashBlade. This returns test results indicating whether Phone Home and remote assist
         connections are functioning properly.
+    .PARAMETER TestType
+        Restricts which support connectivity test is run. Valid values are "all", "phonehome",
+        and "remote-assist".
     .PARAMETER Array
         The FlashBlade connection object. If not specified, the default connection is used.
     .EXAMPLE
         Test-PfbSupport
 
         Runs the support connectivity test on the connected FlashBlade.
+    .EXAMPLE
+        Test-PfbSupport -TestType 'phonehome'
+
+        Runs only the phone-home connectivity test.
     .EXAMPLE
         Test-PfbSupport -Array $FlashBlade
 
@@ -22,7 +29,16 @@ function Test-PfbSupport {
         Runs the support test and displays the test type from the results.
     #>
     [CmdletBinding()]
-    param([Parameter()] [PSCustomObject]$Array)
+    param(
+        [Parameter()]
+        [ValidateSet('all', 'phonehome', 'remote-assist')]
+        [string]$TestType,
+
+        [Parameter()]
+        [PSCustomObject]$Array
+    )
     Assert-PfbConnection -Array ([ref]$Array)
-    Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'support/test'
+    $queryParams = @{}
+    if ($TestType) { $queryParams['test_type'] = $TestType }
+    Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'support/test' -QueryParams $queryParams
 }

--- a/Tests/Get-PfbArrayConnectionPerformanceReplication.Tests.ps1
+++ b/Tests/Get-PfbArrayConnectionPerformanceReplication.Tests.ps1
@@ -1,0 +1,39 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    Import-Module "$PSScriptRoot/../PureStorageFlashBladePowerShell.psd1" -Force
+    $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
+}
+
+Describe 'Get-PfbArrayConnectionPerformanceReplication' {
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+    }
+
+    It 'restricts -Type to the three real spec-documented values' {
+        $attr = (Get-Command Get-PfbArrayConnectionPerformanceReplication).Parameters['Type'].Attributes |
+            Where-Object { $_ -is [System.Management.Automation.ValidateSetAttribute] }
+        $attr | Should -Not -BeNullOrEmpty
+        $attr.ValidValues | Should -Be @('all', 'file-system', 'object-store')
+    }
+
+    It 'rejects an invalid -Type value before making any API call' {
+        { Get-PfbArrayConnectionPerformanceReplication -Type 'bogus' -Array $fakeArray } | Should -Throw
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 0 -Exactly
+    }
+
+    It 'passes a valid -Type through to the query string' {
+        Get-PfbArrayConnectionPerformanceReplication -Type 'file-system' -Array $fakeArray
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'GET' -and $Endpoint -eq 'array-connections/performance/replication' -and $QueryParams['type'] -eq 'file-system'
+        }
+    }
+
+    It 'omits -Type from the query string when not specified' {
+        Get-PfbArrayConnectionPerformanceReplication -Array $fakeArray
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            -not $QueryParams.ContainsKey('type')
+        }
+    }
+}

--- a/Tests/Get-PfbArrayPerformanceReplication.Tests.ps1
+++ b/Tests/Get-PfbArrayPerformanceReplication.Tests.ps1
@@ -1,0 +1,39 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    Import-Module "$PSScriptRoot/../PureStorageFlashBladePowerShell.psd1" -Force
+    $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
+}
+
+Describe 'Get-PfbArrayPerformanceReplication' {
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+    }
+
+    It 'restricts -Type to the three real spec-documented values' {
+        $attr = (Get-Command Get-PfbArrayPerformanceReplication).Parameters['Type'].Attributes |
+            Where-Object { $_ -is [System.Management.Automation.ValidateSetAttribute] }
+        $attr | Should -Not -BeNullOrEmpty
+        $attr.ValidValues | Should -Be @('all', 'file-system', 'object-store')
+    }
+
+    It 'rejects an invalid -Type value before making any API call' {
+        { Get-PfbArrayPerformanceReplication -Type 'bogus' -Array $fakeArray } | Should -Throw
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 0 -Exactly
+    }
+
+    It 'passes a valid -Type through to the query string' {
+        Get-PfbArrayPerformanceReplication -Type 'file-system' -Array $fakeArray
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'GET' -and $Endpoint -eq 'arrays/performance/replication' -and $QueryParams['type'] -eq 'file-system'
+        }
+    }
+
+    It 'omits -Type from the query string when not specified' {
+        Get-PfbArrayPerformanceReplication -Array $fakeArray
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            -not $QueryParams.ContainsKey('type')
+        }
+    }
+}

--- a/Tests/Get-PfbFileSystemSession.Tests.ps1
+++ b/Tests/Get-PfbFileSystemSession.Tests.ps1
@@ -1,0 +1,39 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    Import-Module "$PSScriptRoot/../PureStorageFlashBladePowerShell.psd1" -Force
+    $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
+}
+
+Describe 'Get-PfbFileSystemSession' {
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+    }
+
+    It 'restricts -Protocol to the two real spec-documented values' {
+        $attr = (Get-Command Get-PfbFileSystemSession).Parameters['Protocol'].Attributes |
+            Where-Object { $_ -is [System.Management.Automation.ValidateSetAttribute] }
+        $attr | Should -Not -BeNullOrEmpty
+        $attr.ValidValues | Should -Be @('nfs', 'smb')
+    }
+
+    It 'rejects an invalid -Protocol value before making any API call' {
+        { Get-PfbFileSystemSession -Protocol 'bogus' -Array $fakeArray } | Should -Throw
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 0 -Exactly
+    }
+
+    It 'passes valid -Protocol values through to the query string, comma-joined' {
+        Get-PfbFileSystemSession -Protocol 'nfs', 'smb' -Array $fakeArray
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'GET' -and $Endpoint -eq 'file-systems/sessions' -and $QueryParams['protocols'] -eq 'nfs,smb'
+        }
+    }
+
+    It 'omits -Protocol from the query string when not specified' {
+        Get-PfbFileSystemSession -Array $fakeArray
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            -not $QueryParams.ContainsKey('protocols')
+        }
+    }
+}

--- a/Tests/Get-PfbFileSystemSession.Tests.ps1
+++ b/Tests/Get-PfbFileSystemSession.Tests.ps1
@@ -36,4 +36,15 @@ Describe 'Get-PfbFileSystemSession' {
             -not $QueryParams.ContainsKey('protocols')
         }
     }
+
+    It 'has no -Id parameter (the endpoint has no ids query parameter in any spec version)' {
+        (Get-Command Get-PfbFileSystemSession).Parameters.ContainsKey('Id') | Should -BeFalse
+    }
+
+    It 'passes -Name through to the query string as the session''s own name filter' {
+        Get-PfbFileSystemSession -Name '22517998136858346-smb' -Array $fakeArray
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['names'] -eq '22517998136858346-smb'
+        }
+    }
 }

--- a/Tests/Get-PfbPolicyAllMember.Tests.ps1
+++ b/Tests/Get-PfbPolicyAllMember.Tests.ps1
@@ -1,0 +1,50 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    Import-Module "$PSScriptRoot/../PureStorageFlashBladePowerShell.psd1" -Force
+    $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
+}
+
+Describe 'Get-PfbPolicyAllMember' {
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+    }
+
+    It '-MemberType offers tab-completion for all five known spec-documented values (not a hard ValidateSet, since the spec value set has grown over time)' {
+        $attr = (Get-Command Get-PfbPolicyAllMember).Parameters['MemberType'].Attributes |
+            Where-Object { $_ -is [System.Management.Automation.ArgumentCompleterAttribute] }
+        $attr | Should -Not -BeNullOrEmpty
+
+        $validateSetAttr = (Get-Command Get-PfbPolicyAllMember).Parameters['MemberType'].Attributes |
+            Where-Object { $_ -is [System.Management.Automation.ValidateSetAttribute] }
+        $validateSetAttr | Should -BeNullOrEmpty
+
+        $completions = & $attr.ScriptBlock 'Get-PfbPolicyAllMember' 'MemberType' '' $null @{}
+        ($completions | Sort-Object) | Should -Be (@(
+            'file-systems', 'file-system-snapshots', 'file-system-replica-links',
+            'object-store-users', 'object-store-accounts'
+        ) | Sort-Object)
+    }
+
+    It 'does NOT reject a value outside the known completion list (non-exhaustive, no hard validation)' {
+        { Get-PfbPolicyAllMember -MemberType 'some-future-member-type' -Array $fakeArray } | Should -Not -Throw
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['member_types'] -eq 'some-future-member-type'
+        }
+    }
+
+    It 'passes valid -MemberType values through to the query string, comma-joined' {
+        Get-PfbPolicyAllMember -MemberType 'file-systems', 'object-store-accounts' -Array $fakeArray
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'GET' -and $Endpoint -eq 'policies-all/members' -and $QueryParams['member_types'] -eq 'file-systems,object-store-accounts'
+        }
+    }
+
+    It 'omits -MemberType from the query string when not specified' {
+        Get-PfbPolicyAllMember -Array $fakeArray
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            -not $QueryParams.ContainsKey('member_types')
+        }
+    }
+}

--- a/Tests/Invoke-PfbNetworkTrace.Tests.ps1
+++ b/Tests/Invoke-PfbNetworkTrace.Tests.ps1
@@ -1,0 +1,39 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    Import-Module "$PSScriptRoot/../PureStorageFlashBladePowerShell.psd1" -Force
+    $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
+}
+
+Describe 'Invoke-PfbNetworkTrace' {
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+    }
+
+    It 'restricts -Method to the three real spec-documented values' {
+        $attr = (Get-Command Invoke-PfbNetworkTrace).Parameters['Method'].Attributes |
+            Where-Object { $_ -is [System.Management.Automation.ValidateSetAttribute] }
+        $attr | Should -Not -BeNullOrEmpty
+        $attr.ValidValues | Should -Be @('icmp', 'tcp', 'udp')
+    }
+
+    It 'rejects an invalid -Method value before making any API call' {
+        { Invoke-PfbNetworkTrace -Destination '10.0.0.1' -Method 'bogus' -Array $fakeArray } | Should -Throw
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 0 -Exactly
+    }
+
+    It 'passes a valid -Method through to the query string' {
+        Invoke-PfbNetworkTrace -Destination '10.0.0.1' -Method 'tcp' -Array $fakeArray
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'GET' -and $Endpoint -eq 'network-interfaces/trace' -and $QueryParams['method'] -eq 'tcp'
+        }
+    }
+
+    It 'omits -Method from the query string when not specified' {
+        Invoke-PfbNetworkTrace -Destination '10.0.0.1' -Array $fakeArray
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            -not $QueryParams.ContainsKey('method')
+        }
+    }
+}

--- a/Tests/Remove-PfbFileSystemSession.Tests.ps1
+++ b/Tests/Remove-PfbFileSystemSession.Tests.ps1
@@ -1,0 +1,58 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    Import-Module "$PSScriptRoot/../PureStorageFlashBladePowerShell.psd1" -Force
+    $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
+}
+
+Describe 'Remove-PfbFileSystemSession' {
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+    }
+
+    It 'restricts -Protocol to the two real spec-documented values' {
+        $attr = (Get-Command Remove-PfbFileSystemSession).Parameters['Protocol'].Attributes |
+            Where-Object { $_ -is [System.Management.Automation.ValidateSetAttribute] }
+        $attr | Should -Not -BeNullOrEmpty
+        $attr.ValidValues | Should -Be @('nfs', 'smb')
+    }
+
+    It 'rejects an invalid -Protocol value before making any API call' {
+        { Remove-PfbFileSystemSession -Name 'fs01' -Protocol 'bogus' -Confirm:$false -Array $fakeArray } | Should -Throw
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 0 -Exactly
+    }
+
+    It 'still requires -Name or -Id even with -Protocol supplied' {
+        { Remove-PfbFileSystemSession -Protocol 'nfs' -Confirm:$false -Array $fakeArray } | Should -Throw
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 0 -Exactly
+    }
+
+    It 'passes valid -Protocol values through to the query string, comma-joined, alongside -Name' {
+        Remove-PfbFileSystemSession -Name 'fs01' -Protocol 'nfs', 'smb' -Confirm:$false -Array $fakeArray
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'DELETE' -and $Endpoint -eq 'file-systems/sessions' -and
+            $QueryParams['names'] -eq 'fs01' -and $QueryParams['protocols'] -eq 'nfs,smb'
+        }
+    }
+
+    It 'passes valid -Protocol values through to the query string alongside -Id' {
+        Remove-PfbFileSystemSession -Id 'abc-123' -Protocol 'smb' -Confirm:$false -Array $fakeArray
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'DELETE' -and $Endpoint -eq 'file-systems/sessions' -and
+            $QueryParams['ids'] -eq 'abc-123' -and $QueryParams['protocols'] -eq 'smb'
+        }
+    }
+
+    It 'omits -Protocol from the query string when not specified' {
+        Remove-PfbFileSystemSession -Name 'fs01' -Confirm:$false -Array $fakeArray
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            -not $QueryParams.ContainsKey('protocols')
+        }
+    }
+
+    It 'honors -WhatIf (no call made)' {
+        Remove-PfbFileSystemSession -Name 'fs01' -Protocol 'nfs' -WhatIf -Array $fakeArray
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 0 -Exactly
+    }
+}

--- a/Tests/Remove-PfbFileSystemSession.Tests.ps1
+++ b/Tests/Remove-PfbFileSystemSession.Tests.ps1
@@ -11,6 +11,10 @@ Describe 'Remove-PfbFileSystemSession' {
         Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
     }
 
+    It 'has no -Id parameter (the endpoint has no ids query parameter in any spec version)' {
+        (Get-Command Remove-PfbFileSystemSession).Parameters.ContainsKey('Id') | Should -BeFalse
+    }
+
     It 'restricts -Protocol to the two real spec-documented values' {
         $attr = (Get-Command Remove-PfbFileSystemSession).Parameters['Protocol'].Attributes |
             Where-Object { $_ -is [System.Management.Automation.ValidateSetAttribute] }
@@ -19,40 +23,45 @@ Describe 'Remove-PfbFileSystemSession' {
     }
 
     It 'rejects an invalid -Protocol value before making any API call' {
-        { Remove-PfbFileSystemSession -Name 'fs01' -Protocol 'bogus' -Confirm:$false -Array $fakeArray } | Should -Throw
+        { Remove-PfbFileSystemSession -Protocol 'bogus' -Confirm:$false -Array $fakeArray } | Should -Throw
         Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 0 -Exactly
     }
 
-    It 'still requires -Name or -Id even with -Protocol supplied' {
-        { Remove-PfbFileSystemSession -Protocol 'nfs' -Confirm:$false -Array $fakeArray } | Should -Throw
+    It 'rejects combining -Name and -Protocol (true mutual exclusivity, matching the server)' {
+        { Remove-PfbFileSystemSession -Name 'some-session-name' -Protocol 'nfs' -Confirm:$false -Array $fakeArray } | Should -Throw
         Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 0 -Exactly
     }
 
-    It 'passes valid -Protocol values through to the query string, comma-joined, alongside -Name' {
-        Remove-PfbFileSystemSession -Name 'fs01' -Protocol 'nfs', 'smb' -Confirm:$false -Array $fakeArray
+    It 'terminates a single session by its own session name via -Name, sending only names' {
+        Remove-PfbFileSystemSession -Name '22517998136858346-smb' -Confirm:$false -Array $fakeArray
         Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
             $Method -eq 'DELETE' -and $Endpoint -eq 'file-systems/sessions' -and
-            $QueryParams['names'] -eq 'fs01' -and $QueryParams['protocols'] -eq 'nfs,smb'
+            $QueryParams['names'] -eq '22517998136858346-smb' -and
+            -not $QueryParams.ContainsKey('protocols') -and -not $QueryParams.ContainsKey('disruptive')
         }
     }
 
-    It 'passes valid -Protocol values through to the query string alongside -Id' {
-        Remove-PfbFileSystemSession -Id 'abc-123' -Protocol 'smb' -Confirm:$false -Array $fakeArray
+    It 'bulk-terminates by -Protocol, sending protocols comma-joined plus the required disruptive flag' {
+        Remove-PfbFileSystemSession -Protocol 'nfs', 'smb' -Force -Confirm:$false -Array $fakeArray
         Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
             $Method -eq 'DELETE' -and $Endpoint -eq 'file-systems/sessions' -and
-            $QueryParams['ids'] -eq 'abc-123' -and $QueryParams['protocols'] -eq 'smb'
+            $QueryParams['protocols'] -eq 'nfs,smb' -and $QueryParams['disruptive'] -eq 'true' -and
+            -not $QueryParams.ContainsKey('names')
         }
     }
 
-    It 'omits -Protocol from the query string when not specified' {
-        Remove-PfbFileSystemSession -Name 'fs01' -Confirm:$false -Array $fakeArray
-        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
-            -not $QueryParams.ContainsKey('protocols')
-        }
+    It 'requires -Force for the -Protocol bulk path, independent of $ConfirmPreference (rejects -Protocol without -Force even with -Confirm:$false)' {
+        { Remove-PfbFileSystemSession -Protocol 'smb' -Confirm:$false -Array $fakeArray } | Should -Throw
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 0 -Exactly
     }
 
-    It 'honors -WhatIf (no call made)' {
-        Remove-PfbFileSystemSession -Name 'fs01' -Protocol 'nfs' -WhatIf -Array $fakeArray
+    It 'honors -WhatIf for the -Name path (no call made)' {
+        Remove-PfbFileSystemSession -Name '22517998136858346-smb' -WhatIf -Array $fakeArray
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 0 -Exactly
+    }
+
+    It 'honors -WhatIf for the -Protocol bulk path (no call made)' {
+        Remove-PfbFileSystemSession -Protocol 'smb' -Force -WhatIf -Array $fakeArray
         Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 0 -Exactly
     }
 }

--- a/Tests/Test-PfbSupport.Tests.ps1
+++ b/Tests/Test-PfbSupport.Tests.ps1
@@ -1,0 +1,39 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    Import-Module "$PSScriptRoot/../PureStorageFlashBladePowerShell.psd1" -Force
+    $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
+}
+
+Describe 'Test-PfbSupport' {
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+    }
+
+    It 'restricts -TestType to the three real spec-documented values' {
+        $attr = (Get-Command Test-PfbSupport).Parameters['TestType'].Attributes |
+            Where-Object { $_ -is [System.Management.Automation.ValidateSetAttribute] }
+        $attr | Should -Not -BeNullOrEmpty
+        $attr.ValidValues | Should -Be @('all', 'phonehome', 'remote-assist')
+    }
+
+    It 'rejects an invalid -TestType value before making any API call' {
+        { Test-PfbSupport -TestType 'bogus' -Array $fakeArray } | Should -Throw
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 0 -Exactly
+    }
+
+    It 'passes a valid -TestType through to the query string' {
+        Test-PfbSupport -TestType 'phonehome' -Array $fakeArray
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'GET' -and $Endpoint -eq 'support/test' -and $QueryParams['test_type'] -eq 'phonehome'
+        }
+    }
+
+    It 'omits -TestType from the query string when not specified' {
+        Test-PfbSupport -Array $fakeArray
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            -not $QueryParams.ContainsKey('test_type')
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes 7 feature gaps surfaced by the inline-path-parameter coverage-gap fix (`fix/get-pfbarrayspace-type-validateset`, PR #15): spec-documented query-parameter enums that had no corresponding cmdlet parameter at all. Each new parameter is purely additive (defaults to "not sent"), verified byte-stable against all 28 cached OpenAPI spec versions (2.0-2.27) before choosing `ValidateSet` vs `ArgumentCompleter`.

**5 new `ValidateSet` parameters:**
- `Get-PfbArrayConnectionPerformanceReplication -Type` (`all`/`file-system`/`object-store`)
- `Get-PfbArrayPerformanceReplication -Type` (`all`/`file-system`/`object-store`)
- `Test-PfbSupport -TestType` (`all`/`phonehome`/`remote-assist`)
- `Invoke-PfbNetworkTrace -Method` (`icmp`/`tcp`/`udp`)
- `Get-PfbFileSystemSession -Protocol` (`nfs`/`smb`)

**1 new `ArgumentCompleter` (not `ValidateSet`):**
- `Get-PfbPolicyAllMember -MemberType` — re-verifying against the specs found this value set is *not* stable (grew 4→5 values at REST v2.17, adding `object-store-accounts`, with non-exhaustive "include"/"subsets" wording). Per this project's own rule (a value set that changed since introduction gets a completer, not a hard-validating `ValidateSet`), this got a tab-completing `ArgumentCompleter` instead. Live-verified: the server accepts `object-store-accounts` (which a naive 4-value `ValidateSet` would have permanently blocked) and rejects a genuinely bogus value with a clear server-side error.

## Get-/Remove-PfbFileSystemSession changes

Live-testing `Remove-PfbFileSystemSession -Protocol` against a real array surfaced two additional pre-existing bugs, fixed here:

- **`-Protocol` is now its own mutually-exclusive parameter set.** The server rejects combining `names` with any other query parameter (confirmed live: 400 "mutually exclusive"; confirmed in the spec's own DELETE description, stable since v2.10: "When `names` is specified, no other query parameter can be specified"). `-Protocol` is a genuine bulk-terminate-by-protocol mode (array-wide, all clients, no per-client filter exposed) and now requires an explicit `-Force` switch — checked independent of `$ConfirmPreference`/`-Confirm` — in addition to the existing `SupportsShouldProcess`/`ConfirmImpact=High` prompt.
- **Removed the non-functional `-Id` parameter from both cmdlets.** There is no `ids` query parameter on `file-systems/sessions` in any of the 28 cached spec versions (2.10-2.27) — session objects have no `id` field at all, only a self-contained `name` (e.g. `"22517998136858346-smb"`). `-Id` could never have worked.
- **Fixed `-Name`'s help text on both cmdlets** — it wrongly claimed to filter by "file system name"; live-verified it actually filters by the session's own generated name (as returned by `Get-PfbFileSystemSession`'s `Name` property).

## Test plan
- [x] New Pester test file per cmdlet (none had prior coverage), TDD throughout (each test watched RED before implementing)
- [x] Full suite: 189 passed / 0 failed / 2 pre-existing skips, no regressions
- [x] Live-verified all 6 read-only cmdlets against FB-A (lab simulator)
- [x] Live-verified the corrected `Remove-PfbFileSystemSession -Name` path against a real array  — terminated a real SMB session, 200 OK, confirmed gone
- [ ] `-Protocol` bulk-terminate path not live-tested (shared lab array with other real users' active sessions; no per-client filter to scope a safe live test) — covered by mocked tests only

🤖 Generated with [Claude Code](https://claude.com/claude-code)