### PR TITLE
Fix: -Limit ignored under AutoPaginate (#30)

### DIFF
--- a/Private/Invoke-PfbApiRequest.ps1
+++ b/Private/Invoke-PfbApiRequest.ps1
@@ -109,6 +109,15 @@ function Invoke-PfbApiRequest {
     # HTTP timeout handling — default to 30s if the connection object predates this field
     $restParams['TimeoutSec'] = if ($Array.HttpTimeoutMs) { [int][Math]::Ceiling($Array.HttpTimeoutMs / 1000.0) } else { 30 }
 
+    # If the caller set a page-size/limit query param (every Get-Pfb* cmdlet's -Limit maps to
+    # this), treat it as a hard cap on the running total across pages -- Purity//FB REST treats
+    # `limit` as page size only and keeps returning a continuation_token even once the caller's
+    # desired item count has been reached, so AutoPaginate must stop itself.
+    $requestedLimit = $null
+    if ($QueryParams -and $QueryParams.ContainsKey('limit') -and $QueryParams['limit']) {
+        $requestedLimit = [int]$QueryParams['limit']
+    }
+
     $allItems = [System.Collections.Generic.List[object]]::new()
     $totalItemCount = $null
     $hasMore = $true
@@ -211,7 +220,8 @@ function Invoke-PfbApiRequest {
         }
 
         # Handle pagination
-        if ($AutoPaginate -and $response.continuation_token) {
+        $limitReached = ($null -ne $requestedLimit -and $allItems.Count -ge $requestedLimit)
+        if ($AutoPaginate -and $response.continuation_token -and -not $limitReached) {
             # Update the URI with continuation token
             if (-not $QueryParams) { $QueryParams = @{} }
             $QueryParams['continuation_token'] = $response.continuation_token
@@ -222,6 +232,12 @@ function Invoke-PfbApiRequest {
         else {
             $hasMore = $false
         }
+    }
+
+    # The last page fetched may have overshot the requested limit (server-side page size is
+    # independent of it) -- trim so callers get exactly what they asked for.
+    if ($null -ne $requestedLimit -and $allItems.Count -gt $requestedLimit) {
+        $allItems = $allItems.GetRange(0, $requestedLimit)
     }
 
     # If TotalOnly was requested and we got a count but no items, return the count

--- a/Private/Invoke-PfbApiRequest.ps1
+++ b/Private/Invoke-PfbApiRequest.ps1
@@ -114,7 +114,7 @@ function Invoke-PfbApiRequest {
     # `limit` as page size only and keeps returning a continuation_token even once the caller's
     # desired item count has been reached, so AutoPaginate must stop itself.
     $requestedLimit = $null
-    if ($QueryParams -and $QueryParams.ContainsKey('limit') -and $QueryParams['limit']) {
+    if ($QueryParams -and $QueryParams.ContainsKey('limit') -and [int]$QueryParams['limit'] -gt 0) {
         $requestedLimit = [int]$QueryParams['limit']
     }
 

--- a/Tests/Invoke-PfbApiRequest.Tests.ps1
+++ b/Tests/Invoke-PfbApiRequest.Tests.ps1
@@ -63,3 +63,70 @@ Describe 'Invoke-PfbApiRequest - HttpTimeoutMs is applied' {
         }
     }
 }
+
+Describe 'Invoke-PfbApiRequest - AutoPaginate honors -Limit' {
+    It 'stops paginating and trims results once the running total reaches the requested limit' {
+        $script:pageCallCount = 0
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
+            $script:pageCallCount++
+            switch ($script:pageCallCount) {
+                1 {
+                    [PSCustomObject]@{
+                        items              = @(1..6 | ForEach-Object { [PSCustomObject]@{ name = "fs$_" } })
+                        continuation_token = 'token-page-2'
+                    }
+                }
+                2 {
+                    [PSCustomObject]@{
+                        items              = @(7..12 | ForEach-Object { [PSCustomObject]@{ name = "fs$_" } })
+                        continuation_token = 'token-page-3'
+                    }
+                }
+                default {
+                    throw "Unexpected extra page request (call #$script:pageCallCount) -- the -Limit guard should have stopped pagination after call #2"
+                }
+            }
+        } -ParameterFilter { $Uri -like '*file-systems*' }
+
+        InModuleScope PureStorageFlashBladePowerShell {
+            $array = [PSCustomObject]@{
+                Endpoint = 'fb.test'; ApiVersion = '2.26'; AuthToken = 'tok'
+                ApiToken = $null; AuthMethod = 'ApiToken'; SkipCertificateCheck = $false
+            }
+            $script:result = Invoke-PfbApiRequest -Array $array -Method GET -Endpoint 'file-systems' -QueryParams @{ limit = 10 } -AutoPaginate
+        }
+
+        $script:result.Count | Should -Be 10
+        $script:pageCallCount | Should -Be 2
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod -Times 2 -Exactly -ParameterFilter { $Uri -like '*file-systems*' }
+    }
+
+    It 'still auto-paginates the full collection when no -Limit is given' {
+        $script:pageCallCount2 = 0
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
+            $script:pageCallCount2++
+            if ($script:pageCallCount2 -eq 1) {
+                [PSCustomObject]@{
+                    items              = @(1..6 | ForEach-Object { [PSCustomObject]@{ name = "fs$_" } })
+                    continuation_token = 'token-page-2'
+                }
+            }
+            else {
+                [PSCustomObject]@{
+                    items = @(7..9 | ForEach-Object { [PSCustomObject]@{ name = "fs$_" } })
+                }
+            }
+        } -ParameterFilter { $Uri -like '*file-systems*' }
+
+        InModuleScope PureStorageFlashBladePowerShell {
+            $array = [PSCustomObject]@{
+                Endpoint = 'fb.test'; ApiVersion = '2.26'; AuthToken = 'tok'
+                ApiToken = $null; AuthMethod = 'ApiToken'; SkipCertificateCheck = $false
+            }
+            $script:result2 = Invoke-PfbApiRequest -Array $array -Method GET -Endpoint 'file-systems' -QueryParams @{} -AutoPaginate
+        }
+
+        $script:result2.Count | Should -Be 9
+        $script:pageCallCount2 | Should -Be 2
+    }
+}

--- a/Tests/Invoke-PfbApiRequest.Tests.ps1
+++ b/Tests/Invoke-PfbApiRequest.Tests.ps1
@@ -88,12 +88,12 @@ Describe 'Invoke-PfbApiRequest - AutoPaginate honors -Limit' {
             }
         } -ParameterFilter { $Uri -like '*file-systems*' }
 
-        InModuleScope PureStorageFlashBladePowerShell {
+        $script:result = InModuleScope PureStorageFlashBladePowerShell {
             $array = [PSCustomObject]@{
                 Endpoint = 'fb.test'; ApiVersion = '2.26'; AuthToken = 'tok'
                 ApiToken = $null; AuthMethod = 'ApiToken'; SkipCertificateCheck = $false
             }
-            $script:result = Invoke-PfbApiRequest -Array $array -Method GET -Endpoint 'file-systems' -QueryParams @{ limit = 10 } -AutoPaginate
+            Invoke-PfbApiRequest -Array $array -Method GET -Endpoint 'file-systems' -QueryParams @{ limit = 10 } -AutoPaginate
         }
 
         $script:result.Count | Should -Be 10
@@ -118,12 +118,12 @@ Describe 'Invoke-PfbApiRequest - AutoPaginate honors -Limit' {
             }
         } -ParameterFilter { $Uri -like '*file-systems*' }
 
-        InModuleScope PureStorageFlashBladePowerShell {
+        $script:result2 = InModuleScope PureStorageFlashBladePowerShell {
             $array = [PSCustomObject]@{
                 Endpoint = 'fb.test'; ApiVersion = '2.26'; AuthToken = 'tok'
                 ApiToken = $null; AuthMethod = 'ApiToken'; SkipCertificateCheck = $false
             }
-            $script:result2 = Invoke-PfbApiRequest -Array $array -Method GET -Endpoint 'file-systems' -QueryParams @{} -AutoPaginate
+            Invoke-PfbApiRequest -Array $array -Method GET -Endpoint 'file-systems' -QueryParams @{} -AutoPaginate
         }
 
         $script:result2.Count | Should -Be 9


### PR DESCRIPTION
## Summary
- `Invoke-PfbApiRequest -AutoPaginate` had no running-total guard against the caller's `-Limit`: Purity//FB REST treats `limit` as page size only and keeps returning a `continuation_token` past that point, so every `Get-Pfb* -Limit N` call was silently re-paging the full collection.
- Adds a running-total check (`$requestedLimit`, read once from `$QueryParams['limit']`) that stops issuing further paginated requests once the total reaches the limit, and trims the final result to exactly that count.
- Follow-up hardening: tightened the limit guard to reject non-positive values, closing a latent `GetRange()` crash risk (unreachable via any current public cmdlet, but cheap to close).
- No cmdlet-surface change -- fix is entirely inside `Private/Invoke-PfbApiRequest.ps1`.

Fixes #30.

## Test plan
- [x] New Pester regression tests in `Tests/Invoke-PfbApiRequest.Tests.ps1` covering: (a) pagination stops early and trims to `-Limit` when the server keeps returning `continuation_token`s past that point, (b) full-collection auto-pagination is unchanged when no `-Limit` is given.
- [x] Live-verified against a lab FlashBlade array (REST 2.26): a raw single-page request with `limit=100` against a 340-item collection confirmed the server returns exactly 100 items **and** a `continuation_token` even though more items remain -- the exact root cause. `Get-PfbSession -Limit 5` / `-Limit 250` each returned exactly that many items with only one page request; `Get-PfbSession` with no `-Limit` still returned the full 340.
- [x] Full unit test suite: 386 passed, 0 failed, 2 skipped -- no regressions.