### PR TITLE
test(drift-report): replace pinned acceptance-figure literals with drift-proof invariants

### DIFF
--- a/Tests/Build-PfbApiDriftReport.Tests.ps1
+++ b/Tests/Build-PfbApiDriftReport.Tests.ps1
@@ -496,10 +496,25 @@ Describe 'Build-PfbApiDriftReport (real generated artifacts, skips gracefully if
         }
     }
 
-    It 'Task 7: wires conventionStrength through with the pinned acceptance figures (names 306, ids 218, context_names 0)' {
+    It 'Task 7: wires conventionStrength through -- cmdletCount is internally consistent and non-vacuous for established conventions, and remains 0 for context_names by design' {
         if (-not $hasRealArtifacts) { Set-ItResult -Skipped -Because 'real artifacts not present locally'; return }
-        ($realManifest.conventionStrength | Where-Object { $_.name -eq 'names' }).cmdletCount | Should -Be 306
-        ($realManifest.conventionStrength | Where-Object { $_.name -eq 'ids' }).cmdletCount | Should -Be 218
+
+        foreach ($fieldName in @('names', 'ids')) {
+            $entry = $realManifest.conventionStrength | Where-Object { $_.name -eq $fieldName }
+            $entry | Should -Not -BeNullOrEmpty -Because "$fieldName is expected to still be a systemic gap with an established convention"
+            # cmdletCount and cmdlets.Count are set from the same value at generation time
+            # (tools/Build-PfbApiDriftReport.ps1's `cmdletCount = $_.CmdletCount`) but travel
+            # through JSON serialization separately -- this catches a stale/mismatched field
+            # surviving a future refactor, without caring how many cmdlets there actually are.
+            $entry.cmdletCount | Should -Be @($entry.cmdlets).Count -Because 'cmdletCount must match the actual cmdlets array length after JSON round-trip'
+            $entry.cmdletCount | Should -BeGreaterThan 0 -Because "$fieldName is a widely-adopted convention; a drop to zero would be a real regression worth failing loudly for"
+        }
+
+        # context_names is the ONE name this report expects to have NO adopting cmdlets --
+        # Get-PfbConventionStrength's own docstring: "that zero IS the finding for names like
+        # context_names". This is an architectural fact (see the Fusion context_names design
+        # conclusion), not a live-count regression canary -- it stays an exact pin
+        # deliberately, unlike names/ids above.
         ($realManifest.conventionStrength | Where-Object { $_.name -eq 'context_names' }).cmdletCount | Should -Be 0
     }
 

--- a/Tests/Build-PfbApiDriftReport.Tests.ps1
+++ b/Tests/Build-PfbApiDriftReport.Tests.ps1
@@ -729,7 +729,7 @@ Describe 'Build-PfbApiDriftReport (Task 8: regression canaries + spot-checks aga
             $t8PhantomExcludedSet.Count | Should -Be $t8Manifest.phantomFieldCount
         }
 
-        It 'restricting the same diff to high-confidence-only gaps reproduces the doc-comment-pinned 13' {
+        It 'restricting the same diff to high-confidence-only gaps still yields a non-vacuous phantom-exclusion set' {
             if (-not $t8HasRealArtifacts) { Set-ItResult -Skipped -Because 'real artifacts not present locally'; return }
             $populationHigh = @($t8PopulationRaw | Where-Object { $_.Confidence.Level -eq 'high' })
             $reportedHigh = @($t8ReportedRaw | Where-Object { $_.Confidence.Level -eq 'high' })
@@ -737,7 +737,14 @@ Describe 'Build-PfbApiDriftReport (Task 8: regression canaries + spot-checks aga
             $reportedHighSet = Get-T8TripleSet -Gaps $reportedHigh
             $phantomHighSet = [System.Collections.Generic.HashSet[string]]::new([string[]]@($populationHighSet))
             $phantomHighSet.ExceptWith([string[]]@($reportedHighSet))
-            $phantomHighSet.Count | Should -Be 13
+            # No independent recount is available here (unlike phantomFieldCount above, which
+            # self-consistency-checks against the manifest) -- so this can only assert
+            # non-vacuousness. The doc-comment example this used to pin against
+            # (tools/lib/PfbApiDriftTools.ps1's Get-PfbParameterCoverageGaps: "13 real
+            # (endpoint, field) pairs hit this against fb2.27 today") is illustrative prose,
+            # not a contract; pinning a test to that exact number reproduced the same
+            # live-data-literal anti-pattern this whole effort exists to remove.
+            $phantomHighSet.Count | Should -BeGreaterThan 0 -Because 'a vacuous/zero count would mean high-confidence phantom-field exclusion silently stopped happening without anyone noticing here'
         }
 
         It 'the in-memory reported set matches the real committed Reports/PfbApiDriftReport.json on disk exactly (no serialization-only divergence)' {

--- a/Tests/Build-PfbApiDriftReport.Tests.ps1
+++ b/Tests/Build-PfbApiDriftReport.Tests.ps1
@@ -506,6 +506,10 @@ Describe 'Build-PfbApiDriftReport (real generated artifacts, skips gracefully if
             # (tools/Build-PfbApiDriftReport.ps1's `cmdletCount = $_.CmdletCount`) but travel
             # through JSON serialization separately -- this catches a stale/mismatched field
             # surviving a future refactor, without caring how many cmdlets there actually are.
+            # The property-existence check guards against @($null).Count being 1 in
+            # PowerShell -- without it, a `cmdlets` property that vanished entirely from the
+            # manifest would be indistinguishable from one holding exactly one cmdlet.
+            $entry.PSObject.Properties.Name | Should -Contain 'cmdlets' -Because 'the cmdlets property must actually be present to compare its Count against cmdletCount'
             $entry.cmdletCount | Should -Be @($entry.cmdlets).Count -Because 'cmdletCount must match the actual cmdlets array length after JSON round-trip'
             $entry.cmdletCount | Should -BeGreaterThan 0 -Because "$fieldName is a widely-adopted convention; a drop to zero would be a real regression worth failing loudly for"
         }

--- a/Tests/Build-PfbApiDriftReport.Tests.ps1
+++ b/Tests/Build-PfbApiDriftReport.Tests.ps1
@@ -786,7 +786,7 @@ function Get-PfbFixtureAlpha {
         # hatch) -- exercises the Markdown confidence marker/footnote wiring on a fixture
         # this task fully controls. It also misses 'shared_gap', but Get-PfbSystemicGaps
         # is aggregated ONLY over 'high'-confidence gaps (this task's own precedent, same
-        # as the real 253/109 acceptance figures), so Beta must NOT count towards
+        # as the real systemic-gaps invariants' high-confidence-only filtering), so Beta must NOT count towards
         # 'shared_gap's systemic EndpointCount below -- Gamma (high-confidence) is the
         # fixture's second contributor to that finding instead.
         Set-Content -Path (Join-Path $t7PublicDir 'Get-PfbFixtureBeta.ps1') -Value @'

--- a/Tests/Build-PfbApiDriftReport.Tests.ps1
+++ b/Tests/Build-PfbApiDriftReport.Tests.ps1
@@ -724,10 +724,9 @@ Describe 'Build-PfbApiDriftReport (Task 8: regression canaries + spot-checks aga
             $overlap.Count | Should -Be 0
         }
 
-        It 'the phantom-excluded count matches the real manifest''s phantomFieldCount exactly (34, full population)' {
+        It 'the phantom-excluded count matches the real manifest''s phantomFieldCount exactly (self-consistent, full population)' {
             if (-not $t8HasRealArtifacts) { Set-ItResult -Skipped -Because 'real artifacts not present locally'; return }
             $t8PhantomExcludedSet.Count | Should -Be $t8Manifest.phantomFieldCount
-            $t8PhantomExcludedSet.Count | Should -Be 34
         }
 
         It 'restricting the same diff to high-confidence-only gaps reproduces the doc-comment-pinned 13' {

--- a/Tests/Build-PfbApiDriftReport.Tests.ps1
+++ b/Tests/Build-PfbApiDriftReport.Tests.ps1
@@ -406,6 +406,19 @@ Describe 'Build-PfbApiDriftReport (real generated artifacts, skips gracefully if
                 -OutputPath $realOutput -ReportPath $realReport
             $script:realManifest = Get-Content -Path $realOutput -Raw | ConvertFrom-Json -Depth 20
             $script:realCapMapForCheck = Get-Content -Path $realCapabilityMapPath -Raw | ConvertFrom-Json -Depth 20
+
+            function Get-RealRecountedEndpointCount {
+                param([Parameter(Mandatory)][object[]]$Gaps, [Parameter(Mandatory)][string]$FieldName)
+                $endpoints = [System.Collections.Generic.HashSet[string]]::new()
+                foreach ($g in $Gaps) {
+                    $queryNames = @($g.missingQueryParameters)
+                    $bodyNames = @($g.missingBodyProperties | ForEach-Object { if ($_ -is [string]) { $_ } else { $_.name } })
+                    if (($queryNames -contains $FieldName) -or ($bodyNames -contains $FieldName)) {
+                        [void]$endpoints.Add($g.endpoint)
+                    }
+                }
+                return $endpoints.Count
+            }
         }
     }
 
@@ -463,10 +476,24 @@ Describe 'Build-PfbApiDriftReport (real generated artifacts, skips gracefully if
         Test-Path $realOutput | Should -BeTrue
     }
 
-    It 'Task 7: wires systemicGaps through with the pinned acceptance figures (context_names 253, allow_errors 109)' {
+    It 'Task 7: wires systemicGaps through -- endpointCount for context_names/allow_errors matches an independent recount straight from parameterGaps' {
         if (-not $hasRealArtifacts) { Set-ItResult -Skipped -Because 'real artifacts not present locally'; return }
-        ($realManifest.systemicGaps | Where-Object { $_.name -eq 'context_names' }).endpointCount | Should -Be 253
-        ($realManifest.systemicGaps | Where-Object { $_.name -eq 'allow_errors' }).endpointCount | Should -Be 109
+
+        # Recomputes endpointCount from the manifest's own high-confidence parameterGaps,
+        # completely independently of Get-PfbSystemicGaps' internal aggregation. Deliberately
+        # does NOT hardcode the real API surface's current size: the assertion is "the
+        # summary field matches a fresh tally of the detail rows", which stays true forever,
+        # rather than "the detail rows currently total exactly N", which breaks the instant
+        # an unrelated PR adds or removes one endpoint missing context_names/allow_errors.
+        # See docs/superpowers/plans/2026-07-30-drift-report-acceptance-figure-invariants.md.
+        $highConfidenceGaps = @($realManifest.parameterGaps | Where-Object { $_.confidence.level -eq 'high' })
+        foreach ($fieldName in @('context_names', 'allow_errors')) {
+            $finding = $realManifest.systemicGaps | Where-Object { $_.name -eq $fieldName }
+            $finding | Should -Not -BeNullOrEmpty -Because "$fieldName is expected to still be a systemic gap in the real API surface"
+            $recount = Get-RealRecountedEndpointCount -Gaps $highConfidenceGaps -FieldName $fieldName
+            $finding.endpointCount | Should -Be $recount -Because 'endpointCount must equal a fresh tally over parameterGaps, independent of the total endpoint count'
+            $finding.endpointCount | Should -BeGreaterThan 0 -Because 'a vacuous/zero count would mean the field silently stopped being a systemic gap without anyone noticing here'
+        }
     }
 
     It 'Task 7: wires conventionStrength through with the pinned acceptance figures (names 306, ids 218, context_names 0)' {

--- a/Tests/PfbApiDriftTools.Tests.ps1
+++ b/Tests/PfbApiDriftTools.Tests.ps1
@@ -1227,8 +1227,9 @@ Describe 'Task 6 real-data invariants (systemic gaps + convention strength, skip
             # Mirrors tools/Build-PfbApiDriftReport.ps1's own construction exactly (same
             # -CurrentSpecCapabilities phantom-field filtering, same -ExcludedFields via
             # Get-PfbNonActionableParameters) -- Get-PfbSystemicGaps must be fed the SAME
-            # gaps the real report actually emits, not a looser, unfiltered set, or its
-            # acceptance figures will not reproduce.
+            # gaps the real report actually emits, not a looser, unfiltered set, or the
+            # invariants below would no longer reflect the filtering the production report
+            # actually applies.
             . (Join-Path $repoRoot 'tools/lib/PfbSpecTools.ps1')
 
             $script:realCapMap2 = Get-Content -Path $realCapabilityMapPath2 -Raw | ConvertFrom-Json -Depth 20

--- a/Tests/PfbApiDriftTools.Tests.ps1
+++ b/Tests/PfbApiDriftTools.Tests.ps1
@@ -1295,11 +1295,20 @@ Describe 'Task 6 real-data invariants (systemic gaps + convention strength, skip
         }
     }
 
-    It 'convention strength: names = 306, ids = 218, context_names = 0 (acceptance figures)' {
+    It 'convention strength: names/ids have a non-vacuous, established convention; context_names has none (0 cmdlets, by design)' {
         if (-not $hasRealData) { Set-ItResult -Skipped -Because 'Data/PfbCapabilityMap.json not present locally'; return }
         $strength = Get-PfbConventionStrength -CmdletInventory $realInventory2 -Names @('names', 'ids', 'context_names')
-        ($strength | Where-Object { $_.Name -eq 'names' }).CmdletCount | Should -Be 306
-        ($strength | Where-Object { $_.Name -eq 'ids' }).CmdletCount | Should -Be 218
+        foreach ($fieldName in @('names', 'ids')) {
+            $entry = $strength | Where-Object { $_.Name -eq $fieldName }
+            $entry | Should -Not -BeNullOrEmpty
+            # CmdletCount is asserted -BeGreaterThan 0, not an exact number: both grow every
+            # time an unrelated PR adds a cmdlet that happens to expose this wire name as a
+            # Typed parameter, which is neither a regression nor something worth re-pinning for.
+            $entry.CmdletCount | Should -BeGreaterThan 0 -Because "$fieldName is a widely-adopted convention; a drop to zero would be a real regression"
+        }
+        # context_names is the ONE name Get-PfbConventionStrength's own docstring calls out
+        # as an architectural fact, not a live count: "that zero IS the finding". Unlike
+        # names/ids above, this stays an exact pin deliberately.
         ($strength | Where-Object { $_.Name -eq 'context_names' }).CmdletCount | Should -Be 0
     }
 

--- a/Tests/PfbApiDriftTools.Tests.ps1
+++ b/Tests/PfbApiDriftTools.Tests.ps1
@@ -1313,7 +1313,7 @@ Describe 'Task 6 real-data invariants (systemic gaps + convention strength, skip
         ($strength | Where-Object { $_.Name -eq 'context_names' }).CmdletCount | Should -Be 0
     }
 
-    It 'the top-10 most-common field names absorb roughly 41.7% of total missing-field (endpoint, name) pairs' {
+    It 'the top-10 most-common field names absorb between 30% and 55% of total missing-field (endpoint, name) pairs' {
         if (-not $hasRealData) { Set-ItResult -Skipped -Because 'Data/PfbCapabilityMap.json not present locally'; return }
         $pairCounts = $realSystemicGaps2 | ForEach-Object { $_.QueryEndpointCount + $_.BodyEndpointCount }
         $totalPairs = ($pairCounts | Measure-Object -Sum).Sum
@@ -1322,8 +1322,10 @@ Describe 'Task 6 real-data invariants (systemic gaps + convention strength, skip
         $ratio = $top10Sum / $totalPairs
         Write-Host "Task 6 real-data verification: top-10 aggregation ratio = $top10Sum / $totalPairs = $([Math]::Round($ratio * 100, 2))%"
         # Not bit-for-bit pinned (Task 4/5 changed some list membership per this task's own
-        # brief) -- just confirms the aggregation actually matters, close to the
-        # independently-measured ~41.7%/642 figure.
+        # brief) -- just confirms the aggregation actually matters. Historical note: the
+        # independently-measured ratio AT THE TIME these bounds were chosen was ~41.7%
+        # (576/1302 pairs); kept here as institutional memory for why 30%/55% were picked,
+        # not as an expectation this should still measure exactly that today.
         $ratio | Should -BeGreaterThan 0.30
         $ratio | Should -BeLessThan 0.55
     }

--- a/Tests/PfbApiDriftTools.Tests.ps1
+++ b/Tests/PfbApiDriftTools.Tests.ps1
@@ -1215,7 +1215,7 @@ Describe 'Central-injection detection against the REAL Private/ tree (confirms t
     }
 }
 
-Describe 'Task 6 real-data acceptance figures (systemic gaps + convention strength, skips gracefully if the real capability map is absent)' -Skip:($PSVersionTable.PSVersion.Major -lt 7) {
+Describe 'Task 6 real-data invariants (systemic gaps + convention strength, skips gracefully if the real capability map is absent)' -Skip:($PSVersionTable.PSVersion.Major -lt 7) {
     BeforeAll {
         $script:realCapabilityMapPath2 = Join-Path $repoRoot 'Data/PfbCapabilityMap.json'
         $script:realPublicDirectory2 = Join-Path $repoRoot 'Public'
@@ -1258,24 +1258,41 @@ Describe 'Task 6 real-data acceptance figures (systemic gaps + convention streng
             # warns against. Get-PfbSystemicGaps/Get-PfbConventionStrength themselves are
             # confidence-agnostic by design (aggregation is a pure grouping over WHATEVER
             # gaps they're handed) -- filtering by confidence is the CALLER's decision, made
-            # explicitly here to reproduce this task's pinned acceptance figures.
+            # explicitly here to match tools/Build-PfbApiDriftReport.ps1's own filtering exactly.
             $script:realGaps2 = @($realGapsAllConfidence2 | Where-Object { $_.Confidence.Level -eq 'high' })
             $script:realSystemicGaps2 = @(Get-PfbSystemicGaps -Gaps $realGaps2)
+
+            function Get-RealRecountedEndpointCount2 {
+                param([Parameter(Mandatory)][object[]]$Gaps, [Parameter(Mandatory)][string]$FieldName)
+                $endpoints = [System.Collections.Generic.HashSet[string]]::new()
+                foreach ($g in $Gaps) {
+                    $queryNames = @($g.MissingQueryParameters)
+                    $bodyNames = @($g.MissingBodyProperties | ForEach-Object { if ($_ -is [string]) { $_ } else { $_.Name } })
+                    if (($queryNames -contains $FieldName) -or ($bodyNames -contains $FieldName)) {
+                        [void]$endpoints.Add($g.Endpoint)
+                    }
+                }
+                return $endpoints.Count
+            }
         }
     }
 
-    It 'shows allow_errors at 109 endpoints (systemic-gaps acceptance figure -- exact match)' {
+    # Historical note (Task 6 investigation): the task brief's corrected figure for
+    # context_names was 252; three independent methodological variants (with/without
+    # phantom-field filtering, with/without -ExcludedFields) all converged on 253 instead,
+    # and 252 could not be reproduced. 253 was the actual, honestly-measured, reproducible
+    # value AT THE TIME -- kept here as institutional memory, not as a hardcoded expectation.
+    # See docs/superpowers/plans/2026-07-30-drift-report-acceptance-figure-invariants.md for
+    # why exact real-data counts are the wrong assertion for an ever-growing API surface.
+    It 'systemic-gaps EndpointCount for allow_errors/context_names matches an independent recount straight from the same $realGaps2 fed to Get-PfbSystemicGaps' {
         if (-not $hasRealData) { Set-ItResult -Skipped -Because 'Data/PfbCapabilityMap.json not present locally'; return }
-        $finding = $realSystemicGaps2 | Where-Object { $_.Name -eq 'allow_errors' }
-        $finding | Should -Not -BeNullOrEmpty
-        $finding.EndpointCount | Should -Be 109
-    }
-
-    It 'shows context_names at 253 endpoints -- the task brief''s corrected figure says 252; investigated (3 independent methodological variants: with/without phantom-field filtering, with/without -ExcludedFields, all converge on 253) and could not reproduce 252 exactly, so this pins the actual, honestly-measured, reproducible value rather than force-matching a figure one endpoint stale' {
-        if (-not $hasRealData) { Set-ItResult -Skipped -Because 'Data/PfbCapabilityMap.json not present locally'; return }
-        $finding = $realSystemicGaps2 | Where-Object { $_.Name -eq 'context_names' }
-        $finding | Should -Not -BeNullOrEmpty
-        $finding.EndpointCount | Should -Be 253
+        foreach ($fieldName in @('allow_errors', 'context_names')) {
+            $finding = $realSystemicGaps2 | Where-Object { $_.Name -eq $fieldName }
+            $finding | Should -Not -BeNullOrEmpty -Because "$fieldName is expected to still be a systemic gap in the real API surface"
+            $recount = Get-RealRecountedEndpointCount2 -Gaps $realGaps2 -FieldName $fieldName
+            $finding.EndpointCount | Should -Be $recount -Because 'EndpointCount must equal a fresh tally over the same input gaps, independent of Get-PfbSystemicGaps'' own aggregation'
+            $finding.EndpointCount | Should -BeGreaterThan 0 -Because 'a vacuous/zero count would mean the field silently stopped being a systemic gap without anyone noticing here'
+        }
     }
 
     It 'convention strength: names = 306, ids = 218, context_names = 0 (acceptance figures)' {

--- a/tools/Build-PfbApiDriftReport.ps1
+++ b/tools/Build-PfbApiDriftReport.ps1
@@ -424,10 +424,11 @@ $parameterGaps = @($parameterGapsRaw | ForEach-Object {
 # can contain false positives (an unresolved parameter may already cover the apparent gap
 # through a path this AST-only inventory can't see -- see Get-PfbParameterCoverageGaps's
 # own Confidence.Caveat), so folding it into a systemic FINDING would overstate a
-# confidence the endpoint's own row already warns against. This mirrors the precedent this
-# task's own pinned acceptance figures (context_names 253 / allow_errors 109) were
-# verified against in Tests/PfbApiDriftTools.Tests.ps1's 'Task 6 real-data acceptance
-# figures' Describe block -- reproducing those figures here requires the same filter.
+# confidence the endpoint's own row already warns against. This mirrors the same
+# high-confidence-only filter Tests/PfbApiDriftTools.Tests.ps1's 'Task 6 real-data
+# invariants' Describe block applies before calling Get-PfbSystemicGaps, so the two stay
+# in sync -- that Describe block recounts EndpointCount independently rather than pinning
+# an exact figure (see docs/superpowers/plans/2026-07-30-drift-report-acceptance-figure-invariants.md).
 $highConfidenceGapsRaw = @($parameterGapsRaw | Where-Object { $_.Confidence.Level -eq 'high' })
 $systemicGapsRaw = @(Get-PfbSystemicGaps -Gaps $highConfidenceGapsRaw)
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -299,8 +299,8 @@ Run in this order:
    would overstate a confidence the endpoint's own row already warns against). Each finding is
    `{ name, endpointCount, queryEndpointCount, bodyEndpointCount, endpoints, annotations }` --
    turning hundreds of per-endpoint rows into a handful of real, actionable decisions: e.g.
-   `context_names` (253 endpoints) and `allow_errors` (109 endpoints) are two decisions, not 362
-   findings. `conventionStrength` then ranks each systemic-gap name by how many existing `Public/`
+   `context_names` and `allow_errors` are each one decision, not one finding per affected
+   endpoint. `conventionStrength` then ranks each systemic-gap name by how many existing `Public/`
    cmdlets already expose it as a `Typed` parameter somewhere in the module (`Get-PfbConventionStrength`),
    sorted by that count descending: a high count (`names` at 306 cmdlets) means closing the
    remaining gaps for that name is a mechanical batch fix; a count of zero (`context_names`, 0 --
@@ -321,15 +321,19 @@ Run in this order:
    partial-confidence rows and are therefore absent from both `systemicGaps` and
    `conventionStrength` entirely** (e.g. `base_dn`, `bind_password`, `domain`, `nameservers`,
    `qos_policy`, `storage_class`, `owner`, ...), and a name that DOES appear can still undercount:
-   `context_names`'s pinned `systemicGaps` figure is 253 (high-confidence only), but its true
-   cross-confidence total across every endpoint is 289. No individual endpoint's own
+   `context_names`'s high-confidence-only `systemicGaps` figure is smaller than its true
+   cross-confidence total across every endpoint, by design (that's the limitation described
+   above, not a discrepancy worth investigating). No individual endpoint's own
    `missingQueryParameters`/`missingBodyProperties` row is affected -- this is purely a gap in the
    *aggregated triage view*, not in the underlying per-endpoint data. A future revisit should
    aggregate `systemicGaps`/`conventionStrength` across ALL confidence levels, carrying the current
    high-confidence-only count as `endpointCount` alongside a separate `partialEndpointCount`, rather
-   than silently dropping names or re-baselining `endpointCount` itself. Not fixed here because doing
-   so moves the `context_names`/`allow_errors`/etc. figures this whole effort measured and pinned
-   throughout every task.
+   than silently dropping names or re-baselining `endpointCount` itself. Not fixed here because
+   doing so would change what `context_names`/`allow_errors`/etc. mean, which is a larger, separate
+   design decision from the invariant-based tests that verify today's high-confidence-only
+   aggregation (`Tests/PfbApiDriftTools.Tests.ps1`, `Tests/Build-PfbApiDriftReport.Tests.ps1`) --
+   those tests recount/bound rather than pin to an exact figure, specifically so this kind of
+   real-data number does not need to stay in sync with prose like this.
 
    **`phantomFieldCount` -- two correct, differently-scoped numbers.** How many `(endpoint,
    field)` pairs were silently dropped from every gap/read-only list because the field is
@@ -337,11 +341,15 @@ Run in this order:
    the newest ANALYSED spec (i.e. withdrawn from the real API after the version that first added
    it)? Two numbers are simultaneously correct, because they answer different-population
    questions:
-   - **34**, measured across the FULL population of endpoints an existing cmdlet calls,
-     regardless of confidence level -- this is what `phantomFieldCount` in
-     `Reports/PfbApiDriftReport.json` actually reports.
-   - **13**, measured over ONLY the high-confidence-endpoint subset -- this is the number in
-     `Get-PfbParameterCoverageGaps`'s own doc comment and this task's real-data acceptance tests.
+   - Measured across the FULL population of endpoints an existing cmdlet calls, regardless of
+     confidence level -- this is what `phantomFieldCount` in `Reports/PfbApiDriftReport.json`
+     actually reports. (Deliberately not pinned to an exact figure in this prose -- it changes
+     with the real API surface; `Tests/Build-PfbApiDriftReport.Tests.ps1` verifies it via a
+     self-consistency check instead of an exact number.)
+   - Measured over ONLY the high-confidence-endpoint subset -- this is the number in
+     `Get-PfbParameterCoverageGaps`'s own doc comment (illustrative example text, not a contract)
+     and in this task's real-data invariant tests (verified non-vacuous, likewise not pinned to
+     an exact figure).
    Do not treat a mismatch between the two as a bug; check which population a given historical
    reference is scoped to first. Computed by calling `Get-PfbParameterCoverageGaps` a second time
    without `-CurrentSpecCapabilities` (its documented no-op default -- no phantom filtering) and

--- a/tools/lib/PfbApiDriftTools.ps1
+++ b/tools/lib/PfbApiDriftTools.ps1
@@ -889,8 +889,8 @@ function Get-PfbSystemicGaps {
         Decision 7: collapses Get-PfbParameterCoverageGaps's per-endpoint
         MissingQueryParameters/MissingBodyProperties lists into ONE finding PER DISTINCT
         WIRE NAME, across every endpoint AND both lists together -- e.g. `context_names`
-        showing up as a missing query parameter on 253 different endpoints becomes a
-        SINGLE finding with an EndpointCount of 253, not 253 separate per-endpoint rows.
+        showing up as a missing query parameter on hundreds of different endpoints becomes a
+        SINGLE finding with an EndpointCount matching that total, not one separate per-endpoint row.
         This is what turns hundreds of individual gap rows into a handful of real,
         actionable decisions.
     .DESCRIPTION


### PR DESCRIPTION
## Summary

`Tests/Build-PfbApiDriftReport.Tests.ps1` and `Tests/PfbApiDriftTools.Tests.ps1` had several
tests asserting exact hardcoded counts from the real, ever-growing API surface (e.g.
`context_names` endpointCount must be exactly `253`). That data grows with every unrelated PR,
so these literals went stale constantly, causing repeated CI failures on both `main`s and an open
PR. This replaces each pinned literal with a check that stays true regardless of data size:
self-consistency (recompute independently and compare) where possible, non-vacuousness
(`-BeGreaterThan 0`) where a recount isn't possible, or kept as an exact pin where the value is a
documented architectural fact rather than a live count (`context_names` cmdletCount `== 0`).

Test/docs-only -- no production behavior changes; also fixes a couple of now-stale/false numbers
in `tools/README.md`, and one more instance of the same anti-pattern an independent review turned
up.

## Test plan

- [x] Full local Pester suite: 635 passed, 0 failed, 2 skipped (pre-existing, unrelated)
- [x] Each touched assertion individually confirmed fail-then-pass against real artifacts
- [x] `git diff --stat main` limited to the expected 5 files
- Mandatory live-FlashBlade testing doesn't apply -- no cmdlet/API behavior changed