### PR TITLE
Centralize -Filter/-Sort/-Limit/-TotalOnly query params (#32)

### DIFF
--- a/Private/Add-PfbCommonQueryParams.ps1
+++ b/Private/Add-PfbCommonQueryParams.ps1
@@ -1,0 +1,24 @@
+function Add-PfbCommonQueryParams {
+    <#
+    .SYNOPSIS
+        Adds common query parameters to a query-parameter hashtable.
+    .DESCRIPTION
+        Populates a hashtable with the standard -Filter, -Sort, -Limit, -TotalOnly,
+        -Names, and -Ids query parameters used across all Get-Pfb* cmdlets. Uses
+        ContainsKey semantics to detect bound parameters, allowing explicit passes
+        of falsy values (e.g. -Limit 0 or empty-string -Filter) to be included.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][hashtable]$Into,
+        [Parameter(Mandatory)][System.Collections.IDictionary]$BoundParameters,
+        [string[]]$Names,
+        [string[]]$Ids
+    )
+    if ($BoundParameters.ContainsKey('Filter'))    { $Into['filter']     = $BoundParameters['Filter'] }
+    if ($BoundParameters.ContainsKey('Sort'))      { $Into['sort']       = $BoundParameters['Sort'] }
+    if ($BoundParameters.ContainsKey('Limit'))     { $Into['limit']      = $BoundParameters['Limit'] }
+    if ($BoundParameters.ContainsKey('TotalOnly')) { $Into['total_only'] = 'true' }
+    if ($Names) { $Into['names'] = $Names -join ',' }
+    if ($Ids)   { $Into['ids']   = $Ids   -join ',' }
+}

--- a/Public/Bucket/Get-PfbBucket.ps1
+++ b/Public/Bucket/Get-PfbBucket.ps1
@@ -65,12 +65,7 @@ function Get-PfbBucket {
 
     end {
         $queryParams = @{}
-        if ($allNames.Count -gt 0) { $queryParams['names']      = $allNames -join ',' }
-        if ($allIds.Count -gt 0)   { $queryParams['ids']        = $allIds -join ',' }
-        if ($Filter)               { $queryParams['filter']     = $Filter }
-        if ($Sort)                 { $queryParams['sort']       = $Sort }
-        if ($Limit -gt 0)         { $queryParams['limit']      = $Limit }
-        if ($TotalOnly)            { $queryParams['total_only'] = 'true' }
+        Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
         if ($Destroyed)            { $queryParams['destroyed']  = 'true' }
 
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'buckets' -QueryParams $queryParams -AutoPaginate

--- a/Public/Bucket/Get-PfbBucketPerformance.ps1
+++ b/Public/Bucket/Get-PfbBucketPerformance.ps1
@@ -66,15 +66,10 @@ function Get-PfbBucketPerformance {
 
     end {
         $queryParams = @{}
-        if ($allNames.Count -gt 0) { $queryParams['names']      = $allNames -join ',' }
-        if ($allIds.Count -gt 0)   { $queryParams['ids']        = $allIds -join ',' }
-        if ($Filter)               { $queryParams['filter']     = $Filter }
-        if ($Sort)                 { $queryParams['sort']       = $Sort }
-        if ($Limit -gt 0)          { $queryParams['limit']      = $Limit }
+        Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
         if ($StartTime)            { $queryParams['start_time'] = $StartTime }
         if ($EndTime)              { $queryParams['end_time']   = $EndTime }
         if ($Resolution)           { $queryParams['resolution'] = $Resolution }
-        if ($TotalOnly)            { $queryParams['total_only'] = 'true' }
 
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'buckets/performance' -QueryParams $queryParams -AutoPaginate
     }

--- a/Public/Bucket/Get-PfbBucketS3Performance.ps1
+++ b/Public/Bucket/Get-PfbBucketS3Performance.ps1
@@ -67,15 +67,10 @@ function Get-PfbBucketS3Performance {
 
     end {
         $queryParams = @{}
-        if ($allNames.Count -gt 0) { $queryParams['names']      = $allNames -join ',' }
-        if ($allIds.Count -gt 0)   { $queryParams['ids']        = $allIds -join ',' }
-        if ($Filter)               { $queryParams['filter']     = $Filter }
-        if ($Sort)                 { $queryParams['sort']       = $Sort }
-        if ($Limit -gt 0)          { $queryParams['limit']      = $Limit }
+        Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
         if ($StartTime)            { $queryParams['start_time'] = $StartTime }
         if ($EndTime)              { $queryParams['end_time']   = $EndTime }
         if ($Resolution)           { $queryParams['resolution'] = $Resolution }
-        if ($TotalOnly)            { $queryParams['total_only'] = 'true' }
 
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'buckets/s3-specific-performance' -QueryParams $queryParams -AutoPaginate
     }

--- a/Public/FileSystem/Get-PfbFileLock.ps1
+++ b/Public/FileSystem/Get-PfbFileLock.ps1
@@ -70,12 +70,7 @@ function Get-PfbFileLock {
 
     end {
         $queryParams = @{}
-        if ($allNames.Count -gt 0) { $queryParams['names']      = $allNames -join ',' }
-        if ($allIds.Count -gt 0)   { $queryParams['ids']        = $allIds -join ',' }
-        if ($Filter)               { $queryParams['filter']     = $Filter }
-        if ($Sort)                 { $queryParams['sort']       = $Sort }
-        if ($Limit -gt 0)         { $queryParams['limit']      = $Limit }
-        if ($TotalOnly)            { $queryParams['total_only'] = 'true' }
+        Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
 
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'file-systems/locks' -QueryParams $queryParams -AutoPaginate
     }

--- a/Public/FileSystem/Get-PfbFileLockClient.ps1
+++ b/Public/FileSystem/Get-PfbFileLockClient.ps1
@@ -70,12 +70,7 @@ function Get-PfbFileLockClient {
 
     end {
         $queryParams = @{}
-        if ($allNames.Count -gt 0) { $queryParams['names']      = $allNames -join ',' }
-        if ($allIds.Count -gt 0)   { $queryParams['ids']        = $allIds -join ',' }
-        if ($Filter)               { $queryParams['filter']     = $Filter }
-        if ($Sort)                 { $queryParams['sort']       = $Sort }
-        if ($Limit -gt 0)         { $queryParams['limit']      = $Limit }
-        if ($TotalOnly)            { $queryParams['total_only'] = 'true' }
+        Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
 
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'file-systems/locks/clients' -QueryParams $queryParams -AutoPaginate
     }

--- a/Public/FileSystem/Get-PfbFileSystem.ps1
+++ b/Public/FileSystem/Get-PfbFileSystem.ps1
@@ -73,12 +73,7 @@ function Get-PfbFileSystem {
 
     end {
         $queryParams = @{}
-        if ($allNames.Count -gt 0) { $queryParams['names']      = $allNames -join ',' }
-        if ($allIds.Count -gt 0)   { $queryParams['ids']        = $allIds -join ',' }
-        if ($Filter)               { $queryParams['filter']     = $Filter }
-        if ($Sort)                 { $queryParams['sort']       = $Sort }
-        if ($Limit -gt 0)         { $queryParams['limit']      = $Limit }
-        if ($TotalOnly)            { $queryParams['total_only'] = 'true' }
+        Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
         if ($Destroyed)            { $queryParams['destroyed']  = 'true' }
 
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'file-systems' -QueryParams $queryParams -AutoPaginate

--- a/Public/FileSystem/Get-PfbFileSystemExport.ps1
+++ b/Public/FileSystem/Get-PfbFileSystemExport.ps1
@@ -70,12 +70,7 @@ function Get-PfbFileSystemExport {
 
     end {
         $queryParams = @{}
-        if ($allNames.Count -gt 0) { $queryParams['names']      = $allNames -join ',' }
-        if ($allIds.Count -gt 0)   { $queryParams['ids']        = $allIds -join ',' }
-        if ($Filter)               { $queryParams['filter']     = $Filter }
-        if ($Sort)                 { $queryParams['sort']       = $Sort }
-        if ($Limit -gt 0)         { $queryParams['limit']      = $Limit }
-        if ($TotalOnly)            { $queryParams['total_only'] = 'true' }
+        Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
 
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'file-system-exports' -QueryParams $queryParams -AutoPaginate
     }

--- a/Public/FileSystem/Get-PfbFileSystemGroupPerformance.ps1
+++ b/Public/FileSystem/Get-PfbFileSystemGroupPerformance.ps1
@@ -85,12 +85,9 @@ function Get-PfbFileSystemGroupPerformance {
 
     end {
         $queryParams = @{}
+        Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters
         if ($allNames.Count -gt 0) { $queryParams['file_system_names'] = $allNames -join ',' }
         if ($allIds.Count -gt 0)   { $queryParams['file_system_ids']  = $allIds -join ',' }
-        if ($Filter)               { $queryParams['filter']     = $Filter }
-        if ($Sort)                 { $queryParams['sort']       = $Sort }
-        if ($Limit -gt 0)         { $queryParams['limit']      = $Limit }
-        if ($TotalOnly)            { $queryParams['total_only'] = 'true' }
         if ($StartTime -gt 0)     { $queryParams['start_time'] = $StartTime }
         if ($EndTime -gt 0)       { $queryParams['end_time']   = $EndTime }
         if ($Resolution -gt 0)    { $queryParams['resolution'] = $Resolution }

--- a/Public/FileSystem/Get-PfbFileSystemSession.ps1
+++ b/Public/FileSystem/Get-PfbFileSystemSession.ps1
@@ -71,11 +71,7 @@ function Get-PfbFileSystemSession {
 
     end {
         $queryParams = @{}
-        if ($allNames.Count -gt 0) { $queryParams['names']      = $allNames -join ',' }
-        if ($Filter)               { $queryParams['filter']     = $Filter }
-        if ($Sort)                 { $queryParams['sort']       = $Sort }
-        if ($Limit -gt 0)         { $queryParams['limit']      = $Limit }
-        if ($TotalOnly)            { $queryParams['total_only'] = 'true' }
+        Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames
         if ($Protocol)             { $queryParams['protocols']  = $Protocol -join ',' }
 
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'file-systems/sessions' -QueryParams $queryParams -AutoPaginate

--- a/Public/FileSystem/Get-PfbFileSystemStorageClass.ps1
+++ b/Public/FileSystem/Get-PfbFileSystemStorageClass.ps1
@@ -70,12 +70,7 @@ function Get-PfbFileSystemStorageClass {
 
     end {
         $queryParams = @{}
-        if ($allNames.Count -gt 0) { $queryParams['names']      = $allNames -join ',' }
-        if ($allIds.Count -gt 0)   { $queryParams['ids']        = $allIds -join ',' }
-        if ($Filter)               { $queryParams['filter']     = $Filter }
-        if ($Sort)                 { $queryParams['sort']       = $Sort }
-        if ($Limit -gt 0)         { $queryParams['limit']      = $Limit }
-        if ($TotalOnly)            { $queryParams['total_only'] = 'true' }
+        Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
 
         try {
             Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'file-systems/space/storage-classes' -QueryParams $queryParams -AutoPaginate

--- a/Public/FileSystem/Get-PfbFileSystemUserPerformance.ps1
+++ b/Public/FileSystem/Get-PfbFileSystemUserPerformance.ps1
@@ -85,12 +85,9 @@ function Get-PfbFileSystemUserPerformance {
 
     end {
         $queryParams = @{}
+        Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters
         if ($allNames.Count -gt 0) { $queryParams['file_system_names'] = $allNames -join ',' }
         if ($allIds.Count -gt 0)   { $queryParams['file_system_ids']  = $allIds -join ',' }
-        if ($Filter)               { $queryParams['filter']     = $Filter }
-        if ($Sort)                 { $queryParams['sort']       = $Sort }
-        if ($Limit -gt 0)         { $queryParams['limit']      = $Limit }
-        if ($TotalOnly)            { $queryParams['total_only'] = 'true' }
         if ($StartTime -gt 0)     { $queryParams['start_time'] = $StartTime }
         if ($EndTime -gt 0)       { $queryParams['end_time']   = $EndTime }
         if ($Resolution -gt 0)    { $queryParams['resolution'] = $Resolution }

--- a/Public/FileSystem/Get-PfbOpenFile.ps1
+++ b/Public/FileSystem/Get-PfbOpenFile.ps1
@@ -70,12 +70,7 @@ function Get-PfbOpenFile {
 
     end {
         $queryParams = @{}
-        if ($allNames.Count -gt 0) { $queryParams['names']      = $allNames -join ',' }
-        if ($allIds.Count -gt 0)   { $queryParams['ids']        = $allIds -join ',' }
-        if ($Filter)               { $queryParams['filter']     = $Filter }
-        if ($Sort)                 { $queryParams['sort']       = $Sort }
-        if ($Limit -gt 0)         { $queryParams['limit']      = $Limit }
-        if ($TotalOnly)            { $queryParams['total_only'] = 'true' }
+        Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
 
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'file-systems/open-files' -QueryParams $queryParams -AutoPaginate
     }

--- a/Public/FileSystemSnapshot/Get-PfbFileSystemSnapshot.ps1
+++ b/Public/FileSystemSnapshot/Get-PfbFileSystemSnapshot.ps1
@@ -68,13 +68,8 @@ function Get-PfbFileSystemSnapshot {
 
     end {
         $queryParams = @{}
-        if ($allNames.Count -gt 0) { $queryParams['names']         = $allNames -join ',' }
-        if ($allIds.Count -gt 0)   { $queryParams['ids']           = $allIds -join ',' }
+        Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
         if ($SourceName)           { $queryParams['source_names']  = $SourceName }
-        if ($Filter)               { $queryParams['filter']        = $Filter }
-        if ($Sort)                 { $queryParams['sort']          = $Sort }
-        if ($Limit -gt 0)         { $queryParams['limit']         = $Limit }
-        if ($TotalOnly)            { $queryParams['total_only']    = 'true' }
         if ($Destroyed)            { $queryParams['destroyed']     = 'true' }
 
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'file-system-snapshots' -QueryParams $queryParams -AutoPaginate

--- a/Public/FileSystemSnapshot/Get-PfbFileSystemSnapshotTransfer.ps1
+++ b/Public/FileSystemSnapshot/Get-PfbFileSystemSnapshotTransfer.ps1
@@ -66,12 +66,7 @@ function Get-PfbFileSystemSnapshotTransfer {
 
     end {
         $queryParams = @{}
-        if ($allNames.Count -gt 0) { $queryParams['names']      = $allNames -join ',' }
-        if ($allIds.Count -gt 0)   { $queryParams['ids']        = $allIds -join ',' }
-        if ($Filter)               { $queryParams['filter']     = $Filter }
-        if ($Sort)                 { $queryParams['sort']       = $Sort }
-        if ($Limit -gt 0)         { $queryParams['limit']      = $Limit }
-        if ($TotalOnly)            { $queryParams['total_only'] = 'true' }
+        Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
 
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'file-system-snapshots/transfer' -QueryParams $queryParams -AutoPaginate
     }

--- a/Public/ObjectStore/Get-PfbObjectStoreAccessPolicy.ps1
+++ b/Public/ObjectStore/Get-PfbObjectStoreAccessPolicy.ps1
@@ -58,12 +58,7 @@ function Get-PfbObjectStoreAccessPolicy {
 
     end {
         $queryParams = @{}
-        if ($allNames.Count -gt 0) { $queryParams['names']      = $allNames -join ',' }
-        if ($allIds.Count -gt 0)   { $queryParams['ids']        = $allIds -join ',' }
-        if ($Filter)               { $queryParams['filter']     = $Filter }
-        if ($Sort)                 { $queryParams['sort']       = $Sort }
-        if ($Limit -gt 0)         { $queryParams['limit']      = $Limit }
-        if ($TotalOnly)            { $queryParams['total_only'] = 'true' }
+        Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
 
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'object-store-access-policies' -QueryParams $queryParams -AutoPaginate
     }

--- a/Public/ObjectStore/Get-PfbObjectStoreAccessPolicyAction.ps1
+++ b/Public/ObjectStore/Get-PfbObjectStoreAccessPolicyAction.ps1
@@ -38,10 +38,7 @@ function Get-PfbObjectStoreAccessPolicyAction {
     Assert-PfbConnection -Array ([ref]$Array)
 
     $queryParams = @{}
-    if ($Filter)     { $queryParams['filter']     = $Filter }
-    if ($Sort)       { $queryParams['sort']       = $Sort }
-    if ($Limit -gt 0) { $queryParams['limit']    = $Limit }
-    if ($TotalOnly)  { $queryParams['total_only'] = 'true' }
+    Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters
 
     Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'object-store-access-policy-actions' -QueryParams $queryParams -AutoPaginate
 }

--- a/Public/ObjectStore/Get-PfbObjectStoreAccessPolicyRole.ps1
+++ b/Public/ObjectStore/Get-PfbObjectStoreAccessPolicyRole.ps1
@@ -72,14 +72,11 @@ function Get-PfbObjectStoreAccessPolicyRole {
 
     end {
         $queryParams = @{}
+        Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters
         if ($allPolicyNames.Count -gt 0) { $queryParams['policy_names'] = $allPolicyNames -join ',' }
         if ($allPolicyIds.Count -gt 0)   { $queryParams['policy_ids']   = $allPolicyIds -join ',' }
         if ($allMemberNames.Count -gt 0) { $queryParams['member_names'] = $allMemberNames -join ',' }
         if ($allMemberIds.Count -gt 0)   { $queryParams['member_ids']   = $allMemberIds -join ',' }
-        if ($Filter)                     { $queryParams['filter']       = $Filter }
-        if ($Sort)                       { $queryParams['sort']         = $Sort }
-        if ($Limit -gt 0)              { $queryParams['limit']        = $Limit }
-        if ($TotalOnly)                  { $queryParams['total_only']   = 'true' }
 
         $response = Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'object-store-access-policies/object-store-roles' -QueryParams $queryParams -AutoPaginate
         foreach ($item in $response) {

--- a/Public/ObjectStore/Get-PfbObjectStoreAccessPolicyRule.ps1
+++ b/Public/ObjectStore/Get-PfbObjectStoreAccessPolicyRule.ps1
@@ -65,13 +65,9 @@ function Get-PfbObjectStoreAccessPolicyRule {
 
     end {
         $queryParams = @{}
+        Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames
         if ($allPolicyNames.Count -gt 0) { $queryParams['policy_names'] = $allPolicyNames -join ',' }
         if ($allPolicyIds.Count -gt 0)   { $queryParams['policy_ids']   = $allPolicyIds -join ',' }
-        if ($allNames.Count -gt 0)       { $queryParams['names']        = $allNames -join ',' }
-        if ($Filter)                     { $queryParams['filter']       = $Filter }
-        if ($Sort)                       { $queryParams['sort']         = $Sort }
-        if ($Limit -gt 0)              { $queryParams['limit']        = $Limit }
-        if ($TotalOnly)                  { $queryParams['total_only']   = 'true' }
 
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'object-store-access-policies/rules' -QueryParams $queryParams -AutoPaginate
     }

--- a/Public/ObjectStore/Get-PfbObjectStoreAccessPolicyUser.ps1
+++ b/Public/ObjectStore/Get-PfbObjectStoreAccessPolicyUser.ps1
@@ -72,14 +72,11 @@ function Get-PfbObjectStoreAccessPolicyUser {
 
     end {
         $queryParams = @{}
+        Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters
         if ($allPolicyNames.Count -gt 0) { $queryParams['policy_names'] = $allPolicyNames -join ',' }
         if ($allPolicyIds.Count -gt 0)   { $queryParams['policy_ids']   = $allPolicyIds -join ',' }
         if ($allMemberNames.Count -gt 0) { $queryParams['member_names'] = $allMemberNames -join ',' }
         if ($allMemberIds.Count -gt 0)   { $queryParams['member_ids']   = $allMemberIds -join ',' }
-        if ($Filter)                     { $queryParams['filter']       = $Filter }
-        if ($Sort)                       { $queryParams['sort']         = $Sort }
-        if ($Limit -gt 0)              { $queryParams['limit']        = $Limit }
-        if ($TotalOnly)                  { $queryParams['total_only']   = 'true' }
 
         $response = Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'object-store-access-policies/object-store-users' -QueryParams $queryParams -AutoPaginate
         foreach ($item in $response) {

--- a/Public/ObjectStore/Get-PfbObjectStoreAccount.ps1
+++ b/Public/ObjectStore/Get-PfbObjectStoreAccount.ps1
@@ -47,12 +47,7 @@ function Get-PfbObjectStoreAccount {
 
     end {
         $queryParams = @{}
-        if ($allNames.Count -gt 0) { $queryParams['names']      = $allNames -join ',' }
-        if ($allIds.Count -gt 0)   { $queryParams['ids']        = $allIds -join ',' }
-        if ($Filter)               { $queryParams['filter']     = $Filter }
-        if ($Sort)                 { $queryParams['sort']       = $Sort }
-        if ($Limit -gt 0)         { $queryParams['limit']      = $Limit }
-        if ($TotalOnly)            { $queryParams['total_only'] = 'true' }
+        Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
 
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'object-store-accounts' -QueryParams $queryParams -AutoPaginate
     }

--- a/Public/ObjectStore/Get-PfbObjectStoreAccountExport.ps1
+++ b/Public/ObjectStore/Get-PfbObjectStoreAccountExport.ps1
@@ -57,12 +57,7 @@ function Get-PfbObjectStoreAccountExport {
 
     end {
         $queryParams = @{}
-        if ($allNames.Count -gt 0) { $queryParams['names']      = $allNames -join ',' }
-        if ($allIds.Count -gt 0)   { $queryParams['ids']        = $allIds -join ',' }
-        if ($Filter)               { $queryParams['filter']     = $Filter }
-        if ($Sort)                 { $queryParams['sort']       = $Sort }
-        if ($Limit -gt 0)         { $queryParams['limit']      = $Limit }
-        if ($TotalOnly)            { $queryParams['total_only'] = 'true' }
+        Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
 
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'object-store-account-exports' -QueryParams $queryParams -AutoPaginate
     }

--- a/Public/ObjectStore/Get-PfbObjectStoreRemoteCredential.ps1
+++ b/Public/ObjectStore/Get-PfbObjectStoreRemoteCredential.ps1
@@ -58,12 +58,7 @@ function Get-PfbObjectStoreRemoteCredential {
 
     end {
         $queryParams = @{}
-        if ($allNames.Count -gt 0) { $queryParams['names']      = $allNames -join ',' }
-        if ($allIds.Count -gt 0)   { $queryParams['ids']        = $allIds -join ',' }
-        if ($Filter)               { $queryParams['filter']     = $Filter }
-        if ($Sort)                 { $queryParams['sort']       = $Sort }
-        if ($Limit -gt 0)         { $queryParams['limit']      = $Limit }
-        if ($TotalOnly)            { $queryParams['total_only'] = 'true' }
+        Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
 
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'object-store-remote-credentials' -QueryParams $queryParams -AutoPaginate
     }

--- a/Public/ObjectStore/Get-PfbObjectStoreRole.ps1
+++ b/Public/ObjectStore/Get-PfbObjectStoreRole.ps1
@@ -58,12 +58,7 @@ function Get-PfbObjectStoreRole {
 
     end {
         $queryParams = @{}
-        if ($allNames.Count -gt 0) { $queryParams['names']      = $allNames -join ',' }
-        if ($allIds.Count -gt 0)   { $queryParams['ids']        = $allIds -join ',' }
-        if ($Filter)               { $queryParams['filter']     = $Filter }
-        if ($Sort)                 { $queryParams['sort']       = $Sort }
-        if ($Limit -gt 0)         { $queryParams['limit']      = $Limit }
-        if ($TotalOnly)            { $queryParams['total_only'] = 'true' }
+        Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
 
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'object-store-roles' -QueryParams $queryParams -AutoPaginate
     }

--- a/Public/ObjectStore/Get-PfbObjectStoreRoleAccessPolicy.ps1
+++ b/Public/ObjectStore/Get-PfbObjectStoreRoleAccessPolicy.ps1
@@ -72,14 +72,11 @@ function Get-PfbObjectStoreRoleAccessPolicy {
 
     end {
         $queryParams = @{}
+        Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters
         if ($allRoleNames.Count -gt 0)   { $queryParams['role_names']   = $allRoleNames -join ',' }
         if ($allRoleIds.Count -gt 0)     { $queryParams['role_ids']     = $allRoleIds -join ',' }
         if ($allMemberNames.Count -gt 0) { $queryParams['member_names'] = $allMemberNames -join ',' }
         if ($allMemberIds.Count -gt 0)   { $queryParams['member_ids']   = $allMemberIds -join ',' }
-        if ($Filter)                     { $queryParams['filter']       = $Filter }
-        if ($Sort)                       { $queryParams['sort']         = $Sort }
-        if ($Limit -gt 0)              { $queryParams['limit']        = $Limit }
-        if ($TotalOnly)                  { $queryParams['total_only']   = 'true' }
 
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'object-store-roles/object-store-access-policies' -QueryParams $queryParams -AutoPaginate
     }

--- a/Public/ObjectStore/Get-PfbObjectStoreTrustPolicy.ps1
+++ b/Public/ObjectStore/Get-PfbObjectStoreTrustPolicy.ps1
@@ -58,12 +58,9 @@ function Get-PfbObjectStoreTrustPolicy {
 
     end {
         $queryParams = @{}
+        Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters
         if ($allRoleNames.Count -gt 0) { $queryParams['role_names'] = $allRoleNames -join ',' }
         if ($allRoleIds.Count -gt 0)   { $queryParams['role_ids']   = $allRoleIds -join ',' }
-        if ($Filter)                   { $queryParams['filter']     = $Filter }
-        if ($Sort)                     { $queryParams['sort']       = $Sort }
-        if ($Limit -gt 0)            { $queryParams['limit']      = $Limit }
-        if ($TotalOnly)                { $queryParams['total_only'] = 'true' }
 
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'object-store-roles/object-store-trust-policies' -QueryParams $queryParams -AutoPaginate
     }

--- a/Public/ObjectStore/Get-PfbObjectStoreTrustPolicyRule.ps1
+++ b/Public/ObjectStore/Get-PfbObjectStoreTrustPolicyRule.ps1
@@ -65,13 +65,9 @@ function Get-PfbObjectStoreTrustPolicyRule {
 
     end {
         $queryParams = @{}
+        Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames
         if ($allPolicyNames.Count -gt 0) { $queryParams['policy_names'] = $allPolicyNames -join ',' }
         if ($allPolicyIds.Count -gt 0)   { $queryParams['policy_ids']   = $allPolicyIds -join ',' }
-        if ($allNames.Count -gt 0)       { $queryParams['names']        = $allNames -join ',' }
-        if ($Filter)                     { $queryParams['filter']       = $Filter }
-        if ($Sort)                       { $queryParams['sort']         = $Sort }
-        if ($Limit -gt 0)              { $queryParams['limit']        = $Limit }
-        if ($TotalOnly)                  { $queryParams['total_only']   = 'true' }
 
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'object-store-roles/object-store-trust-policies/rules' -QueryParams $queryParams -AutoPaginate
     }

--- a/Public/ObjectStore/Get-PfbObjectStoreUserAccessPolicy.ps1
+++ b/Public/ObjectStore/Get-PfbObjectStoreUserAccessPolicy.ps1
@@ -72,14 +72,11 @@ function Get-PfbObjectStoreUserAccessPolicy {
 
     end {
         $queryParams = @{}
+        Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters
         if ($allMemberNames.Count -gt 0) { $queryParams['member_names'] = $allMemberNames -join ',' }
         if ($allMemberIds.Count -gt 0)   { $queryParams['member_ids']   = $allMemberIds -join ',' }
         if ($allPolicyNames.Count -gt 0) { $queryParams['policy_names'] = $allPolicyNames -join ',' }
         if ($allPolicyIds.Count -gt 0)   { $queryParams['policy_ids']   = $allPolicyIds -join ',' }
-        if ($Filter)                     { $queryParams['filter']       = $Filter }
-        if ($Sort)                       { $queryParams['sort']         = $Sort }
-        if ($Limit -gt 0)              { $queryParams['limit']        = $Limit }
-        if ($TotalOnly)                  { $queryParams['total_only']   = 'true' }
 
         $response = Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'object-store-users/object-store-access-policies' -QueryParams $queryParams -AutoPaginate
         foreach ($item in $response) {

--- a/Public/Realm/Get-PfbRealm.ps1
+++ b/Public/Realm/Get-PfbRealm.ps1
@@ -71,12 +71,7 @@ function Get-PfbRealm {
 
     end {
         $queryParams = @{}
-        if ($allNames.Count -gt 0) { $queryParams['names']      = $allNames -join ',' }
-        if ($allIds.Count -gt 0)   { $queryParams['ids']        = $allIds -join ',' }
-        if ($Filter)               { $queryParams['filter']     = $Filter }
-        if ($Sort)                 { $queryParams['sort']       = $Sort }
-        if ($Limit -gt 0)         { $queryParams['limit']      = $Limit }
-        if ($TotalOnly)            { $queryParams['total_only'] = 'true' }
+        Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
         if ($Destroyed)            { $queryParams['destroyed']  = 'true' }
 
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'realms' -QueryParams $queryParams -AutoPaginate

--- a/Public/Replication/Get-PfbFileSystemReplicaLinkTransfer.ps1
+++ b/Public/Replication/Get-PfbFileSystemReplicaLinkTransfer.ps1
@@ -70,12 +70,7 @@ function Get-PfbFileSystemReplicaLinkTransfer {
 
     end {
         $queryParams = @{}
-        if ($allNames.Count -gt 0) { $queryParams['names']      = $allNames -join ',' }
-        if ($allIds.Count -gt 0)   { $queryParams['ids']        = $allIds -join ',' }
-        if ($Filter)               { $queryParams['filter']     = $Filter }
-        if ($Sort)                 { $queryParams['sort']       = $Sort }
-        if ($Limit -gt 0)         { $queryParams['limit']      = $Limit }
-        if ($TotalOnly)            { $queryParams['total_only'] = 'true' }
+        Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
 
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'file-system-replica-links/transfer' -QueryParams $queryParams -AutoPaginate
     }

--- a/Public/Server/Get-PfbServer.ps1
+++ b/Public/Server/Get-PfbServer.ps1
@@ -73,12 +73,7 @@ function Get-PfbServer {
 
     end {
         $queryParams = @{}
-        if ($allNames.Count -gt 0) { $queryParams['names']      = $allNames -join ',' }
-        if ($allIds.Count -gt 0)   { $queryParams['ids']        = $allIds -join ',' }
-        if ($Filter)               { $queryParams['filter']     = $Filter }
-        if ($Sort)                 { $queryParams['sort']       = $Sort }
-        if ($Limit -gt 0)         { $queryParams['limit']      = $Limit }
-        if ($TotalOnly)            { $queryParams['total_only'] = 'true' }
+        Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
 
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'servers' -QueryParams $queryParams -AutoPaginate
     }

--- a/Tests/Add-PfbCommonQueryParams.Tests.ps1
+++ b/Tests/Add-PfbCommonQueryParams.Tests.ps1
@@ -1,0 +1,329 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    Import-Module "$PSScriptRoot/../PureStorageFlashBladePowerShell.psd1" -Force
+}
+
+Describe 'Add-PfbCommonQueryParams' {
+    Context 'Filter parameter' {
+        It 'adds Filter to $Into when present in BoundParameters' {
+            InModuleScope PureStorageFlashBladePowerShell -Parameters @{
+                Into = @{}
+                BoundParameters = @{ Filter = 'name=~foo' }
+            } {
+                param($Into, $BoundParameters)
+                Add-PfbCommonQueryParams -Into $Into -BoundParameters $BoundParameters
+                $Into.ContainsKey('filter') | Should -BeTrue
+                $Into['filter'] | Should -Be 'name=~foo'
+            }
+        }
+
+        It 'does not add Filter to $Into when absent from BoundParameters' {
+            InModuleScope PureStorageFlashBladePowerShell -Parameters @{
+                Into = @{}
+                BoundParameters = @{}
+            } {
+                param($Into, $BoundParameters)
+                Add-PfbCommonQueryParams -Into $Into -BoundParameters $BoundParameters
+                $Into.ContainsKey('filter') | Should -BeFalse
+            }
+        }
+
+        It 'adds empty-string Filter when explicitly passed' {
+            InModuleScope PureStorageFlashBladePowerShell -Parameters @{
+                Into = @{}
+                BoundParameters = @{ Filter = '' }
+            } {
+                param($Into, $BoundParameters)
+                Add-PfbCommonQueryParams -Into $Into -BoundParameters $BoundParameters
+                $Into.ContainsKey('filter') | Should -BeTrue
+                $Into['filter'] | Should -Be ''
+            }
+        }
+    }
+
+    Context 'Sort parameter' {
+        It 'adds Sort to $Into when present in BoundParameters' {
+            InModuleScope PureStorageFlashBladePowerShell -Parameters @{
+                Into = @{}
+                BoundParameters = @{ Sort = 'name' }
+            } {
+                param($Into, $BoundParameters)
+                Add-PfbCommonQueryParams -Into $Into -BoundParameters $BoundParameters
+                $Into.ContainsKey('sort') | Should -BeTrue
+                $Into['sort'] | Should -Be 'name'
+            }
+        }
+
+        It 'does not add Sort to $Into when absent from BoundParameters' {
+            InModuleScope PureStorageFlashBladePowerShell -Parameters @{
+                Into = @{}
+                BoundParameters = @{}
+            } {
+                param($Into, $BoundParameters)
+                Add-PfbCommonQueryParams -Into $Into -BoundParameters $BoundParameters
+                $Into.ContainsKey('sort') | Should -BeFalse
+            }
+        }
+    }
+
+    Context 'Limit parameter' {
+        It 'adds Limit to $Into when present in BoundParameters' {
+            InModuleScope PureStorageFlashBladePowerShell -Parameters @{
+                Into = @{}
+                BoundParameters = @{ Limit = 100 }
+            } {
+                param($Into, $BoundParameters)
+                Add-PfbCommonQueryParams -Into $Into -BoundParameters $BoundParameters
+                $Into.ContainsKey('limit') | Should -BeTrue
+                $Into['limit'] | Should -Be 100
+            }
+        }
+
+        It 'does not add Limit to $Into when absent from BoundParameters' {
+            InModuleScope PureStorageFlashBladePowerShell -Parameters @{
+                Into = @{}
+                BoundParameters = @{}
+            } {
+                param($Into, $BoundParameters)
+                Add-PfbCommonQueryParams -Into $Into -BoundParameters $BoundParameters
+                $Into.ContainsKey('limit') | Should -BeFalse
+            }
+        }
+
+        It 'adds Limit 0 when explicitly passed (proves ContainsKey semantics, not truthiness)' {
+            InModuleScope PureStorageFlashBladePowerShell -Parameters @{
+                Into = @{}
+                BoundParameters = @{ Limit = 0 }
+            } {
+                param($Into, $BoundParameters)
+                Add-PfbCommonQueryParams -Into $Into -BoundParameters $BoundParameters
+                $Into.ContainsKey('limit') | Should -BeTrue
+                $Into['limit'] | Should -Be 0
+            }
+        }
+    }
+
+    Context 'TotalOnly parameter' {
+        It 'adds total_only = true to $Into when TotalOnly is present in BoundParameters' {
+            InModuleScope PureStorageFlashBladePowerShell -Parameters @{
+                Into = @{}
+                BoundParameters = @{ TotalOnly = $true }
+            } {
+                param($Into, $BoundParameters)
+                Add-PfbCommonQueryParams -Into $Into -BoundParameters $BoundParameters
+                $Into.ContainsKey('total_only') | Should -BeTrue
+                $Into['total_only'] | Should -Be 'true'
+            }
+        }
+
+        It 'does not add total_only to $Into when TotalOnly is absent from BoundParameters' {
+            InModuleScope PureStorageFlashBladePowerShell -Parameters @{
+                Into = @{}
+                BoundParameters = @{}
+            } {
+                param($Into, $BoundParameters)
+                Add-PfbCommonQueryParams -Into $Into -BoundParameters $BoundParameters
+                $Into.ContainsKey('total_only') | Should -BeFalse
+            }
+        }
+    }
+
+    Context 'Names parameter' {
+        It 'adds names joined by comma when Names are provided' {
+            InModuleScope PureStorageFlashBladePowerShell -Parameters @{
+                Into = @{}
+                BoundParameters = @{}
+                Names = @('fs1', 'fs2', 'fs3')
+            } {
+                param($Into, $BoundParameters, $Names)
+                Add-PfbCommonQueryParams -Into $Into -BoundParameters $BoundParameters -Names $Names
+                $Into.ContainsKey('names') | Should -BeTrue
+                $Into['names'] | Should -Be 'fs1,fs2,fs3'
+            }
+        }
+
+        It 'does not add names when Names are not provided' {
+            InModuleScope PureStorageFlashBladePowerShell -Parameters @{
+                Into = @{}
+                BoundParameters = @{}
+            } {
+                param($Into, $BoundParameters)
+                Add-PfbCommonQueryParams -Into $Into -BoundParameters $BoundParameters
+                $Into.ContainsKey('names') | Should -BeFalse
+            }
+        }
+
+        It 'does not add names when Names is an empty array' {
+            InModuleScope PureStorageFlashBladePowerShell -Parameters @{
+                Into = @{}
+                BoundParameters = @{}
+                Names = @()
+            } {
+                param($Into, $BoundParameters, $Names)
+                Add-PfbCommonQueryParams -Into $Into -BoundParameters $BoundParameters -Names $Names
+                $Into.ContainsKey('names') | Should -BeFalse
+            }
+        }
+
+        It 'adds single Name when only one is provided' {
+            InModuleScope PureStorageFlashBladePowerShell -Parameters @{
+                Into = @{}
+                BoundParameters = @{}
+                Names = @('fs1')
+            } {
+                param($Into, $BoundParameters, $Names)
+                Add-PfbCommonQueryParams -Into $Into -BoundParameters $BoundParameters -Names $Names
+                $Into.ContainsKey('names') | Should -BeTrue
+                $Into['names'] | Should -Be 'fs1'
+            }
+        }
+    }
+
+    Context 'Ids parameter' {
+        It 'adds ids joined by comma when Ids are provided' {
+            InModuleScope PureStorageFlashBladePowerShell -Parameters @{
+                Into = @{}
+                BoundParameters = @{}
+                Ids = @('id1', 'id2', 'id3')
+            } {
+                param($Into, $BoundParameters, $Ids)
+                Add-PfbCommonQueryParams -Into $Into -BoundParameters $BoundParameters -Ids $Ids
+                $Into.ContainsKey('ids') | Should -BeTrue
+                $Into['ids'] | Should -Be 'id1,id2,id3'
+            }
+        }
+
+        It 'does not add ids when Ids are not provided' {
+            InModuleScope PureStorageFlashBladePowerShell -Parameters @{
+                Into = @{}
+                BoundParameters = @{}
+            } {
+                param($Into, $BoundParameters)
+                Add-PfbCommonQueryParams -Into $Into -BoundParameters $BoundParameters
+                $Into.ContainsKey('ids') | Should -BeFalse
+            }
+        }
+
+        It 'does not add ids when Ids is an empty array' {
+            InModuleScope PureStorageFlashBladePowerShell -Parameters @{
+                Into = @{}
+                BoundParameters = @{}
+                Ids = @()
+            } {
+                param($Into, $BoundParameters, $Ids)
+                Add-PfbCommonQueryParams -Into $Into -BoundParameters $BoundParameters -Ids $Ids
+                $Into.ContainsKey('ids') | Should -BeFalse
+            }
+        }
+
+        It 'adds single Id when only one is provided' {
+            InModuleScope PureStorageFlashBladePowerShell -Parameters @{
+                Into = @{}
+                BoundParameters = @{}
+                Ids = @('id1')
+            } {
+                param($Into, $BoundParameters, $Ids)
+                Add-PfbCommonQueryParams -Into $Into -BoundParameters $BoundParameters -Ids $Ids
+                $Into.ContainsKey('ids') | Should -BeTrue
+                $Into['ids'] | Should -Be 'id1'
+            }
+        }
+    }
+
+    Context 'Names and Ids independence' {
+        It 'adds only Names when only Names are provided' {
+            InModuleScope PureStorageFlashBladePowerShell -Parameters @{
+                Into = @{}
+                BoundParameters = @{}
+                Names = @('fs1', 'fs2')
+            } {
+                param($Into, $BoundParameters, $Names)
+                Add-PfbCommonQueryParams -Into $Into -BoundParameters $BoundParameters -Names $Names
+                $Into.ContainsKey('names') | Should -BeTrue
+                $Into['names'] | Should -Be 'fs1,fs2'
+                $Into.ContainsKey('ids') | Should -BeFalse
+            }
+        }
+
+        It 'adds only Ids when only Ids are provided' {
+            InModuleScope PureStorageFlashBladePowerShell -Parameters @{
+                Into = @{}
+                BoundParameters = @{}
+                Ids = @('id1', 'id2')
+            } {
+                param($Into, $BoundParameters, $Ids)
+                Add-PfbCommonQueryParams -Into $Into -BoundParameters $BoundParameters -Ids $Ids
+                $Into.ContainsKey('ids') | Should -BeTrue
+                $Into['ids'] | Should -Be 'id1,id2'
+                $Into.ContainsKey('names') | Should -BeFalse
+            }
+        }
+
+        It 'adds both Names and Ids when both are provided' {
+            InModuleScope PureStorageFlashBladePowerShell -Parameters @{
+                Into = @{}
+                BoundParameters = @{}
+                Names = @('fs1', 'fs2')
+                Ids = @('id1', 'id2')
+            } {
+                param($Into, $BoundParameters, $Names, $Ids)
+                Add-PfbCommonQueryParams -Into $Into -BoundParameters $BoundParameters -Names $Names -Ids $Ids
+                $Into.ContainsKey('names') | Should -BeTrue
+                $Into['names'] | Should -Be 'fs1,fs2'
+                $Into.ContainsKey('ids') | Should -BeTrue
+                $Into['ids'] | Should -Be 'id1,id2'
+            }
+        }
+    }
+
+    Context 'In-place mutation' {
+        It 'mutates the $Into hashtable in place' {
+            InModuleScope PureStorageFlashBladePowerShell -Parameters @{
+                Into = @{ existing_key = 'existing_value' }
+                BoundParameters = @{ Filter = 'test'; Limit = 50 }
+                Names = @('name1')
+            } {
+                param($Into, $BoundParameters, $Names)
+                Add-PfbCommonQueryParams -Into $Into -BoundParameters $BoundParameters -Names $Names
+                # Verify original key is still there
+                $Into['existing_key'] | Should -Be 'existing_value'
+                # Verify new keys were added
+                $Into['filter'] | Should -Be 'test'
+                $Into['limit'] | Should -Be 50
+                $Into['names'] | Should -Be 'name1'
+            }
+        }
+
+        It 'function returns nothing (hashtable is mutated, not returned)' {
+            InModuleScope PureStorageFlashBladePowerShell -Parameters @{
+                Into = @{}
+                BoundParameters = @{ Filter = 'test' }
+            } {
+                param($Into, $BoundParameters)
+                $result = Add-PfbCommonQueryParams -Into $Into -BoundParameters $BoundParameters
+                $result | Should -BeNullOrEmpty
+            }
+        }
+    }
+
+    Context 'All parameters together' {
+        It 'handles all four scalar parameters and both array parameters in one call' {
+            InModuleScope PureStorageFlashBladePowerShell -Parameters @{
+                Into = @{}
+                BoundParameters = @{ Filter = 'name=test'; Sort = 'name'; Limit = 25; TotalOnly = $true }
+                Names = @('fs1', 'fs2')
+                Ids = @('id1')
+            } {
+                param($Into, $BoundParameters, $Names, $Ids)
+                Add-PfbCommonQueryParams -Into $Into -BoundParameters $BoundParameters -Names $Names -Ids $Ids
+                $Into['filter'] | Should -Be 'name=test'
+                $Into['sort'] | Should -Be 'name'
+                $Into['limit'] | Should -Be 25
+                $Into['total_only'] | Should -Be 'true'
+                $Into['names'] | Should -Be 'fs1,fs2'
+                $Into['ids'] | Should -Be 'id1'
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #32. 30 `Get-Pfb*` cmdlets each hand-rolled an identical block mapping
`-Filter`/`-Sort`/`-Limit`/`-TotalOnly` (and, where applicable, accumulated
`-Name`/`-Id` pipeline input) onto the `$queryParams` hashtable passed to
`Invoke-PfbApiRequest`. This adds one shared private helper and migrates all
30 cmdlets onto it — pure internal refactor, no public parameter/behavior
change intended beyond one deliberate fix noted below.

**New helper:** `Private/Add-PfbCommonQueryParams.ps1`, with 24 Pester tests
covering each scalar independently, `-Names`/`-Ids` joining, and in-place
hashtable mutation.

**Migrated (30 cmdlets, in 7 batches):** Bucket (3) · FileSystem (9) ·
FileSystemSnapshot/Replication (3) · ObjectStore (15) · Realm · Server.

**Intentional behavior change:** the helper checks `.ContainsKey()` on the
four scalars instead of truthiness, so an explicit `-Limit 0` is now sent to
the API where the old per-cmdlet `if ($Limit -gt 0)` guard silently dropped
it. (An empty-string `-Filter ''` is unaffected in practice — `ConvertTo-PfbQueryString`
already strips null/empty values before they reach the wire.)

**Wire-key handling:** several cmdlets map their Name/Id-equivalent params to
non-generic wire keys (`file_system_names`/`ids`, `policy_names`/`ids`,
`role_names`/`ids`, `member_names`/`ids`) instead of the helper's generic
`names`/`ids`. Those are left as the cmdlet's own untouched lines rather than
being routed through the helper, so the actual wire format sent to the array
is unchanged. One cmdlet (`Get-PfbObjectStoreAccessPolicyRule`) mixes both —
handled by passing only the generic-keyed param through the helper.

**Out of scope (follow-up candidate):** ~55 other `Get-Pfb*` cmdlets without
a `-TotalOnly` param still hand-roll `filter`/`sort`/`limit` and weren't
touched here, per the issue's own scoping.

## Test plan

- [x] New unit tests for `Add-PfbCommonQueryParams` (24/24 passing)
- [x] Full existing suite green throughout (404 passed / 0 failed / 6 skipped, unchanged)
- [x] Existing dedicated tests that intersect this refactor pass unmodified:
      `Get-PfbFileSystemSession.Tests.ps1`, `ObjectStoreAccessPolicyAssociations.Tests.ps1`
- [x] Live-verified against a real FlashBlade array (FB-A) after every batch —
      confirmed correct query strings for `-Limit`/`-Sort`/`-Filter`/`-TotalOnly`
      and every non-generic/mixed wire-key case
- [x] Completeness sweep: all 30 originally-identified cmdlets confirmed to
      call the helper, zero leftover hand-rolled `total_only` assignments

## Notes

Live-testing incidentally reproduced the `-Limit`/`AutoPaginate` pagination
bug already tracked and fixed by #30 (PR #48, still open) — no file overlap
with that PR, confirmed no conflict either way this merges.