### PR TITLE
chore(release): 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 All notable changes to `PureStorageFlashBladePowerShell` are documented in this file.
 
+## [2.2.0] - 2026-07-22
+
+API version-awareness plus seven documented-but-unexposed query-parameter enums.
+
+### Added
+
+- API capability check. A generated capability map (`Data/PfbCapabilityMap.json`)
+  records the REST API version that introduced every endpoint, query parameter, and
+  field; a REST-to-Purity//FB version map (`Data/PfbVersionMap.json`) makes the errors
+  readable. `Invoke-PfbApiRequest` now runs a fail-fast check (`Assert-PfbApiCapability`)
+  that rejects a call **before any HTTP request** when the connected array's version
+  cannot support what is being asked, with a clear "upgrade the array or omit the
+  unsupported option(s)" message. The check **fails safe**: a missing map, an unmatched
+  endpoint, or an unresolvable version is a graceful no-op, never a false rejection.
+- Seven query-parameter enums the REST API documents but the cmdlets never exposed
+  (all additive, default to "not sent"): `Get-PfbArrayConnectionPerformanceReplication -Type`,
+  `Get-PfbArrayPerformanceReplication -Type`, `Test-PfbSupport -TestType`,
+  `Invoke-PfbNetworkTrace -Method`, `Get-PfbFileSystemSession -Protocol`,
+  `Remove-PfbFileSystemSession -Protocol`, and `Get-PfbPolicyAllMember -MemberType`
+  (an `ArgumentCompleter` rather than a `ValidateSet`, because that value set grew from
+  4 to 5 at REST v2.17 and a hard set would block a value the array accepts).
+- A reporting-only maintainer toolchain under `tools/` (value-enum extraction,
+  field-to-cmdlet validation recommendations, and a combined API drift report). Nothing
+  is wired into cmdlet validation yet; that is a deliberate follow-on decision.
+
+### Fixed
+
+- `Get-`/`Remove-PfbFileSystemSession`: removed the `-Id` parameter (the endpoint has no
+  `ids` query parameter in any spec version, so it never worked), corrected `-Name` help
+  (it filters by the session's own generated name, not a file system name), and made
+  `-Protocol` its own mutually-exclusive parameter set. On `Remove-PfbFileSystemSession`,
+  `-Protocol` is a genuine array-wide bulk-terminate mode and now requires an explicit
+  `-Force` switch.
+
+### Changed
+
+- `scripts/build.ps1` and `scripts/Publish-Gallery.ps1` now bundle `Data/` into the
+  built and branded packages, so the capability check is live for installed copies.
+
 ## [2.1.2] - 2026-07-20
 
 API-drift cleanup: parameter-validation fixes and removal of three cmdlets that

--- a/PureStorageFlashBladePowerShell.psd1
+++ b/PureStorageFlashBladePowerShell.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule        = 'PureStorageFlashBladePowerShell.psm1'
-    ModuleVersion     = '2.1.2'
+    ModuleVersion     = '2.2.0'
     GUID              = 'b25473b3-9eb7-414d-8da1-264e10f73d86'
     Author            = 'Pure Storage, Inc.'
     CompanyName       = 'Pure Storage, Inc.'
@@ -548,6 +548,17 @@
             LicenseUri   = 'https://github.com/PureStorage-OpenConnect/flashblade-powershell/blob/main/LICENSE'
             # ReleaseNotes carries only the latest-version highlight; full history is in CHANGELOG.md.
             ReleaseNotes = @'
+v2.2.0 - API version-awareness + feature-gap parameters.
+  Adds a generated capability map of every FlashBlade REST endpoint/parameter/field to
+  the API version that introduced it, and a fail-fast runtime check that rejects a call
+  (before any HTTP request) when the connected array's version cannot support it. The
+  check fails safe: a missing map / unmatched endpoint / unresolvable version is a no-op.
+  Also exposes seven documented query-parameter enums that cmdlets never surfaced
+  (Get-PfbArrayConnectionPerformanceReplication/Get-PfbArrayPerformanceReplication -Type,
+  Test-PfbSupport -TestType, Invoke-PfbNetworkTrace -Method, Get-PfbFileSystemSession
+  -Protocol, Get-PfbPolicyAllMember -MemberType), and fixes Get-/Remove-PfbFileSystemSession
+  (removed a non-working -Id, added a -Protocol bulk-terminate mode, corrected -Name help).
+
 v2.1.2 - API-drift cleanup. Removes three cmdlets that modeled endpoints that never
   existed in the FlashBlade API and always returned HTTP 405 (Remove-PfbSession,
   New-/Remove-PfbNetworkAccessPolicy; network-access policy *rules* remain fully

--- a/scripts/Publish-Gallery.ps1
+++ b/scripts/Publish-Gallery.ps1
@@ -55,6 +55,11 @@ if (Test-Path $dstDir) { Remove-Item $dstDir -Recurse -Force }
 New-Item -ItemType Directory -Path $dstDir | Out-Null
 Copy-Item (Join-Path $srcDir "$srcName.psm1") (Join-Path $dstDir "$packageName.psm1")
 Copy-Item (Join-Path $srcDir 'LICENSE')       (Join-Path $dstDir 'LICENSE') -ErrorAction SilentlyContinue
+# Data/ holds the runtime capability + version maps (read from disk relative to the
+# module root). build.ps1 copies it into the source package; carry it into the branded
+# package too, or the API version-awareness check silently no-ops on every Gallery install.
+$dataDir = Join-Path $srcDir 'Data'
+if (Test-Path $dataDir) { Copy-Item $dataDir (Join-Path $dstDir 'Data') -Recurse }
 
 # 3. Re-brand the manifest.
 $psd1 = Get-Content (Join-Path $srcDir "$srcName.psd1") -Raw


### PR DESCRIPTION
Release 2.2.0. Rolls up everything on `main` since 2.1.2:

- **PR #21** - API version-awareness: capability map + fail-fast `Assert-PfbApiCapability` check in `Invoke-PfbApiRequest` (fails safe).
- **PR #20** - seven documented query-param enums the cmdlets never exposed, plus `Get-`/`Remove-PfbFileSystemSession` fixes.

Changes here:
- `ModuleVersion` 2.1.2 -> 2.2.0, v2.2.0 ReleaseNotes highlight, CHANGELOG `[2.2.0]` entry.
- **`Publish-Gallery.ps1` now copies `Data/` into the branded `EverpureFBModule` package.** `build.ps1` (from #21) copies `Data/` into the source package, but the rebrand step only copied the psm1 + LICENSE, so the published module would have shipped without the capability/version maps and the whole version-awareness check would have silently no-op'd on every Gallery install.

Verified: `Test-ModuleManifest` -> 2.2.0 / 523 exports; dry-run `Publish-Gallery.ps1` confirms `EverpureFBModule/Data/PfbCapabilityMap.json` + `PfbVersionMap.json` land in the branded package.

Closes #24.