### PR TITLE
Fix Get-PfbSsotVersionMapUri hanging on missing mandatory params

### DIFF
--- a/tools/lib/PfbVersionMapTools.ps1
+++ b/tools/lib/PfbVersionMapTools.ps1
@@ -26,14 +26,20 @@ function Get-PfbSsotVersionMapUri {
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory)]
-        [ValidateNotNullOrEmpty()]
+        [Parameter()]
         [string]$BaseUri,
 
-        [Parameter(Mandatory)]
-        [ValidateNotNullOrEmpty()]
+        [Parameter()]
         [string]$TopicId
     )
+
+    # Deliberately not [Parameter(Mandatory)]: PowerShell's mandatory-parameter binder
+    # prompts interactively for a missing value when the host supports it (a real
+    # console), rather than throwing - which would hang a script or corrupt a terminal
+    # session instead of failing fast. Explicit checks guarantee a deterministic throw
+    # in every host.
+    if ([string]::IsNullOrEmpty($BaseUri)) { throw [System.Management.Automation.PSArgumentException]::new('BaseUri is required.', 'BaseUri') }
+    if ([string]::IsNullOrEmpty($TopicId)) { throw [System.Management.Automation.PSArgumentException]::new('TopicId is required.', 'TopicId') }
 
     return "$BaseUri/v1/topics/$TopicId/content"
 }


### PR DESCRIPTION
## Summary
- `Get-PfbSsotVersionMapUri` (in `tools/lib/PfbVersionMapTools.ps1`) declared
  `-BaseUri`/`-TopicId` as `[Parameter(Mandatory)]`. When run in a real
  interactive PowerShell host, a missing mandatory parameter doesn't throw —
  it prompts interactively for the value instead, which hangs the terminal
  rather than failing fast. Non-interactive hosts (most CI runners) throw
  immediately, so this was invisible until run by hand.
- Replaces the two params with plain optional params plus explicit
  `IsNullOrEmpty` checks that throw a deterministic
  `PSArgumentException` in every host, interactive or not.
- Found incidentally while live-testing an unrelated PR (#33's query-param
  migration) locally — not connected to that work otherwise.

## Test plan
- [x] `Tests/PfbVersionMapTools.Tests.ps1`'s existing "requires -BaseUri" /
      "requires -TopicId" assertions still pass unchanged (10/10)
- [x] Confirmed no more interactive prompt when calling the cmdlet without
      a required param in a real console session
- [x] `tools/Update-PfbVersionMap.ps1` (the only caller) always passes both
      params explicitly, so behavior for it is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)