### PR TITLE
Add user & group quota policy cmdlets (#34)

### DIFF
--- a/Public/FileSystem/Get-PfbFileSystemGroup.ps1
+++ b/Public/FileSystem/Get-PfbFileSystemGroup.ps1
@@ -5,7 +5,7 @@ function Get-PfbFileSystemGroup {
     .DESCRIPTION
         The Get-PfbFileSystemGroup cmdlet returns group identities (GID/name) associated with
         one or more file systems on the connected Pure Storage FlashBlade. Distinct from
-        Get-PfbUsageGroup (per-group usage statistics) — this is identity/lookup data, useful
+        Get-PfbUsageGroup (per-group usage statistics) -- this is identity/lookup data, useful
         for building -Subject hashtables for New-PfbUserGroupQuotaPolicyRule.
     .PARAMETER FileSystemName
         One or more file system names to filter by.
@@ -21,6 +21,8 @@ function Get-PfbFileSystemGroup {
         Sort field and direction.
     .PARAMETER Limit
         Maximum number of items to return.
+    .PARAMETER TotalOnly
+        Return only the total count, not the items.
     .PARAMETER Array
         The FlashBlade connection object. If not specified, the default connection is used.
     .EXAMPLE
@@ -35,6 +37,7 @@ function Get-PfbFileSystemGroup {
         [Parameter()] [string]$Filter,
         [Parameter()] [string]$Sort,
         [Parameter()] [int]$Limit,
+        [Parameter()] [switch]$TotalOnly,
         [Parameter()] [PSCustomObject]$Array
     )
 
@@ -45,9 +48,7 @@ function Get-PfbFileSystemGroup {
     if ($FileSystemId)   { $queryParams['file_system_ids']   = $FileSystemId -join ',' }
     if ($GroupName) { $queryParams['group_names'] = $GroupName -join ',' }
     if ($GroupId)   { $queryParams['gids']        = $GroupId -join ',' }
-    if ($Filter) { $queryParams['filter'] = $Filter }
-    if ($Sort)   { $queryParams['sort']   = $Sort }
-    if ($Limit -gt 0) { $queryParams['limit'] = $Limit }
+    Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters
 
     Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'file-systems/groups' -QueryParams $queryParams -AutoPaginate
 }

--- a/Public/FileSystem/Get-PfbFileSystemGroup.ps1
+++ b/Public/FileSystem/Get-PfbFileSystemGroup.ps1
@@ -1,0 +1,53 @@
+function Get-PfbFileSystemGroup {
+    <#
+    .SYNOPSIS
+        Retrieves groups known to file systems on a FlashBlade array.
+    .DESCRIPTION
+        The Get-PfbFileSystemGroup cmdlet returns group identities (GID/name) associated with
+        one or more file systems on the connected Pure Storage FlashBlade. Distinct from
+        Get-PfbUsageGroup (per-group usage statistics) — this is identity/lookup data, useful
+        for building -Subject hashtables for New-PfbUserGroupQuotaPolicyRule.
+    .PARAMETER FileSystemName
+        One or more file system names to filter by.
+    .PARAMETER FileSystemId
+        One or more file system IDs to filter by.
+    .PARAMETER GroupName
+        One or more group names to filter by.
+    .PARAMETER GroupId
+        One or more numeric GIDs to filter by.
+    .PARAMETER Filter
+        A server-side filter expression to narrow results.
+    .PARAMETER Sort
+        Sort field and direction.
+    .PARAMETER Limit
+        Maximum number of items to return.
+    .PARAMETER Array
+        The FlashBlade connection object. If not specified, the default connection is used.
+    .EXAMPLE
+        Get-PfbFileSystemGroup -FileSystemName "fs-home"
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter()] [string[]]$FileSystemName,
+        [Parameter()] [string[]]$FileSystemId,
+        [Parameter()] [string[]]$GroupName,
+        [Parameter()] [string[]]$GroupId,
+        [Parameter()] [string]$Filter,
+        [Parameter()] [string]$Sort,
+        [Parameter()] [int]$Limit,
+        [Parameter()] [PSCustomObject]$Array
+    )
+
+    Assert-PfbConnection -Array ([ref]$Array)
+
+    $queryParams = @{}
+    if ($FileSystemName) { $queryParams['file_system_names'] = $FileSystemName -join ',' }
+    if ($FileSystemId)   { $queryParams['file_system_ids']   = $FileSystemId -join ',' }
+    if ($GroupName) { $queryParams['group_names'] = $GroupName -join ',' }
+    if ($GroupId)   { $queryParams['gids']        = $GroupId -join ',' }
+    if ($Filter) { $queryParams['filter'] = $Filter }
+    if ($Sort)   { $queryParams['sort']   = $Sort }
+    if ($Limit -gt 0) { $queryParams['limit'] = $Limit }
+
+    Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'file-systems/groups' -QueryParams $queryParams -AutoPaginate
+}

--- a/Public/FileSystem/Get-PfbFileSystemGroupQuota.ps1
+++ b/Public/FileSystem/Get-PfbFileSystemGroupQuota.ps1
@@ -5,7 +5,7 @@ function Get-PfbFileSystemGroupQuota {
     .DESCRIPTION
         The Get-PfbFileSystemGroupQuota cmdlet returns the effective user-group-quota-policy
         usage/limit entries for individual groups on one or more file systems. Distinct from
-        Get-PfbQuotaGroup (the legacy per-filesystem purequota/purefs quota model) — this
+        Get-PfbQuotaGroup (the legacy per-filesystem purequota/purefs quota model) -- this
         cmdlet reports quotas from the newer policy-based user-group-quota-policy model.
     .PARAMETER FileSystemName
         One or more file system names to filter by.

--- a/Public/FileSystem/Get-PfbFileSystemGroupQuota.ps1
+++ b/Public/FileSystem/Get-PfbFileSystemGroupQuota.ps1
@@ -4,7 +4,9 @@ function Get-PfbFileSystemGroupQuota {
         Retrieves per-group quota usage and limits for file systems on a FlashBlade array.
     .DESCRIPTION
         The Get-PfbFileSystemGroupQuota cmdlet returns the effective user-group-quota-policy
-        usage/limit entries for individual groups on one or more file systems.
+        usage/limit entries for individual groups on one or more file systems. Distinct from
+        Get-PfbQuotaGroup (the legacy per-filesystem purequota/purefs quota model) — this
+        cmdlet reports quotas from the newer policy-based user-group-quota-policy model.
     .PARAMETER FileSystemName
         One or more file system names to filter by.
     .PARAMETER FileSystemId
@@ -19,6 +21,8 @@ function Get-PfbFileSystemGroupQuota {
         Sort field and direction.
     .PARAMETER Limit
         Maximum number of items to return.
+    .PARAMETER TotalOnly
+        Return only the total count, not the items.
     .PARAMETER Array
         The FlashBlade connection object. If not specified, the default connection is used.
     .EXAMPLE
@@ -33,6 +37,7 @@ function Get-PfbFileSystemGroupQuota {
         [Parameter()] [string]$Filter,
         [Parameter()] [string]$Sort,
         [Parameter()] [int]$Limit,
+        [Parameter()] [switch]$TotalOnly,
         [Parameter()] [PSCustomObject]$Array
     )
 
@@ -43,9 +48,7 @@ function Get-PfbFileSystemGroupQuota {
     if ($FileSystemId)   { $queryParams['file_system_ids']   = $FileSystemId -join ',' }
     if ($GroupName) { $queryParams['group_names'] = $GroupName -join ',' }
     if ($GroupId)   { $queryParams['gids']        = $GroupId -join ',' }
-    if ($Filter) { $queryParams['filter'] = $Filter }
-    if ($Sort)   { $queryParams['sort']   = $Sort }
-    if ($Limit -gt 0) { $queryParams['limit'] = $Limit }
+    Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters
 
     Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'file-system-group-quotas' -QueryParams $queryParams -AutoPaginate
 }

--- a/Public/FileSystem/Get-PfbFileSystemGroupQuota.ps1
+++ b/Public/FileSystem/Get-PfbFileSystemGroupQuota.ps1
@@ -1,0 +1,51 @@
+function Get-PfbFileSystemGroupQuota {
+    <#
+    .SYNOPSIS
+        Retrieves per-group quota usage and limits for file systems on a FlashBlade array.
+    .DESCRIPTION
+        The Get-PfbFileSystemGroupQuota cmdlet returns the effective user-group-quota-policy
+        usage/limit entries for individual groups on one or more file systems.
+    .PARAMETER FileSystemName
+        One or more file system names to filter by.
+    .PARAMETER FileSystemId
+        One or more file system IDs to filter by.
+    .PARAMETER GroupName
+        One or more group names to filter by.
+    .PARAMETER GroupId
+        One or more numeric GIDs to filter by.
+    .PARAMETER Filter
+        A server-side filter expression to narrow results.
+    .PARAMETER Sort
+        Sort field and direction.
+    .PARAMETER Limit
+        Maximum number of items to return.
+    .PARAMETER Array
+        The FlashBlade connection object. If not specified, the default connection is used.
+    .EXAMPLE
+        Get-PfbFileSystemGroupQuota -FileSystemName "fs-home"
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter()] [string[]]$FileSystemName,
+        [Parameter()] [string[]]$FileSystemId,
+        [Parameter()] [string[]]$GroupName,
+        [Parameter()] [string[]]$GroupId,
+        [Parameter()] [string]$Filter,
+        [Parameter()] [string]$Sort,
+        [Parameter()] [int]$Limit,
+        [Parameter()] [PSCustomObject]$Array
+    )
+
+    Assert-PfbConnection -Array ([ref]$Array)
+
+    $queryParams = @{}
+    if ($FileSystemName) { $queryParams['file_system_names'] = $FileSystemName -join ',' }
+    if ($FileSystemId)   { $queryParams['file_system_ids']   = $FileSystemId -join ',' }
+    if ($GroupName) { $queryParams['group_names'] = $GroupName -join ',' }
+    if ($GroupId)   { $queryParams['gids']        = $GroupId -join ',' }
+    if ($Filter) { $queryParams['filter'] = $Filter }
+    if ($Sort)   { $queryParams['sort']   = $Sort }
+    if ($Limit -gt 0) { $queryParams['limit'] = $Limit }
+
+    Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'file-system-group-quotas' -QueryParams $queryParams -AutoPaginate
+}

--- a/Public/FileSystem/Get-PfbFileSystemUser.ps1
+++ b/Public/FileSystem/Get-PfbFileSystemUser.ps1
@@ -1,0 +1,57 @@
+function Get-PfbFileSystemUser {
+    <#
+    .SYNOPSIS
+        Retrieves users known to file systems on a FlashBlade array.
+    .DESCRIPTION
+        The Get-PfbFileSystemUser cmdlet returns user identities (UID/name/SID) associated
+        with one or more file systems on the connected Pure Storage FlashBlade. Distinct from
+        Get-PfbUsageUser (per-user usage statistics) — this is identity/lookup data, useful
+        for building -Subject hashtables for New-PfbUserGroupQuotaPolicyRule.
+    .PARAMETER FileSystemName
+        One or more file system names to filter by.
+    .PARAMETER FileSystemId
+        One or more file system IDs to filter by.
+    .PARAMETER UserName
+        One or more user names to filter by.
+    .PARAMETER UserId
+        One or more numeric UIDs to filter by.
+    .PARAMETER UserSid
+        One or more user SIDs to filter by.
+    .PARAMETER Filter
+        A server-side filter expression to narrow results.
+    .PARAMETER Sort
+        Sort field and direction.
+    .PARAMETER Limit
+        Maximum number of items to return.
+    .PARAMETER Array
+        The FlashBlade connection object. If not specified, the default connection is used.
+    .EXAMPLE
+        Get-PfbFileSystemUser -FileSystemName "fs-home"
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter()] [string[]]$FileSystemName,
+        [Parameter()] [string[]]$FileSystemId,
+        [Parameter()] [string[]]$UserName,
+        [Parameter()] [string[]]$UserId,
+        [Parameter()] [string[]]$UserSid,
+        [Parameter()] [string]$Filter,
+        [Parameter()] [string]$Sort,
+        [Parameter()] [int]$Limit,
+        [Parameter()] [PSCustomObject]$Array
+    )
+
+    Assert-PfbConnection -Array ([ref]$Array)
+
+    $queryParams = @{}
+    if ($FileSystemName) { $queryParams['file_system_names'] = $FileSystemName -join ',' }
+    if ($FileSystemId)   { $queryParams['file_system_ids']   = $FileSystemId -join ',' }
+    if ($UserName) { $queryParams['user_names'] = $UserName -join ',' }
+    if ($UserId)   { $queryParams['uids']       = $UserId -join ',' }
+    if ($UserSid)  { $queryParams['user_sids']  = $UserSid -join ',' }
+    if ($Filter) { $queryParams['filter'] = $Filter }
+    if ($Sort)   { $queryParams['sort']   = $Sort }
+    if ($Limit -gt 0) { $queryParams['limit'] = $Limit }
+
+    Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'file-systems/users' -QueryParams $queryParams -AutoPaginate
+}

--- a/Public/FileSystem/Get-PfbFileSystemUser.ps1
+++ b/Public/FileSystem/Get-PfbFileSystemUser.ps1
@@ -5,7 +5,7 @@ function Get-PfbFileSystemUser {
     .DESCRIPTION
         The Get-PfbFileSystemUser cmdlet returns user identities (UID/name/SID) associated
         with one or more file systems on the connected Pure Storage FlashBlade. Distinct from
-        Get-PfbUsageUser (per-user usage statistics) — this is identity/lookup data, useful
+        Get-PfbUsageUser (per-user usage statistics) -- this is identity/lookup data, useful
         for building -Subject hashtables for New-PfbUserGroupQuotaPolicyRule.
     .PARAMETER FileSystemName
         One or more file system names to filter by.
@@ -23,6 +23,8 @@ function Get-PfbFileSystemUser {
         Sort field and direction.
     .PARAMETER Limit
         Maximum number of items to return.
+    .PARAMETER TotalOnly
+        Return only the total count, not the items.
     .PARAMETER Array
         The FlashBlade connection object. If not specified, the default connection is used.
     .EXAMPLE
@@ -38,6 +40,7 @@ function Get-PfbFileSystemUser {
         [Parameter()] [string]$Filter,
         [Parameter()] [string]$Sort,
         [Parameter()] [int]$Limit,
+        [Parameter()] [switch]$TotalOnly,
         [Parameter()] [PSCustomObject]$Array
     )
 
@@ -49,9 +52,7 @@ function Get-PfbFileSystemUser {
     if ($UserName) { $queryParams['user_names'] = $UserName -join ',' }
     if ($UserId)   { $queryParams['uids']       = $UserId -join ',' }
     if ($UserSid)  { $queryParams['user_sids']  = $UserSid -join ',' }
-    if ($Filter) { $queryParams['filter'] = $Filter }
-    if ($Sort)   { $queryParams['sort']   = $Sort }
-    if ($Limit -gt 0) { $queryParams['limit'] = $Limit }
+    Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters
 
     Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'file-systems/users' -QueryParams $queryParams -AutoPaginate
 }

--- a/Public/FileSystem/Get-PfbFileSystemUserGroupQuotaPolicy.ps1
+++ b/Public/FileSystem/Get-PfbFileSystemUserGroupQuotaPolicy.ps1
@@ -20,6 +20,8 @@ function Get-PfbFileSystemUserGroupQuotaPolicy {
         Sort field and direction.
     .PARAMETER Limit
         Maximum number of items to return.
+    .PARAMETER TotalOnly
+        Return only the total count, not the items.
     .PARAMETER Array
         The FlashBlade connection object. If not specified, the default connection is used.
     .EXAMPLE
@@ -36,6 +38,7 @@ function Get-PfbFileSystemUserGroupQuotaPolicy {
         [Parameter()] [string]$Filter,
         [Parameter()] [string]$Sort,
         [Parameter()] [int]$Limit,
+        [Parameter()] [switch]$TotalOnly,
         [Parameter()] [PSCustomObject]$Array
     )
 
@@ -46,9 +49,7 @@ function Get-PfbFileSystemUserGroupQuotaPolicy {
     if ($PolicyId)   { $queryParams['policy_ids']   = $PolicyId -join ',' }
     if ($MemberName) { $queryParams['member_names'] = $MemberName -join ',' }
     if ($MemberId)   { $queryParams['member_ids']   = $MemberId -join ',' }
-    if ($Filter) { $queryParams['filter'] = $Filter }
-    if ($Sort)   { $queryParams['sort']   = $Sort }
-    if ($Limit -gt 0) { $queryParams['limit'] = $Limit }
+    Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters
 
     Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'file-systems/user-group-quota-policies' -QueryParams $queryParams -AutoPaginate
 }

--- a/Public/FileSystem/Get-PfbFileSystemUserGroupQuotaPolicy.ps1
+++ b/Public/FileSystem/Get-PfbFileSystemUserGroupQuotaPolicy.ps1
@@ -1,0 +1,54 @@
+function Get-PfbFileSystemUserGroupQuotaPolicy {
+    <#
+    .SYNOPSIS
+        Retrieves user/group quota policies attached to file systems on a FlashBlade array.
+    .DESCRIPTION
+        The Get-PfbFileSystemUserGroupQuotaPolicy cmdlet returns the mapping between file
+        systems and their attached user-group-quota policies. Same underlying relationship as
+        Get-PfbUserGroupQuotaPolicyFileSystem, queried from the file-system side.
+    .PARAMETER PolicyName
+        One or more policy names to filter by.
+    .PARAMETER PolicyId
+        One or more policy IDs to filter by.
+    .PARAMETER MemberName
+        One or more file system names to filter by.
+    .PARAMETER MemberId
+        One or more file system IDs to filter by.
+    .PARAMETER Filter
+        A server-side filter expression to narrow results.
+    .PARAMETER Sort
+        Sort field and direction.
+    .PARAMETER Limit
+        Maximum number of items to return.
+    .PARAMETER Array
+        The FlashBlade connection object. If not specified, the default connection is used.
+    .EXAMPLE
+        Get-PfbFileSystemUserGroupQuotaPolicy -MemberName "fs1"
+
+        Retrieves the user-group-quota policies attached to file system 'fs1'.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter()] [string[]]$PolicyName,
+        [Parameter()] [string[]]$PolicyId,
+        [Parameter()] [string[]]$MemberName,
+        [Parameter()] [string[]]$MemberId,
+        [Parameter()] [string]$Filter,
+        [Parameter()] [string]$Sort,
+        [Parameter()] [int]$Limit,
+        [Parameter()] [PSCustomObject]$Array
+    )
+
+    Assert-PfbConnection -Array ([ref]$Array)
+
+    $queryParams = @{}
+    if ($PolicyName) { $queryParams['policy_names'] = $PolicyName -join ',' }
+    if ($PolicyId)   { $queryParams['policy_ids']   = $PolicyId -join ',' }
+    if ($MemberName) { $queryParams['member_names'] = $MemberName -join ',' }
+    if ($MemberId)   { $queryParams['member_ids']   = $MemberId -join ',' }
+    if ($Filter) { $queryParams['filter'] = $Filter }
+    if ($Sort)   { $queryParams['sort']   = $Sort }
+    if ($Limit -gt 0) { $queryParams['limit'] = $Limit }
+
+    Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'file-systems/user-group-quota-policies' -QueryParams $queryParams -AutoPaginate
+}

--- a/Public/FileSystem/Get-PfbFileSystemUserQuota.ps1
+++ b/Public/FileSystem/Get-PfbFileSystemUserQuota.ps1
@@ -1,0 +1,55 @@
+function Get-PfbFileSystemUserQuota {
+    <#
+    .SYNOPSIS
+        Retrieves per-user quota usage and limits for file systems on a FlashBlade array.
+    .DESCRIPTION
+        The Get-PfbFileSystemUserQuota cmdlet returns the effective user-group-quota-policy
+        usage/limit entries for individual users on one or more file systems.
+    .PARAMETER FileSystemName
+        One or more file system names to filter by.
+    .PARAMETER FileSystemId
+        One or more file system IDs to filter by.
+    .PARAMETER UserName
+        One or more user names to filter by.
+    .PARAMETER UserId
+        One or more numeric UIDs to filter by.
+    .PARAMETER UserSid
+        One or more user SIDs to filter by.
+    .PARAMETER Filter
+        A server-side filter expression to narrow results.
+    .PARAMETER Sort
+        Sort field and direction.
+    .PARAMETER Limit
+        Maximum number of items to return.
+    .PARAMETER Array
+        The FlashBlade connection object. If not specified, the default connection is used.
+    .EXAMPLE
+        Get-PfbFileSystemUserQuota -FileSystemName "fs-home"
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter()] [string[]]$FileSystemName,
+        [Parameter()] [string[]]$FileSystemId,
+        [Parameter()] [string[]]$UserName,
+        [Parameter()] [string[]]$UserId,
+        [Parameter()] [string[]]$UserSid,
+        [Parameter()] [string]$Filter,
+        [Parameter()] [string]$Sort,
+        [Parameter()] [int]$Limit,
+        [Parameter()] [PSCustomObject]$Array
+    )
+
+    Assert-PfbConnection -Array ([ref]$Array)
+
+    $queryParams = @{}
+    if ($FileSystemName) { $queryParams['file_system_names'] = $FileSystemName -join ',' }
+    if ($FileSystemId)   { $queryParams['file_system_ids']   = $FileSystemId -join ',' }
+    if ($UserName) { $queryParams['user_names'] = $UserName -join ',' }
+    if ($UserId)   { $queryParams['uids']       = $UserId -join ',' }
+    if ($UserSid)  { $queryParams['user_sids']  = $UserSid -join ',' }
+    if ($Filter) { $queryParams['filter'] = $Filter }
+    if ($Sort)   { $queryParams['sort']   = $Sort }
+    if ($Limit -gt 0) { $queryParams['limit'] = $Limit }
+
+    Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'file-system-user-quotas' -QueryParams $queryParams -AutoPaginate
+}

--- a/Public/FileSystem/Get-PfbFileSystemUserQuota.ps1
+++ b/Public/FileSystem/Get-PfbFileSystemUserQuota.ps1
@@ -4,7 +4,9 @@ function Get-PfbFileSystemUserQuota {
         Retrieves per-user quota usage and limits for file systems on a FlashBlade array.
     .DESCRIPTION
         The Get-PfbFileSystemUserQuota cmdlet returns the effective user-group-quota-policy
-        usage/limit entries for individual users on one or more file systems.
+        usage/limit entries for individual users on one or more file systems. Distinct from
+        Get-PfbQuotaUser (the legacy per-filesystem purequota/purefs quota model) — this cmdlet
+        reports quotas from the newer policy-based user-group-quota-policy model.
     .PARAMETER FileSystemName
         One or more file system names to filter by.
     .PARAMETER FileSystemId
@@ -21,6 +23,8 @@ function Get-PfbFileSystemUserQuota {
         Sort field and direction.
     .PARAMETER Limit
         Maximum number of items to return.
+    .PARAMETER TotalOnly
+        Return only the total count, not the items.
     .PARAMETER Array
         The FlashBlade connection object. If not specified, the default connection is used.
     .EXAMPLE
@@ -36,6 +40,7 @@ function Get-PfbFileSystemUserQuota {
         [Parameter()] [string]$Filter,
         [Parameter()] [string]$Sort,
         [Parameter()] [int]$Limit,
+        [Parameter()] [switch]$TotalOnly,
         [Parameter()] [PSCustomObject]$Array
     )
 
@@ -47,9 +52,7 @@ function Get-PfbFileSystemUserQuota {
     if ($UserName) { $queryParams['user_names'] = $UserName -join ',' }
     if ($UserId)   { $queryParams['uids']       = $UserId -join ',' }
     if ($UserSid)  { $queryParams['user_sids']  = $UserSid -join ',' }
-    if ($Filter) { $queryParams['filter'] = $Filter }
-    if ($Sort)   { $queryParams['sort']   = $Sort }
-    if ($Limit -gt 0) { $queryParams['limit'] = $Limit }
+    Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters
 
     Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'file-system-user-quotas' -QueryParams $queryParams -AutoPaginate
 }

--- a/Public/FileSystem/Get-PfbFileSystemUserQuota.ps1
+++ b/Public/FileSystem/Get-PfbFileSystemUserQuota.ps1
@@ -5,7 +5,7 @@ function Get-PfbFileSystemUserQuota {
     .DESCRIPTION
         The Get-PfbFileSystemUserQuota cmdlet returns the effective user-group-quota-policy
         usage/limit entries for individual users on one or more file systems. Distinct from
-        Get-PfbQuotaUser (the legacy per-filesystem purequota/purefs quota model) — this cmdlet
+        Get-PfbQuotaUser (the legacy per-filesystem purequota/purefs quota model) -- this cmdlet
         reports quotas from the newer policy-based user-group-quota-policy model.
     .PARAMETER FileSystemName
         One or more file system names to filter by.

--- a/Public/FileSystem/New-PfbFileSystemUserGroupQuotaPolicy.ps1
+++ b/Public/FileSystem/New-PfbFileSystemUserGroupQuotaPolicy.ps1
@@ -1,0 +1,58 @@
+function New-PfbFileSystemUserGroupQuotaPolicy {
+    <#
+    .SYNOPSIS
+        Attaches a user/group quota policy to a file system on a FlashBlade array.
+    .DESCRIPTION
+        The New-PfbFileSystemUserGroupQuotaPolicy cmdlet associates an existing
+        user-group-quota policy with a file system, queried/invoked from the file-system side.
+        Functionally identical to New-PfbUserGroupQuotaPolicyFileSystem.
+    .PARAMETER PolicyName
+        The name of the policy to attach.
+    .PARAMETER PolicyId
+        The ID of the policy to attach.
+    .PARAMETER MemberName
+        The name of the file system to attach the policy to.
+    .PARAMETER MemberId
+        The ID of the file system to attach the policy to.
+    .PARAMETER DeleteExistingUserGroupQuotaSettings
+        If set, deletes the file system's existing legacy purequota/purefs quota settings
+        when attaching this policy.
+    .PARAMETER IgnoreUsage
+        If set, existing user/group usage on the file system is not checked against the
+        policy's rules.
+    .PARAMETER Array
+        The FlashBlade connection object. If not specified, the default connection is used.
+    .EXAMPLE
+        New-PfbFileSystemUserGroupQuotaPolicy -PolicyName "quota-pol-1" -MemberName "fs1"
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
+    param(
+        [Parameter()] [string]$PolicyName,
+        [Parameter()] [string]$PolicyId,
+        [Parameter()] [string]$MemberName,
+        [Parameter()] [string]$MemberId,
+        [Parameter()] [switch]$DeleteExistingUserGroupQuotaSettings,
+        [Parameter()] [switch]$IgnoreUsage,
+        [Parameter()] [PSCustomObject]$Array
+    )
+
+    if (-not $PolicyName -and -not $PolicyId) { throw 'You must supply either -PolicyName or -PolicyId.' }
+    if (-not $MemberName -and -not $MemberId) { throw 'You must supply either -MemberName or -MemberId.' }
+
+    Assert-PfbConnection -Array ([ref]$Array)
+
+    $queryParams = @{}
+    if ($PolicyName) { $queryParams['policy_names'] = $PolicyName }
+    if ($PolicyId)   { $queryParams['policy_ids']   = $PolicyId }
+    if ($MemberName) { $queryParams['member_names'] = $MemberName }
+    if ($MemberId)   { $queryParams['member_ids']   = $MemberId }
+    if ($DeleteExistingUserGroupQuotaSettings) { $queryParams['delete_existing_user_group_quota_settings'] = 'true' }
+    if ($IgnoreUsage) { $queryParams['ignore_usage'] = 'true' }
+
+    $target = if ($MemberName) { $MemberName } else { $MemberId }
+    $policy = if ($PolicyName) { $PolicyName } else { $PolicyId }
+
+    if ($PSCmdlet.ShouldProcess($target, "Attach user-group-quota policy '$policy'")) {
+        Invoke-PfbApiRequest -Array $Array -Method POST -Endpoint 'file-systems/user-group-quota-policies' -QueryParams $queryParams
+    }
+}

--- a/Public/FileSystem/Remove-PfbFileSystemUserGroupQuotaPolicy.ps1
+++ b/Public/FileSystem/Remove-PfbFileSystemUserGroupQuotaPolicy.ps1
@@ -1,0 +1,51 @@
+function Remove-PfbFileSystemUserGroupQuotaPolicy {
+    <#
+    .SYNOPSIS
+        Detaches a user/group quota policy from a file system on a FlashBlade array.
+    .DESCRIPTION
+        Functionally identical to Remove-PfbUserGroupQuotaPolicyFileSystem, invoked from the
+        file-system side.
+    .PARAMETER PolicyName
+        The name of the policy to detach.
+    .PARAMETER PolicyId
+        The ID of the policy to detach.
+    .PARAMETER MemberName
+        The name of the file system to detach the policy from.
+    .PARAMETER MemberId
+        The ID of the file system to detach the policy from.
+    .PARAMETER Array
+        The FlashBlade connection object. If not specified, the default connection is used.
+    .EXAMPLE
+        Remove-PfbFileSystemUserGroupQuotaPolicy -PolicyName "quota-pol-1" -MemberName "fs1"
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
+    param(
+        [Parameter()] [string]$PolicyName,
+        [Parameter()] [string]$PolicyId,
+        [Parameter()] [string]$MemberName,
+        [Parameter()] [string]$MemberId,
+        [Parameter()] [PSCustomObject]$Array
+    )
+
+    if (-not $PolicyName -and -not $PolicyId) {
+        throw 'You must supply either -PolicyName or -PolicyId.'
+    }
+    if (-not $MemberName -and -not $MemberId) {
+        throw 'You must supply either -MemberName or -MemberId.'
+    }
+
+    Assert-PfbConnection -Array ([ref]$Array)
+
+    $queryParams = @{}
+    if ($PolicyName) { $queryParams['policy_names'] = $PolicyName }
+    if ($PolicyId)   { $queryParams['policy_ids']   = $PolicyId }
+    if ($MemberName) { $queryParams['member_names'] = $MemberName }
+    if ($MemberId)   { $queryParams['member_ids']   = $MemberId }
+
+    $target = if ($PolicyName) { $PolicyName } else { $PolicyId }
+    $member = if ($MemberName) { $MemberName } else { $MemberId }
+
+    if ($PSCmdlet.ShouldProcess("${target}:${member}", 'Detach user-group-quota policy from file system')) {
+        Invoke-PfbApiRequest -Array $Array -Method DELETE -Endpoint 'file-systems/user-group-quota-policies' -QueryParams $queryParams
+    }
+}

--- a/Public/FileSystem/Remove-PfbFileSystemUserGroupQuotaPolicy.ps1
+++ b/Public/FileSystem/Remove-PfbFileSystemUserGroupQuotaPolicy.ps1
@@ -20,9 +20,16 @@ function Remove-PfbFileSystemUserGroupQuotaPolicy {
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
     param(
-        [Parameter()] [string]$PolicyName,
+        [Parameter()]
+        [ValidateScript({ Assert-PfbSafeName $_ })]
+        [string]$PolicyName,
+
         [Parameter()] [string]$PolicyId,
-        [Parameter()] [string]$MemberName,
+
+        [Parameter()]
+        [ValidateScript({ Assert-PfbSafeName $_ })]
+        [string]$MemberName,
+
         [Parameter()] [string]$MemberId,
         [Parameter()] [PSCustomObject]$Array
     )
@@ -42,10 +49,10 @@ function Remove-PfbFileSystemUserGroupQuotaPolicy {
     if ($MemberName) { $queryParams['member_names'] = $MemberName }
     if ($MemberId)   { $queryParams['member_ids']   = $MemberId }
 
-    $target = if ($PolicyName) { $PolicyName } else { $PolicyId }
+    $policy = if ($PolicyName) { $PolicyName } else { $PolicyId }
     $member = if ($MemberName) { $MemberName } else { $MemberId }
 
-    if ($PSCmdlet.ShouldProcess("${target}:${member}", 'Detach user-group-quota policy from file system')) {
+    if ($PSCmdlet.ShouldProcess($member, "Detach user-group-quota policy '$policy'")) {
         Invoke-PfbApiRequest -Array $Array -Method DELETE -Endpoint 'file-systems/user-group-quota-policies' -QueryParams $queryParams
     }
 }

--- a/Public/Policy/Get-PfbUserGroupQuotaPolicy.ps1
+++ b/Public/Policy/Get-PfbUserGroupQuotaPolicy.ps1
@@ -17,6 +17,8 @@ function Get-PfbUserGroupQuotaPolicy {
         Sort field and direction.
     .PARAMETER Limit
         Maximum number of items to return.
+    .PARAMETER TotalOnly
+        Return only the total count, not the items.
     .PARAMETER Array
         The FlashBlade connection object. If not specified, the default connection is used.
     .EXAMPLE
@@ -39,6 +41,7 @@ function Get-PfbUserGroupQuotaPolicy {
         [Parameter()] [string]$Filter,
         [Parameter()] [string]$Sort,
         [Parameter()] [int]$Limit,
+        [Parameter()] [switch]$TotalOnly,
         [Parameter()] [PSCustomObject]$Array
     )
 

--- a/Public/Policy/Get-PfbUserGroupQuotaPolicy.ps1
+++ b/Public/Policy/Get-PfbUserGroupQuotaPolicy.ps1
@@ -1,0 +1,62 @@
+function Get-PfbUserGroupQuotaPolicy {
+    <#
+    .SYNOPSIS
+        Retrieves user/group quota policies from a FlashBlade array.
+    .DESCRIPTION
+        The Get-PfbUserGroupQuotaPolicy cmdlet returns user-group-quota policies from the
+        connected Pure Storage FlashBlade. These policies define quota rules for users and
+        groups across one or more file systems, replacing the legacy per-filesystem
+        purequota/purefs quota model.
+    .PARAMETER Name
+        One or more policy names to retrieve. Accepts pipeline input.
+    .PARAMETER Id
+        One or more policy IDs to retrieve.
+    .PARAMETER Filter
+        A server-side filter expression to narrow results.
+    .PARAMETER Sort
+        Sort field and direction.
+    .PARAMETER Limit
+        Maximum number of items to return.
+    .PARAMETER Array
+        The FlashBlade connection object. If not specified, the default connection is used.
+    .EXAMPLE
+        Get-PfbUserGroupQuotaPolicy
+
+        Retrieves all user-group-quota policies.
+    .EXAMPLE
+        Get-PfbUserGroupQuotaPolicy -Name "quota-pol-1"
+
+        Retrieves the policy named 'quota-pol-1'.
+    #>
+    [CmdletBinding(DefaultParameterSetName = 'List')]
+    param(
+        [Parameter(ParameterSetName = 'ByName', ValueFromPipeline, ValueFromPipelineByPropertyName)]
+        [string[]]$Name,
+
+        [Parameter(ParameterSetName = 'ById')]
+        [string[]]$Id,
+
+        [Parameter()] [string]$Filter,
+        [Parameter()] [string]$Sort,
+        [Parameter()] [int]$Limit,
+        [Parameter()] [PSCustomObject]$Array
+    )
+
+    begin {
+        Assert-PfbConnection -Array ([ref]$Array)
+        $allNames = [System.Collections.Generic.List[string]]::new()
+        $allIds = [System.Collections.Generic.List[string]]::new()
+    }
+
+    process {
+        if ($Name) { foreach ($n in $Name) { $allNames.Add($n) } }
+        if ($Id)   { foreach ($i in $Id)   { $allIds.Add($i) } }
+    }
+
+    end {
+        $queryParams = @{}
+        Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames.ToArray() -Ids $allIds.ToArray()
+
+        Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'user-group-quota-policies' -QueryParams $queryParams -AutoPaginate
+    }
+}

--- a/Public/Policy/Get-PfbUserGroupQuotaPolicyFileSystem.ps1
+++ b/Public/Policy/Get-PfbUserGroupQuotaPolicyFileSystem.ps1
@@ -19,6 +19,8 @@ function Get-PfbUserGroupQuotaPolicyFileSystem {
         Sort field and direction.
     .PARAMETER Limit
         Maximum number of items to return.
+    .PARAMETER TotalOnly
+        Return only the total count, not the items.
     .PARAMETER Array
         The FlashBlade connection object. If not specified, the default connection is used.
     .EXAMPLE
@@ -35,6 +37,7 @@ function Get-PfbUserGroupQuotaPolicyFileSystem {
         [Parameter()] [string]$Filter,
         [Parameter()] [string]$Sort,
         [Parameter()] [int]$Limit,
+        [Parameter()] [switch]$TotalOnly,
         [Parameter()] [PSCustomObject]$Array
     )
 
@@ -45,9 +48,7 @@ function Get-PfbUserGroupQuotaPolicyFileSystem {
     if ($PolicyId)   { $queryParams['policy_ids']   = $PolicyId -join ',' }
     if ($MemberName) { $queryParams['member_names'] = $MemberName -join ',' }
     if ($MemberId)   { $queryParams['member_ids']   = $MemberId -join ',' }
-    if ($Filter) { $queryParams['filter'] = $Filter }
-    if ($Sort)   { $queryParams['sort']   = $Sort }
-    if ($Limit -gt 0) { $queryParams['limit'] = $Limit }
+    Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters
 
     Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'user-group-quota-policies/file-systems' -QueryParams $queryParams -AutoPaginate
 }

--- a/Public/Policy/Get-PfbUserGroupQuotaPolicyFileSystem.ps1
+++ b/Public/Policy/Get-PfbUserGroupQuotaPolicyFileSystem.ps1
@@ -1,0 +1,53 @@
+function Get-PfbUserGroupQuotaPolicyFileSystem {
+    <#
+    .SYNOPSIS
+        Retrieves user/group quota policy-to-file-system attachments from a FlashBlade array.
+    .DESCRIPTION
+        The Get-PfbUserGroupQuotaPolicyFileSystem cmdlet returns the mapping between
+        user-group-quota policies and the file systems they're attached to.
+    .PARAMETER PolicyName
+        One or more policy names to filter by.
+    .PARAMETER PolicyId
+        One or more policy IDs to filter by.
+    .PARAMETER MemberName
+        One or more file system names to filter by.
+    .PARAMETER MemberId
+        One or more file system IDs to filter by.
+    .PARAMETER Filter
+        A server-side filter expression to narrow results.
+    .PARAMETER Sort
+        Sort field and direction.
+    .PARAMETER Limit
+        Maximum number of items to return.
+    .PARAMETER Array
+        The FlashBlade connection object. If not specified, the default connection is used.
+    .EXAMPLE
+        Get-PfbUserGroupQuotaPolicyFileSystem -PolicyName "quota-pol-1"
+
+        Retrieves the file systems 'quota-pol-1' is attached to.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter()] [string[]]$PolicyName,
+        [Parameter()] [string[]]$PolicyId,
+        [Parameter()] [string[]]$MemberName,
+        [Parameter()] [string[]]$MemberId,
+        [Parameter()] [string]$Filter,
+        [Parameter()] [string]$Sort,
+        [Parameter()] [int]$Limit,
+        [Parameter()] [PSCustomObject]$Array
+    )
+
+    Assert-PfbConnection -Array ([ref]$Array)
+
+    $queryParams = @{}
+    if ($PolicyName) { $queryParams['policy_names'] = $PolicyName -join ',' }
+    if ($PolicyId)   { $queryParams['policy_ids']   = $PolicyId -join ',' }
+    if ($MemberName) { $queryParams['member_names'] = $MemberName -join ',' }
+    if ($MemberId)   { $queryParams['member_ids']   = $MemberId -join ',' }
+    if ($Filter) { $queryParams['filter'] = $Filter }
+    if ($Sort)   { $queryParams['sort']   = $Sort }
+    if ($Limit -gt 0) { $queryParams['limit'] = $Limit }
+
+    Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'user-group-quota-policies/file-systems' -QueryParams $queryParams -AutoPaginate
+}

--- a/Public/Policy/Get-PfbUserGroupQuotaPolicyMember.ps1
+++ b/Public/Policy/Get-PfbUserGroupQuotaPolicyMember.ps1
@@ -1,0 +1,53 @@
+function Get-PfbUserGroupQuotaPolicyMember {
+    <#
+    .SYNOPSIS
+        Retrieves user/group quota policy member associations from a FlashBlade array.
+    .DESCRIPTION
+        The Get-PfbUserGroupQuotaPolicyMember cmdlet returns the cross-reference between
+        user-group-quota policies and their members (file systems) on the connected Pure
+        Storage FlashBlade. This is a read-only view; use Get-PfbUserGroupQuotaPolicyFileSystem
+        to see the same relationship from the file-system-attachment endpoint.
+    .PARAMETER PolicyName
+        One or more policy names to filter by.
+    .PARAMETER PolicyId
+        One or more policy IDs to filter by.
+    .PARAMETER MemberName
+        One or more member names to filter by.
+    .PARAMETER MemberId
+        One or more member IDs to filter by.
+    .PARAMETER Filter
+        A server-side filter expression to narrow results.
+    .PARAMETER Sort
+        Sort field and direction.
+    .PARAMETER Limit
+        Maximum number of entries to return.
+    .PARAMETER Array
+        The FlashBlade connection object. If not specified, the default connection is used.
+    .EXAMPLE
+        Get-PfbUserGroupQuotaPolicyMember -PolicyName "quota-pol-1"
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter()] [string[]]$PolicyName,
+        [Parameter()] [string[]]$PolicyId,
+        [Parameter()] [string[]]$MemberName,
+        [Parameter()] [string[]]$MemberId,
+        [Parameter()] [string]$Filter,
+        [Parameter()] [string]$Sort,
+        [Parameter()] [int]$Limit,
+        [Parameter()] [PSCustomObject]$Array
+    )
+
+    Assert-PfbConnection -Array ([ref]$Array)
+
+    $queryParams = @{}
+    if ($PolicyName) { $queryParams['policy_names'] = $PolicyName -join ',' }
+    if ($PolicyId)   { $queryParams['policy_ids']   = $PolicyId -join ',' }
+    if ($MemberName) { $queryParams['member_names'] = $MemberName -join ',' }
+    if ($MemberId)   { $queryParams['member_ids']   = $MemberId -join ',' }
+    if ($Filter) { $queryParams['filter'] = $Filter }
+    if ($Sort)   { $queryParams['sort']   = $Sort }
+    if ($Limit -gt 0) { $queryParams['limit'] = $Limit }
+
+    Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'user-group-quota-policies/members' -QueryParams $queryParams -AutoPaginate
+}

--- a/Public/Policy/Get-PfbUserGroupQuotaPolicyMember.ps1
+++ b/Public/Policy/Get-PfbUserGroupQuotaPolicyMember.ps1
@@ -21,6 +21,8 @@ function Get-PfbUserGroupQuotaPolicyMember {
         Sort field and direction.
     .PARAMETER Limit
         Maximum number of entries to return.
+    .PARAMETER TotalOnly
+        Return only the total count, not the items.
     .PARAMETER Array
         The FlashBlade connection object. If not specified, the default connection is used.
     .EXAMPLE
@@ -35,6 +37,7 @@ function Get-PfbUserGroupQuotaPolicyMember {
         [Parameter()] [string]$Filter,
         [Parameter()] [string]$Sort,
         [Parameter()] [int]$Limit,
+        [Parameter()] [switch]$TotalOnly,
         [Parameter()] [PSCustomObject]$Array
     )
 
@@ -45,9 +48,7 @@ function Get-PfbUserGroupQuotaPolicyMember {
     if ($PolicyId)   { $queryParams['policy_ids']   = $PolicyId -join ',' }
     if ($MemberName) { $queryParams['member_names'] = $MemberName -join ',' }
     if ($MemberId)   { $queryParams['member_ids']   = $MemberId -join ',' }
-    if ($Filter) { $queryParams['filter'] = $Filter }
-    if ($Sort)   { $queryParams['sort']   = $Sort }
-    if ($Limit -gt 0) { $queryParams['limit'] = $Limit }
+    Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters
 
     Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'user-group-quota-policies/members' -QueryParams $queryParams -AutoPaginate
 }

--- a/Public/Policy/Get-PfbUserGroupQuotaPolicyRule.ps1
+++ b/Public/Policy/Get-PfbUserGroupQuotaPolicyRule.ps1
@@ -1,0 +1,69 @@
+function Get-PfbUserGroupQuotaPolicyRule {
+    <#
+    .SYNOPSIS
+        Retrieves user/group quota policy rules from a FlashBlade array.
+    .DESCRIPTION
+        The Get-PfbUserGroupQuotaPolicyRule cmdlet returns the individual quota rules that
+        belong to user-group-quota policies on the connected Pure Storage FlashBlade.
+    .PARAMETER PolicyName
+        One or more policy names to filter by. Accepts pipeline input.
+    .PARAMETER PolicyId
+        One or more policy IDs to filter by.
+    .PARAMETER Name
+        One or more rule names to retrieve.
+    .PARAMETER Id
+        One or more rule IDs to retrieve.
+    .PARAMETER Filter
+        A server-side filter expression to narrow results.
+    .PARAMETER Sort
+        Sort field and direction.
+    .PARAMETER Limit
+        Maximum number of items to return.
+    .PARAMETER Array
+        The FlashBlade connection object. If not specified, the default connection is used.
+    .EXAMPLE
+        Get-PfbUserGroupQuotaPolicyRule -PolicyName "quota-pol-1"
+
+        Retrieves all rules belonging to the 'quota-pol-1' policy.
+    #>
+    [CmdletBinding(DefaultParameterSetName = 'List')]
+    param(
+        [Parameter(ParameterSetName = 'ByPolicyName', ValueFromPipeline, ValueFromPipelineByPropertyName)]
+        [string[]]$PolicyName,
+
+        [Parameter(ParameterSetName = 'ByPolicyId')]
+        [string[]]$PolicyId,
+
+        [Parameter()] [string[]]$Name,
+        [Parameter()] [string[]]$Id,
+
+        [Parameter()] [string]$Filter,
+        [Parameter()] [string]$Sort,
+        [Parameter()] [int]$Limit,
+        [Parameter()] [PSCustomObject]$Array
+    )
+
+    begin {
+        Assert-PfbConnection -Array ([ref]$Array)
+        $allPolicyNames = [System.Collections.Generic.List[string]]::new()
+        $allPolicyIds = [System.Collections.Generic.List[string]]::new()
+    }
+
+    process {
+        if ($PolicyName) { foreach ($n in $PolicyName) { $allPolicyNames.Add($n) } }
+        if ($PolicyId)   { foreach ($i in $PolicyId)   { $allPolicyIds.Add($i) } }
+    }
+
+    end {
+        $queryParams = @{}
+        if ($allPolicyNames.Count -gt 0) { $queryParams['policy_names'] = $allPolicyNames -join ',' }
+        if ($allPolicyIds.Count -gt 0)   { $queryParams['policy_ids']   = $allPolicyIds -join ',' }
+        if ($Name) { $queryParams['names'] = $Name -join ',' }
+        if ($Id)   { $queryParams['ids']   = $Id -join ',' }
+        if ($Filter) { $queryParams['filter'] = $Filter }
+        if ($Sort)   { $queryParams['sort']   = $Sort }
+        if ($Limit -gt 0) { $queryParams['limit'] = $Limit }
+
+        Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'user-group-quota-policies/rules' -QueryParams $queryParams -AutoPaginate
+    }
+}

--- a/Public/Policy/Get-PfbUserGroupQuotaPolicyRule.ps1
+++ b/Public/Policy/Get-PfbUserGroupQuotaPolicyRule.ps1
@@ -19,6 +19,8 @@ function Get-PfbUserGroupQuotaPolicyRule {
         Sort field and direction.
     .PARAMETER Limit
         Maximum number of items to return.
+    .PARAMETER TotalOnly
+        Return only the total count, not the items.
     .PARAMETER Array
         The FlashBlade connection object. If not specified, the default connection is used.
     .EXAMPLE
@@ -40,10 +42,14 @@ function Get-PfbUserGroupQuotaPolicyRule {
         [Parameter()] [string]$Filter,
         [Parameter()] [string]$Sort,
         [Parameter()] [int]$Limit,
+        [Parameter()] [switch]$TotalOnly,
         [Parameter()] [PSCustomObject]$Array
     )
 
     begin {
+        if ($Name -and $Id) {
+            throw 'You cannot supply both -Name and -Id.'
+        }
         Assert-PfbConnection -Array ([ref]$Array)
         $allPolicyNames = [System.Collections.Generic.List[string]]::new()
         $allPolicyIds = [System.Collections.Generic.List[string]]::new()
@@ -58,11 +64,7 @@ function Get-PfbUserGroupQuotaPolicyRule {
         $queryParams = @{}
         if ($allPolicyNames.Count -gt 0) { $queryParams['policy_names'] = $allPolicyNames -join ',' }
         if ($allPolicyIds.Count -gt 0)   { $queryParams['policy_ids']   = $allPolicyIds -join ',' }
-        if ($Name) { $queryParams['names'] = $Name -join ',' }
-        if ($Id)   { $queryParams['ids']   = $Id -join ',' }
-        if ($Filter) { $queryParams['filter'] = $Filter }
-        if ($Sort)   { $queryParams['sort']   = $Sort }
-        if ($Limit -gt 0) { $queryParams['limit'] = $Limit }
+        Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $Name -Ids $Id
 
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'user-group-quota-policies/rules' -QueryParams $queryParams -AutoPaginate
     }

--- a/Public/Policy/New-PfbUserGroupQuotaPolicy.ps1
+++ b/Public/Policy/New-PfbUserGroupQuotaPolicy.ps1
@@ -1,0 +1,77 @@
+function New-PfbUserGroupQuotaPolicy {
+    <#
+    .SYNOPSIS
+        Creates a new user/group quota policy on a FlashBlade array.
+    .DESCRIPTION
+        The New-PfbUserGroupQuotaPolicy cmdlet creates a new user-group-quota policy on the
+        connected Pure Storage FlashBlade. Either build a policy from scratch with -Enabled/
+        -Location/-Rules, or import an existing file system's legacy purequota/purefs quota
+        configuration into a new policy by specifying -FileSystemName or -FileSystemId
+        (mutually exclusive with each other).
+    .PARAMETER Name
+        The name for the new policy.
+    .PARAMETER FileSystemName
+        The name of a file system whose existing legacy quota configuration should be
+        imported into this new policy. Mutually exclusive with -FileSystemId.
+    .PARAMETER FileSystemId
+        The ID of a file system whose existing legacy quota configuration should be imported
+        into this new policy. Mutually exclusive with -FileSystemName.
+    .PARAMETER Enabled
+        Whether the policy is enabled. Defaults to true on the array if not specified.
+    .PARAMETER Location
+        A hashtable reference to the array where the policy is defined (fleet/realm use).
+    .PARAMETER Rules
+        An array of rule hashtables to create the policy with (see New-PfbUserGroupQuotaPolicyRule
+        for individual rule shape, e.g. @{ subject = @{ name = 'jdoe' }; quota_type = 'user';
+        quota_limit = 1073741824 }).
+    .PARAMETER Attributes
+        A hashtable used verbatim as the request body, overriding -Enabled/-Location/-Rules.
+    .PARAMETER Array
+        The FlashBlade connection object. If not specified, the default connection is used.
+    .EXAMPLE
+        New-PfbUserGroupQuotaPolicy -Name "quota-pol-1" -Rules @(@{ subject = @{ name = 'jdoe' }; quota_type = 'user'; quota_limit = 1073741824 })
+
+        Creates a policy with one user quota rule for 'jdoe'.
+    .EXAMPLE
+        New-PfbUserGroupQuotaPolicy -Name "imported-pol" -FileSystemName "fs-home"
+
+        Creates a new policy by importing 'fs-home''s existing legacy quota configuration.
+    .EXAMPLE
+        New-PfbUserGroupQuotaPolicy -Name "quota-pol-1" -WhatIf
+
+        Shows what would happen without actually creating the policy.
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
+    param(
+        [Parameter(Mandatory, Position = 0)] [string]$Name,
+        [Parameter()] [string]$FileSystemName,
+        [Parameter()] [string]$FileSystemId,
+        [Parameter()] [Nullable[bool]]$Enabled,
+        [Parameter()] [hashtable]$Location,
+        [Parameter()] [hashtable[]]$Rules,
+        [Parameter()] [hashtable]$Attributes,
+        [Parameter()] [PSCustomObject]$Array
+    )
+
+    if ($FileSystemName -and $FileSystemId) {
+        throw '-FileSystemName and -FileSystemId cannot both be specified.'
+    }
+
+    Assert-PfbConnection -Array ([ref]$Array)
+
+    if ($Attributes) { $body = $Attributes }
+    else {
+        $body = @{}
+        if ($PSBoundParameters.ContainsKey('Enabled')) { $body['enabled'] = [bool]$Enabled }
+        if ($Location) { $body['location'] = $Location }
+        if ($Rules)    { $body['rules']    = $Rules }
+    }
+
+    $queryParams = @{ 'names' = $Name }
+    if ($FileSystemName) { $queryParams['file_system_names'] = $FileSystemName }
+    if ($FileSystemId)   { $queryParams['file_system_ids']   = $FileSystemId }
+
+    if ($PSCmdlet.ShouldProcess($Name, 'Create user-group-quota policy')) {
+        Invoke-PfbApiRequest -Array $Array -Method POST -Endpoint 'user-group-quota-policies' -Body $body -QueryParams $queryParams
+    }
+}

--- a/Public/Policy/New-PfbUserGroupQuotaPolicyFileSystem.ps1
+++ b/Public/Policy/New-PfbUserGroupQuotaPolicyFileSystem.ps1
@@ -1,0 +1,57 @@
+function New-PfbUserGroupQuotaPolicyFileSystem {
+    <#
+    .SYNOPSIS
+        Attaches a user/group quota policy to a file system on a FlashBlade array.
+    .DESCRIPTION
+        The New-PfbUserGroupQuotaPolicyFileSystem cmdlet associates an existing
+        user-group-quota policy with a file system on the connected Pure Storage FlashBlade.
+    .PARAMETER PolicyName
+        The name of the policy to attach.
+    .PARAMETER PolicyId
+        The ID of the policy to attach.
+    .PARAMETER MemberName
+        The name of the file system to attach the policy to.
+    .PARAMETER MemberId
+        The ID of the file system to attach the policy to.
+    .PARAMETER DeleteExistingUserGroupQuotaSettings
+        If set, deletes the file system's existing legacy purequota/purefs quota settings
+        when attaching this policy.
+    .PARAMETER IgnoreUsage
+        If set, existing user/group usage on the file system is not checked against the
+        policy's rules.
+    .PARAMETER Array
+        The FlashBlade connection object. If not specified, the default connection is used.
+    .EXAMPLE
+        New-PfbUserGroupQuotaPolicyFileSystem -PolicyName "quota-pol-1" -MemberName "fs1"
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
+    param(
+        [Parameter()] [string]$PolicyName,
+        [Parameter()] [string]$PolicyId,
+        [Parameter()] [string]$MemberName,
+        [Parameter()] [string]$MemberId,
+        [Parameter()] [switch]$DeleteExistingUserGroupQuotaSettings,
+        [Parameter()] [switch]$IgnoreUsage,
+        [Parameter()] [PSCustomObject]$Array
+    )
+
+    if (-not $PolicyName -and -not $PolicyId) { throw 'You must supply either -PolicyName or -PolicyId.' }
+    if (-not $MemberName -and -not $MemberId) { throw 'You must supply either -MemberName or -MemberId.' }
+
+    Assert-PfbConnection -Array ([ref]$Array)
+
+    $queryParams = @{}
+    if ($PolicyName) { $queryParams['policy_names'] = $PolicyName }
+    if ($PolicyId)   { $queryParams['policy_ids']   = $PolicyId }
+    if ($MemberName) { $queryParams['member_names'] = $MemberName }
+    if ($MemberId)   { $queryParams['member_ids']   = $MemberId }
+    if ($DeleteExistingUserGroupQuotaSettings) { $queryParams['delete_existing_user_group_quota_settings'] = 'true' }
+    if ($IgnoreUsage) { $queryParams['ignore_usage'] = 'true' }
+
+    $target = if ($MemberName) { $MemberName } else { $MemberId }
+    $policy = if ($PolicyName) { $PolicyName } else { $PolicyId }
+
+    if ($PSCmdlet.ShouldProcess($target, "Attach user-group-quota policy '$policy'")) {
+        Invoke-PfbApiRequest -Array $Array -Method POST -Endpoint 'user-group-quota-policies/file-systems' -QueryParams $queryParams
+    }
+}

--- a/Public/Policy/New-PfbUserGroupQuotaPolicyRule.ps1
+++ b/Public/Policy/New-PfbUserGroupQuotaPolicyRule.ps1
@@ -1,0 +1,83 @@
+function New-PfbUserGroupQuotaPolicyRule {
+    <#
+    .SYNOPSIS
+        Adds a quota rule to a user/group quota policy on a FlashBlade array.
+    .DESCRIPTION
+        The New-PfbUserGroupQuotaPolicyRule cmdlet adds a new rule to an existing
+        user-group-quota policy on the connected Pure Storage FlashBlade. A rule applies a
+        quota limit to a specific user or group (-Subject with -QuotaType 'user'/'group'), or
+        sets the policy's default for all users/groups (-QuotaType 'user-default'/
+        'group-default', which cannot be combined with -Subject).
+    .PARAMETER PolicyName
+        The name of the policy to add the rule to.
+    .PARAMETER PolicyId
+        The ID of the policy to add the rule to.
+    .PARAMETER Subject
+        A hashtable identifying the user or group the rule applies to, e.g. @{ name = 'jdoe' },
+        @{ id = 1001 } (UID/GID), or @{ sid = 'S-1-5-...' }. Omit for -QuotaType
+        'user-default'/'group-default'.
+    .PARAMETER QuotaType
+        The rule's quota type: 'user', 'group', 'user-default', or 'group-default'.
+    .PARAMETER QuotaLimit
+        The quota limit in bytes. Cannot be 0.
+    .PARAMETER Enforced
+        If true, exceeding the quota is a hard error; if false, it is advisory-only.
+    .PARAMETER Notifications
+        Whether to notify the affected subject: 'None' or 'Account' (default 'Account').
+    .PARAMETER IgnoreUsage
+        If set, existing user/group usage is not checked against this rule's quota_limit.
+    .PARAMETER Attributes
+        A hashtable used verbatim as the request body, overriding -Subject/-QuotaType/
+        -QuotaLimit/-Enforced/-Notifications.
+    .PARAMETER Array
+        The FlashBlade connection object. If not specified, the default connection is used.
+    .EXAMPLE
+        New-PfbUserGroupQuotaPolicyRule -PolicyName "quota-pol-1" -Subject @{ name = 'jdoe' } -QuotaType user -QuotaLimit 1073741824
+
+        Adds a 1 GiB quota rule for user 'jdoe' to 'quota-pol-1'.
+    .EXAMPLE
+        New-PfbUserGroupQuotaPolicyRule -PolicyName "quota-pol-1" -QuotaType user-default -QuotaLimit 536870912
+
+        Sets a 512 MiB default quota for all users under 'quota-pol-1'.
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
+    param(
+        [Parameter(ParameterSetName = 'ByPolicyName', Mandatory, Position = 0)]
+        [string]$PolicyName,
+
+        [Parameter(ParameterSetName = 'ByPolicyId', Mandatory)]
+        [string]$PolicyId,
+
+        [Parameter()] [hashtable]$Subject,
+        [Parameter()] [ValidateSet('user', 'group', 'user-default', 'group-default')] [string]$QuotaType,
+        [Parameter()] [int64]$QuotaLimit,
+        [Parameter()] [Nullable[bool]]$Enforced,
+        [Parameter()] [ValidateSet('None', 'Account')] [string]$Notifications,
+        [Parameter()] [switch]$IgnoreUsage,
+        [Parameter()] [hashtable]$Attributes,
+        [Parameter()] [PSCustomObject]$Array
+    )
+
+    Assert-PfbConnection -Array ([ref]$Array)
+
+    if ($Attributes) { $body = $Attributes }
+    else {
+        $body = @{}
+        if ($Subject)   { $body['subject']    = $Subject }
+        if ($QuotaType) { $body['quota_type'] = $QuotaType }
+        if ($PSBoundParameters.ContainsKey('QuotaLimit')) { $body['quota_limit'] = $QuotaLimit }
+        if ($PSBoundParameters.ContainsKey('Enforced'))   { $body['enforced']    = [bool]$Enforced }
+        if ($Notifications) { $body['notifications'] = $Notifications }
+    }
+
+    $queryParams = @{}
+    if ($PolicyName) { $queryParams['policy_names'] = $PolicyName }
+    if ($PolicyId)   { $queryParams['policy_ids']   = $PolicyId }
+    if ($IgnoreUsage) { $queryParams['ignore_usage'] = 'true' }
+
+    $target = if ($PolicyName) { $PolicyName } else { $PolicyId }
+
+    if ($PSCmdlet.ShouldProcess($target, 'Add user-group-quota policy rule')) {
+        Invoke-PfbApiRequest -Array $Array -Method POST -Endpoint 'user-group-quota-policies/rules' -Body $body -QueryParams $queryParams
+    }
+}

--- a/Public/Policy/New-PfbUserGroupQuotaPolicyRule.ps1
+++ b/Public/Policy/New-PfbUserGroupQuotaPolicyRule.ps1
@@ -50,13 +50,20 @@ function New-PfbUserGroupQuotaPolicyRule {
 
         [Parameter()] [hashtable]$Subject,
         [Parameter()] [ValidateSet('user', 'group', 'user-default', 'group-default')] [string]$QuotaType,
-        [Parameter()] [int64]$QuotaLimit,
+
+        [Parameter()]
+        [ValidateScript({ if ($_ -eq 0) { throw '-QuotaLimit cannot be 0.' }; $true })]
+        [int64]$QuotaLimit,
         [Parameter()] [Nullable[bool]]$Enforced,
         [Parameter()] [ValidateSet('None', 'Account')] [string]$Notifications,
         [Parameter()] [switch]$IgnoreUsage,
         [Parameter()] [hashtable]$Attributes,
         [Parameter()] [PSCustomObject]$Array
     )
+
+    if ($Subject -and $QuotaType -in @('user-default', 'group-default')) {
+        throw "-QuotaType '$QuotaType' cannot be combined with -Subject."
+    }
 
     Assert-PfbConnection -Array ([ref]$Array)
 

--- a/Public/Policy/Remove-PfbUserGroupQuotaPolicy.ps1
+++ b/Public/Policy/Remove-PfbUserGroupQuotaPolicy.ps1
@@ -1,0 +1,45 @@
+function Remove-PfbUserGroupQuotaPolicy {
+    <#
+    .SYNOPSIS
+        Removes a user/group quota policy from a FlashBlade array.
+    .PARAMETER Name
+        The name of the policy to remove.
+    .PARAMETER Id
+        The ID of the policy to remove.
+    .PARAMETER Version
+        One or more version tags for optimistic concurrency control, ordered to match
+        -Name/-Id. Fails with a 412 if the resource's current version doesn't match.
+    .PARAMETER Array
+        The FlashBlade connection object. If not specified, the default connection is used.
+    .EXAMPLE
+        Remove-PfbUserGroupQuotaPolicy -Name "quota-pol-1"
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
+    param(
+        [Parameter(ParameterSetName = 'ByName', Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)]
+        [ValidateScript({ Assert-PfbSafeName $_ })]
+        [string]$Name,
+
+        [Parameter(ParameterSetName = 'ById', Mandatory)]
+        [string]$Id,
+
+        [Parameter()] [string[]]$Version,
+        [Parameter()] [PSCustomObject]$Array
+    )
+
+    begin {
+        Assert-PfbConnection -Array ([ref]$Array)
+    }
+
+    process {
+        $target = if ($Name) { $Name } else { $Id }
+        $queryParams = @{}
+        if ($Name) { $queryParams['names'] = $Name }
+        if ($Id)   { $queryParams['ids']   = $Id }
+        if ($Version) { $queryParams['versions'] = $Version -join ',' }
+
+        if ($PSCmdlet.ShouldProcess($target, 'Remove user-group-quota policy')) {
+            Invoke-PfbApiRequest -Array $Array -Method DELETE -Endpoint 'user-group-quota-policies' -QueryParams $queryParams
+        }
+    }
+}

--- a/Public/Policy/Remove-PfbUserGroupQuotaPolicy.ps1
+++ b/Public/Policy/Remove-PfbUserGroupQuotaPolicy.ps1
@@ -7,8 +7,8 @@ function Remove-PfbUserGroupQuotaPolicy {
     .PARAMETER Id
         The ID of the policy to remove.
     .PARAMETER Version
-        One or more version tags for optimistic concurrency control, ordered to match
-        -Name/-Id. Fails with a 412 if the resource's current version doesn't match.
+        One or more version tags for optimistic concurrency control. Fails with a 412 if the
+        resource's current version doesn't match.
     .PARAMETER Array
         The FlashBlade connection object. If not specified, the default connection is used.
     .EXAMPLE

--- a/Public/Policy/Remove-PfbUserGroupQuotaPolicyFileSystem.ps1
+++ b/Public/Policy/Remove-PfbUserGroupQuotaPolicyFileSystem.ps1
@@ -1,0 +1,40 @@
+function Remove-PfbUserGroupQuotaPolicyFileSystem {
+    <#
+    .SYNOPSIS
+        Detaches a user/group quota policy from a file system on a FlashBlade array.
+    .PARAMETER PolicyName
+        The name of the policy to detach.
+    .PARAMETER PolicyId
+        The ID of the policy to detach.
+    .PARAMETER MemberName
+        The name of the file system to detach the policy from.
+    .PARAMETER MemberId
+        The ID of the file system to detach the policy from.
+    .PARAMETER Array
+        The FlashBlade connection object. If not specified, the default connection is used.
+    .EXAMPLE
+        Remove-PfbUserGroupQuotaPolicyFileSystem -PolicyName "quota-pol-1" -MemberName "fs1"
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
+    param(
+        [Parameter()] [string]$PolicyName,
+        [Parameter()] [string]$PolicyId,
+        [Parameter()] [string]$MemberName,
+        [Parameter()] [string]$MemberId,
+        [Parameter()] [PSCustomObject]$Array
+    )
+
+    Assert-PfbConnection -Array ([ref]$Array)
+
+    $queryParams = @{}
+    if ($PolicyName) { $queryParams['policy_names'] = $PolicyName }
+    if ($PolicyId)   { $queryParams['policy_ids']   = $PolicyId }
+    if ($MemberName) { $queryParams['member_names'] = $MemberName }
+    if ($MemberId)   { $queryParams['member_ids']   = $MemberId }
+
+    $target = "${PolicyName}:${MemberName}"
+
+    if ($PSCmdlet.ShouldProcess($target, 'Detach user-group-quota policy from file system')) {
+        Invoke-PfbApiRequest -Array $Array -Method DELETE -Endpoint 'user-group-quota-policies/file-systems' -QueryParams $queryParams
+    }
+}

--- a/Public/Policy/Remove-PfbUserGroupQuotaPolicyFileSystem.ps1
+++ b/Public/Policy/Remove-PfbUserGroupQuotaPolicyFileSystem.ps1
@@ -17,9 +17,16 @@ function Remove-PfbUserGroupQuotaPolicyFileSystem {
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
     param(
-        [Parameter()] [string]$PolicyName,
+        [Parameter()]
+        [ValidateScript({ Assert-PfbSafeName $_ })]
+        [string]$PolicyName,
+
         [Parameter()] [string]$PolicyId,
-        [Parameter()] [string]$MemberName,
+
+        [Parameter()]
+        [ValidateScript({ Assert-PfbSafeName $_ })]
+        [string]$MemberName,
+
         [Parameter()] [string]$MemberId,
         [Parameter()] [PSCustomObject]$Array
     )
@@ -39,10 +46,10 @@ function Remove-PfbUserGroupQuotaPolicyFileSystem {
     if ($MemberName) { $queryParams['member_names'] = $MemberName }
     if ($MemberId)   { $queryParams['member_ids']   = $MemberId }
 
-    $target = if ($PolicyName) { $PolicyName } else { $PolicyId }
+    $policy = if ($PolicyName) { $PolicyName } else { $PolicyId }
     $member = if ($MemberName) { $MemberName } else { $MemberId }
 
-    if ($PSCmdlet.ShouldProcess("${target}:${member}", 'Detach user-group-quota policy from file system')) {
+    if ($PSCmdlet.ShouldProcess($member, "Detach user-group-quota policy '$policy'")) {
         Invoke-PfbApiRequest -Array $Array -Method DELETE -Endpoint 'user-group-quota-policies/file-systems' -QueryParams $queryParams
     }
 }

--- a/Public/Policy/Remove-PfbUserGroupQuotaPolicyFileSystem.ps1
+++ b/Public/Policy/Remove-PfbUserGroupQuotaPolicyFileSystem.ps1
@@ -24,6 +24,13 @@ function Remove-PfbUserGroupQuotaPolicyFileSystem {
         [Parameter()] [PSCustomObject]$Array
     )
 
+    if (-not $PolicyName -and -not $PolicyId) {
+        throw 'You must supply either -PolicyName or -PolicyId.'
+    }
+    if (-not $MemberName -and -not $MemberId) {
+        throw 'You must supply either -MemberName or -MemberId.'
+    }
+
     Assert-PfbConnection -Array ([ref]$Array)
 
     $queryParams = @{}
@@ -32,9 +39,10 @@ function Remove-PfbUserGroupQuotaPolicyFileSystem {
     if ($MemberName) { $queryParams['member_names'] = $MemberName }
     if ($MemberId)   { $queryParams['member_ids']   = $MemberId }
 
-    $target = "${PolicyName}:${MemberName}"
+    $target = if ($PolicyName) { $PolicyName } else { $PolicyId }
+    $member = if ($MemberName) { $MemberName } else { $MemberId }
 
-    if ($PSCmdlet.ShouldProcess($target, 'Detach user-group-quota policy from file system')) {
+    if ($PSCmdlet.ShouldProcess("${target}:${member}", 'Detach user-group-quota policy from file system')) {
         Invoke-PfbApiRequest -Array $Array -Method DELETE -Endpoint 'user-group-quota-policies/file-systems' -QueryParams $queryParams
     }
 }

--- a/Public/Policy/Remove-PfbUserGroupQuotaPolicyRule.ps1
+++ b/Public/Policy/Remove-PfbUserGroupQuotaPolicyRule.ps1
@@ -5,7 +5,9 @@ function Remove-PfbUserGroupQuotaPolicyRule {
     .DESCRIPTION
         The Remove-PfbUserGroupQuotaPolicyRule cmdlet deletes rules from a user-group-quota
         policy on the connected Pure Storage FlashBlade. Target specific rules with -Name/-Id,
-        or clear every rule belonging to a policy with -PolicyName/-PolicyId alone.
+        or clear every rule belonging to a policy with -PolicyName/-PolicyId alone. When both
+        -Name/-Id and -PolicyName/-PolicyId are supplied together, they combine as AND: only
+        the named rule(s) that also belong to the named policy/policies are removed.
     .PARAMETER Name
         One or more rule names to remove.
     .PARAMETER Id
@@ -25,18 +27,25 @@ function Remove-PfbUserGroupQuotaPolicyRule {
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
     param(
-        [Parameter()] [string[]]$Name,
+        [Parameter()]
+        [ValidateScript({ Assert-PfbSafeName $_ })]
+        [string[]]$Name,
+
         [Parameter()] [string[]]$Id,
-        [Parameter()] [string[]]$PolicyName,
+
+        [Parameter()]
+        [ValidateScript({ Assert-PfbSafeName $_ })]
+        [string[]]$PolicyName,
+
         [Parameter()] [string[]]$PolicyId,
         [Parameter()] [PSCustomObject]$Array
     )
 
-    Assert-PfbConnection -Array ([ref]$Array)
-
     if (-not $Name -and -not $Id -and -not $PolicyName -and -not $PolicyId) {
         throw 'You must supply at least one of -Name, -Id, -PolicyName, or -PolicyId.'
     }
+
+    Assert-PfbConnection -Array ([ref]$Array)
 
     $queryParams = @{}
     if ($Name)       { $queryParams['names']        = $Name -join ',' }

--- a/Public/Policy/Remove-PfbUserGroupQuotaPolicyRule.ps1
+++ b/Public/Policy/Remove-PfbUserGroupQuotaPolicyRule.ps1
@@ -1,0 +1,52 @@
+function Remove-PfbUserGroupQuotaPolicyRule {
+    <#
+    .SYNOPSIS
+        Removes one or more user/group quota policy rules from a FlashBlade array.
+    .DESCRIPTION
+        The Remove-PfbUserGroupQuotaPolicyRule cmdlet deletes rules from a user-group-quota
+        policy on the connected Pure Storage FlashBlade. Target specific rules with -Name/-Id,
+        or clear every rule belonging to a policy with -PolicyName/-PolicyId alone.
+    .PARAMETER Name
+        One or more rule names to remove.
+    .PARAMETER Id
+        One or more rule IDs to remove.
+    .PARAMETER PolicyName
+        One or more policy names; removes all rules belonging to these policies.
+    .PARAMETER PolicyId
+        One or more policy IDs; removes all rules belonging to these policies.
+    .PARAMETER Array
+        The FlashBlade connection object. If not specified, the default connection is used.
+    .EXAMPLE
+        Remove-PfbUserGroupQuotaPolicyRule -Name "quota-pol-1.1"
+    .EXAMPLE
+        Remove-PfbUserGroupQuotaPolicyRule -PolicyName "quota-pol-1"
+
+        Removes every rule belonging to 'quota-pol-1'.
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
+    param(
+        [Parameter()] [string[]]$Name,
+        [Parameter()] [string[]]$Id,
+        [Parameter()] [string[]]$PolicyName,
+        [Parameter()] [string[]]$PolicyId,
+        [Parameter()] [PSCustomObject]$Array
+    )
+
+    Assert-PfbConnection -Array ([ref]$Array)
+
+    if (-not $Name -and -not $Id -and -not $PolicyName -and -not $PolicyId) {
+        throw 'You must supply at least one of -Name, -Id, -PolicyName, or -PolicyId.'
+    }
+
+    $queryParams = @{}
+    if ($Name)       { $queryParams['names']        = $Name -join ',' }
+    if ($Id)         { $queryParams['ids']          = $Id -join ',' }
+    if ($PolicyName) { $queryParams['policy_names'] = $PolicyName -join ',' }
+    if ($PolicyId)   { $queryParams['policy_ids']   = $PolicyId -join ',' }
+
+    $target = if ($Name) { $Name -join ',' } elseif ($Id) { $Id -join ',' } elseif ($PolicyName) { "policy:$($PolicyName -join ',')" } else { "policy:$($PolicyId -join ',')" }
+
+    if ($PSCmdlet.ShouldProcess($target, 'Remove user-group-quota policy rule')) {
+        Invoke-PfbApiRequest -Array $Array -Method DELETE -Endpoint 'user-group-quota-policies/rules' -QueryParams $queryParams
+    }
+}

--- a/Public/Policy/Update-PfbUserGroupQuotaPolicy.ps1
+++ b/Public/Policy/Update-PfbUserGroupQuotaPolicy.ps1
@@ -1,0 +1,68 @@
+function Update-PfbUserGroupQuotaPolicy {
+    <#
+    .SYNOPSIS
+        Updates an existing user/group quota policy on a FlashBlade array.
+    .PARAMETER Name
+        The name of the policy to update.
+    .PARAMETER Id
+        The ID of the policy to update.
+    .PARAMETER Enabled
+        Enable or disable the policy.
+    .PARAMETER Location
+        A hashtable reference to the array where the policy is defined (fleet/realm use).
+    .PARAMETER Rules
+        Replaces the policy's rules with this array of rule hashtables.
+    .PARAMETER IgnoreUsage
+        If set, user/group usage is not checked against the rules' quota_limits.
+    .PARAMETER Version
+        One or more version tags for optimistic concurrency control, ordered to match
+        -Name/-Id. Fails with a 412 if the resource's current version doesn't match.
+    .PARAMETER Attributes
+        A hashtable used verbatim as the request body, overriding -Enabled/-Location/-Rules.
+    .PARAMETER Array
+        The FlashBlade connection object. If not specified, the default connection is used.
+    .EXAMPLE
+        Update-PfbUserGroupQuotaPolicy -Name "quota-pol-1" -Enabled:$false
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
+    param(
+        [Parameter(ParameterSetName = 'ByName', Mandatory, ValueFromPipelineByPropertyName)]
+        [string]$Name,
+
+        [Parameter(ParameterSetName = 'ById', Mandatory)]
+        [string]$Id,
+
+        [Parameter()] [Nullable[bool]]$Enabled,
+        [Parameter()] [hashtable]$Location,
+        [Parameter()] [hashtable[]]$Rules,
+        [Parameter()] [switch]$IgnoreUsage,
+        [Parameter()] [string[]]$Version,
+        [Parameter()] [hashtable]$Attributes,
+        [Parameter()] [PSCustomObject]$Array
+    )
+
+    begin {
+        Assert-PfbConnection -Array ([ref]$Array)
+    }
+
+    process {
+        if ($Attributes) { $body = $Attributes }
+        else {
+            $body = @{}
+            if ($PSBoundParameters.ContainsKey('Enabled')) { $body['enabled'] = [bool]$Enabled }
+            if ($Location) { $body['location'] = $Location }
+            if ($Rules)    { $body['rules']    = $Rules }
+        }
+
+        $queryParams = @{}
+        if ($Name) { $queryParams['names'] = $Name }
+        if ($Id)   { $queryParams['ids']   = $Id }
+        if ($IgnoreUsage) { $queryParams['ignore_usage'] = 'true' }
+        if ($Version) { $queryParams['versions'] = $Version -join ',' }
+        $target = if ($Name) { $Name } else { $Id }
+
+        if ($PSCmdlet.ShouldProcess($target, 'Update user-group-quota policy')) {
+            Invoke-PfbApiRequest -Array $Array -Method PATCH -Endpoint 'user-group-quota-policies' -Body $body -QueryParams $queryParams
+        }
+    }
+}

--- a/Public/Policy/Update-PfbUserGroupQuotaPolicy.ps1
+++ b/Public/Policy/Update-PfbUserGroupQuotaPolicy.ps1
@@ -15,8 +15,8 @@ function Update-PfbUserGroupQuotaPolicy {
     .PARAMETER IgnoreUsage
         If set, user/group usage is not checked against the rules' quota_limits.
     .PARAMETER Version
-        One or more version tags for optimistic concurrency control, ordered to match
-        -Name/-Id. Fails with a 412 if the resource's current version doesn't match.
+        One or more version tags for optimistic concurrency control. Fails with a 412 if the
+        resource's current version doesn't match.
     .PARAMETER Attributes
         A hashtable used verbatim as the request body, overriding -Enabled/-Location/-Rules.
     .PARAMETER Array
@@ -27,6 +27,7 @@ function Update-PfbUserGroupQuotaPolicy {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
     param(
         [Parameter(ParameterSetName = 'ByName', Mandatory, ValueFromPipelineByPropertyName)]
+        [ValidateScript({ Assert-PfbSafeName $_ })]
         [string]$Name,
 
         [Parameter(ParameterSetName = 'ById', Mandatory)]

--- a/Public/Policy/Update-PfbUserGroupQuotaPolicyRule.ps1
+++ b/Public/Policy/Update-PfbUserGroupQuotaPolicyRule.ps1
@@ -26,12 +26,15 @@ function Update-PfbUserGroupQuotaPolicyRule {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
     param(
         [Parameter(ParameterSetName = 'ByName', Mandatory, ValueFromPipelineByPropertyName)]
+        [ValidateScript({ Assert-PfbSafeName $_ })]
         [string]$Name,
 
         [Parameter(ParameterSetName = 'ById', Mandatory)]
         [string]$Id,
 
-        [Parameter()] [int64]$QuotaLimit,
+        [Parameter()]
+        [ValidateScript({ if ($_ -eq 0) { throw '-QuotaLimit cannot be 0.' }; $true })]
+        [int64]$QuotaLimit,
         [Parameter()] [ValidateSet('None', 'Account')] [string]$Notifications,
         [Parameter()] [switch]$IgnoreUsage,
         [Parameter()] [hashtable]$Attributes,

--- a/Public/Policy/Update-PfbUserGroupQuotaPolicyRule.ps1
+++ b/Public/Policy/Update-PfbUserGroupQuotaPolicyRule.ps1
@@ -1,0 +1,63 @@
+function Update-PfbUserGroupQuotaPolicyRule {
+    <#
+    .SYNOPSIS
+        Updates a user/group quota policy rule on a FlashBlade array.
+    .DESCRIPTION
+        The Update-PfbUserGroupQuotaPolicyRule cmdlet modifies an existing user-group-quota
+        policy rule. Only -QuotaLimit and -Notifications can be changed after creation; to
+        change a rule's subject or quota type, remove and recreate it.
+    .PARAMETER Name
+        The name of the rule to update.
+    .PARAMETER Id
+        The ID of the rule to update.
+    .PARAMETER QuotaLimit
+        The new quota limit in bytes. Cannot be 0.
+    .PARAMETER Notifications
+        Whether to notify the affected subject: 'None' or 'Account'.
+    .PARAMETER IgnoreUsage
+        If set, existing user/group usage is not checked against the new quota_limit.
+    .PARAMETER Attributes
+        A hashtable used verbatim as the request body, overriding -QuotaLimit/-Notifications.
+    .PARAMETER Array
+        The FlashBlade connection object. If not specified, the default connection is used.
+    .EXAMPLE
+        Update-PfbUserGroupQuotaPolicyRule -Name "quota-pol-1.1" -QuotaLimit 2147483648
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
+    param(
+        [Parameter(ParameterSetName = 'ByName', Mandatory, ValueFromPipelineByPropertyName)]
+        [string]$Name,
+
+        [Parameter(ParameterSetName = 'ById', Mandatory)]
+        [string]$Id,
+
+        [Parameter()] [int64]$QuotaLimit,
+        [Parameter()] [ValidateSet('None', 'Account')] [string]$Notifications,
+        [Parameter()] [switch]$IgnoreUsage,
+        [Parameter()] [hashtable]$Attributes,
+        [Parameter()] [PSCustomObject]$Array
+    )
+
+    begin {
+        Assert-PfbConnection -Array ([ref]$Array)
+    }
+
+    process {
+        if ($Attributes) { $body = $Attributes }
+        else {
+            $body = @{}
+            if ($PSBoundParameters.ContainsKey('QuotaLimit')) { $body['quota_limit'] = $QuotaLimit }
+            if ($Notifications) { $body['notifications'] = $Notifications }
+        }
+
+        $queryParams = @{}
+        if ($Name) { $queryParams['names'] = $Name }
+        if ($Id)   { $queryParams['ids']   = $Id }
+        if ($IgnoreUsage) { $queryParams['ignore_usage'] = 'true' }
+        $target = if ($Name) { $Name } else { $Id }
+
+        if ($PSCmdlet.ShouldProcess($target, 'Update user-group-quota policy rule')) {
+            Invoke-PfbApiRequest -Array $Array -Method PATCH -Endpoint 'user-group-quota-policies/rules' -Body $body -QueryParams $queryParams
+        }
+    }
+}

--- a/PureStorageFlashBladePowerShell.psd1
+++ b/PureStorageFlashBladePowerShell.psd1
@@ -535,7 +535,27 @@
         'Remove-PfbLocalGroup',
         'Get-PfbLocalGroupMember',
         'New-PfbLocalGroupMember',
-        'Remove-PfbLocalGroupMember'
+        'Remove-PfbLocalGroupMember',
+        # User/group quota policies (v2.3.0)
+        'Get-PfbUserGroupQuotaPolicy',
+        'New-PfbUserGroupQuotaPolicy',
+        'Update-PfbUserGroupQuotaPolicy',
+        'Remove-PfbUserGroupQuotaPolicy',
+        'Get-PfbUserGroupQuotaPolicyRule',
+        'New-PfbUserGroupQuotaPolicyRule',
+        'Update-PfbUserGroupQuotaPolicyRule',
+        'Remove-PfbUserGroupQuotaPolicyRule',
+        'Get-PfbUserGroupQuotaPolicyFileSystem',
+        'New-PfbUserGroupQuotaPolicyFileSystem',
+        'Remove-PfbUserGroupQuotaPolicyFileSystem',
+        'Get-PfbUserGroupQuotaPolicyMember',
+        'Get-PfbFileSystemUserGroupQuotaPolicy',
+        'New-PfbFileSystemUserGroupQuotaPolicy',
+        'Remove-PfbFileSystemUserGroupQuotaPolicy',
+        'Get-PfbFileSystemUserQuota',
+        'Get-PfbFileSystemGroupQuota',
+        'Get-PfbFileSystemUser',
+        'Get-PfbFileSystemGroup'
     )
     CmdletsToExport   = @()
     VariablesToExport  = @()

--- a/PureStorageFlashBladePowerShell.psd1
+++ b/PureStorageFlashBladePowerShell.psd1
@@ -536,7 +536,7 @@
         'Get-PfbLocalGroupMember',
         'New-PfbLocalGroupMember',
         'Remove-PfbLocalGroupMember',
-        # User/group quota policies (v2.3.0)
+        # User/group quota policies
         'Get-PfbUserGroupQuotaPolicy',
         'New-PfbUserGroupQuotaPolicy',
         'Update-PfbUserGroupQuotaPolicy',

--- a/Tests/Get-PfbFileSystemGroup.Tests.ps1
+++ b/Tests/Get-PfbFileSystemGroup.Tests.ps1
@@ -47,4 +47,27 @@ Describe 'Get-PfbFileSystemGroup' {
             $QueryParams['group_names'] -eq 'staff' -and $QueryParams['gids'] -eq '2001'
         }
     }
+
+    It 'honors falsy -Limit 0 and empty -Filter instead of dropping them' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbFileSystemGroup -Filter '' -Limit 0 -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams.ContainsKey('filter') -and $QueryParams['filter'] -eq '' -and
+            $QueryParams.ContainsKey('limit') -and $QueryParams['limit'] -eq 0
+        }
+    }
+
+    It 'sends total_only=true when -TotalOnly is set' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbFileSystemGroup -TotalOnly -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['total_only'] -eq 'true'
+        }
+    }
 }

--- a/Tests/Get-PfbFileSystemGroup.Tests.ps1
+++ b/Tests/Get-PfbFileSystemGroup.Tests.ps1
@@ -1,0 +1,50 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    $moduleRoot = Split-Path -Parent $PSScriptRoot
+    $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
+    Import-Module $manifest -Force
+
+    $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.25'; AuthToken = 'x' }
+}
+
+Describe 'Get-PfbFileSystemGroup' {
+
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+    }
+
+    It 'GETs file-systems/groups with AutoPaginate' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbFileSystemGroup -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'GET' -and $Endpoint -eq 'file-systems/groups' -and $AutoPaginate -eq $true
+        }
+    }
+
+    It 'filters by -FileSystemName' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbFileSystemGroup -FileSystemName 'fs1' -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['file_system_names'] -eq 'fs1'
+        }
+    }
+
+    It 'sends -GroupName as group_names and -GroupId as gids' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbFileSystemGroup -GroupName 'staff' -GroupId '2001' -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['group_names'] -eq 'staff' -and $QueryParams['gids'] -eq '2001'
+        }
+    }
+}

--- a/Tests/Get-PfbFileSystemGroupQuota.Tests.ps1
+++ b/Tests/Get-PfbFileSystemGroupQuota.Tests.ps1
@@ -58,4 +58,27 @@ Describe 'Get-PfbFileSystemGroupQuota' {
             $QueryParams['filter'] -eq 'quota > 0' -and $QueryParams['sort'] -eq 'usage-' -and $QueryParams['limit'] -eq 5
         }
     }
+
+    It 'honors falsy -Limit 0 and empty -Filter instead of dropping them' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbFileSystemGroupQuota -Filter '' -Limit 0 -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams.ContainsKey('filter') -and $QueryParams['filter'] -eq '' -and
+            $QueryParams.ContainsKey('limit') -and $QueryParams['limit'] -eq 0
+        }
+    }
+
+    It 'sends total_only=true when -TotalOnly is set' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbFileSystemGroupQuota -TotalOnly -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['total_only'] -eq 'true'
+        }
+    }
 }

--- a/Tests/Get-PfbFileSystemGroupQuota.Tests.ps1
+++ b/Tests/Get-PfbFileSystemGroupQuota.Tests.ps1
@@ -1,0 +1,61 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    $moduleRoot = Split-Path -Parent $PSScriptRoot
+    $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
+    Import-Module $manifest -Force
+
+    $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.25'; AuthToken = 'x' }
+}
+
+Describe 'Get-PfbFileSystemGroupQuota' {
+
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+    }
+
+    It 'GETs file-system-group-quotas with AutoPaginate' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbFileSystemGroupQuota -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'GET' -and $Endpoint -eq 'file-system-group-quotas' -and $AutoPaginate -eq $true
+        }
+    }
+
+    It 'filters by -FileSystemName' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbFileSystemGroupQuota -FileSystemName 'fs1' -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['file_system_names'] -eq 'fs1'
+        }
+    }
+
+    It 'sends -GroupName as group_names and -GroupId as gids' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbFileSystemGroupQuota -GroupName 'staff' -GroupId '2001' -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['group_names'] -eq 'staff' -and $QueryParams['gids'] -eq '2001'
+        }
+    }
+
+    It 'passes -Filter, -Sort, and -Limit through' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbFileSystemGroupQuota -Filter "quota > 0" -Sort 'usage-' -Limit 5 -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['filter'] -eq 'quota > 0' -and $QueryParams['sort'] -eq 'usage-' -and $QueryParams['limit'] -eq 5
+        }
+    }
+}

--- a/Tests/Get-PfbFileSystemUser.Tests.ps1
+++ b/Tests/Get-PfbFileSystemUser.Tests.ps1
@@ -47,4 +47,27 @@ Describe 'Get-PfbFileSystemUser' {
             $QueryParams['user_names'] -eq 'jdoe' -and $QueryParams['uids'] -eq '1001' -and $QueryParams['user_sids'] -eq 'S-1-5-1'
         }
     }
+
+    It 'honors falsy -Limit 0 and empty -Filter instead of dropping them' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbFileSystemUser -Filter '' -Limit 0 -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams.ContainsKey('filter') -and $QueryParams['filter'] -eq '' -and
+            $QueryParams.ContainsKey('limit') -and $QueryParams['limit'] -eq 0
+        }
+    }
+
+    It 'sends total_only=true when -TotalOnly is set' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbFileSystemUser -TotalOnly -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['total_only'] -eq 'true'
+        }
+    }
 }

--- a/Tests/Get-PfbFileSystemUser.Tests.ps1
+++ b/Tests/Get-PfbFileSystemUser.Tests.ps1
@@ -1,0 +1,50 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    $moduleRoot = Split-Path -Parent $PSScriptRoot
+    $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
+    Import-Module $manifest -Force
+
+    $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.25'; AuthToken = 'x' }
+}
+
+Describe 'Get-PfbFileSystemUser' {
+
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+    }
+
+    It 'GETs file-systems/users with AutoPaginate' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbFileSystemUser -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'GET' -and $Endpoint -eq 'file-systems/users' -and $AutoPaginate -eq $true
+        }
+    }
+
+    It 'filters by -FileSystemName' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbFileSystemUser -FileSystemName 'fs1' -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['file_system_names'] -eq 'fs1'
+        }
+    }
+
+    It 'sends -UserName as user_names, -UserId as uids, and -UserSid as user_sids' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbFileSystemUser -UserName 'jdoe' -UserId '1001' -UserSid 'S-1-5-1' -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['user_names'] -eq 'jdoe' -and $QueryParams['uids'] -eq '1001' -and $QueryParams['user_sids'] -eq 'S-1-5-1'
+        }
+    }
+}

--- a/Tests/Get-PfbFileSystemUserGroupQuotaPolicy.Tests.ps1
+++ b/Tests/Get-PfbFileSystemUserGroupQuotaPolicy.Tests.ps1
@@ -37,6 +37,17 @@ Describe 'Get-PfbFileSystemUserGroupQuotaPolicy' {
         }
     }
 
+    It 'filters by -PolicyId and -MemberId' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbFileSystemUserGroupQuotaPolicy -PolicyId 'pid-1' -MemberId 'mid-1' -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['policy_ids'] -eq 'pid-1' -and $QueryParams['member_ids'] -eq 'mid-1'
+        }
+    }
+
     It 'passes -Filter, -Sort, and -Limit through' {
         InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
             param($arr)
@@ -45,6 +56,29 @@ Describe 'Get-PfbFileSystemUserGroupQuotaPolicy' {
 
         Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
             $QueryParams['filter'] -eq "name='pol-1'" -and $QueryParams['sort'] -eq 'name-' -and $QueryParams['limit'] -eq 5
+        }
+    }
+
+    It 'honors falsy -Limit 0 and empty -Filter instead of dropping them' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbFileSystemUserGroupQuotaPolicy -Filter '' -Limit 0 -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams.ContainsKey('filter') -and $QueryParams['filter'] -eq '' -and
+            $QueryParams.ContainsKey('limit') -and $QueryParams['limit'] -eq 0
+        }
+    }
+
+    It 'sends total_only=true when -TotalOnly is set' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbFileSystemUserGroupQuotaPolicy -TotalOnly -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['total_only'] -eq 'true'
         }
     }
 }

--- a/Tests/Get-PfbFileSystemUserGroupQuotaPolicy.Tests.ps1
+++ b/Tests/Get-PfbFileSystemUserGroupQuotaPolicy.Tests.ps1
@@ -1,0 +1,50 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    $moduleRoot = Split-Path -Parent $PSScriptRoot
+    $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
+    Import-Module $manifest -Force
+
+    $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.25'; AuthToken = 'x' }
+}
+
+Describe 'Get-PfbFileSystemUserGroupQuotaPolicy' {
+
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+    }
+
+    It 'GETs file-systems/user-group-quota-policies with AutoPaginate' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbFileSystemUserGroupQuotaPolicy -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'GET' -and $Endpoint -eq 'file-systems/user-group-quota-policies' -and $AutoPaginate -eq $true
+        }
+    }
+
+    It 'filters by -MemberName (the file system) and -PolicyName' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbFileSystemUserGroupQuotaPolicy -MemberName 'fs1' -PolicyName 'pol-1' -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['member_names'] -eq 'fs1' -and $QueryParams['policy_names'] -eq 'pol-1'
+        }
+    }
+
+    It 'passes -Filter, -Sort, and -Limit through' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbFileSystemUserGroupQuotaPolicy -Filter "name='pol-1'" -Sort 'name-' -Limit 5 -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['filter'] -eq "name='pol-1'" -and $QueryParams['sort'] -eq 'name-' -and $QueryParams['limit'] -eq 5
+        }
+    }
+}

--- a/Tests/Get-PfbFileSystemUserQuota.Tests.ps1
+++ b/Tests/Get-PfbFileSystemUserQuota.Tests.ps1
@@ -1,0 +1,64 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    $moduleRoot = Split-Path -Parent $PSScriptRoot
+    $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
+    Import-Module $manifest -Force
+
+    $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.25'; AuthToken = 'x' }
+}
+
+Describe 'Get-PfbFileSystemUserQuota' {
+
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+    }
+
+    It 'GETs file-system-user-quotas with AutoPaginate' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbFileSystemUserQuota -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'GET' -and $Endpoint -eq 'file-system-user-quotas' -and $AutoPaginate -eq $true
+        }
+    }
+
+    It 'filters by -FileSystemName' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbFileSystemUserQuota -FileSystemName 'fs1' -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['file_system_names'] -eq 'fs1'
+        }
+    }
+
+    It 'sends -UserName as user_names, -UserId as uids (not user_ids), and -UserSid as user_sids' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbFileSystemUserQuota -UserName 'jdoe' -UserId '1001' -UserSid 'S-1-5-1' -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['user_names'] -eq 'jdoe' -and
+            $QueryParams['uids'] -eq '1001' -and
+            $QueryParams['user_sids'] -eq 'S-1-5-1' -and
+            -not $QueryParams.ContainsKey('user_ids')
+        }
+    }
+
+    It 'passes -Filter, -Sort, and -Limit through' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbFileSystemUserQuota -Filter "quota > 0" -Sort 'usage-' -Limit 5 -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['filter'] -eq 'quota > 0' -and $QueryParams['sort'] -eq 'usage-' -and $QueryParams['limit'] -eq 5
+        }
+    }
+}

--- a/Tests/Get-PfbFileSystemUserQuota.Tests.ps1
+++ b/Tests/Get-PfbFileSystemUserQuota.Tests.ps1
@@ -61,4 +61,27 @@ Describe 'Get-PfbFileSystemUserQuota' {
             $QueryParams['filter'] -eq 'quota > 0' -and $QueryParams['sort'] -eq 'usage-' -and $QueryParams['limit'] -eq 5
         }
     }
+
+    It 'honors falsy -Limit 0 and empty -Filter instead of dropping them' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbFileSystemUserQuota -Filter '' -Limit 0 -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams.ContainsKey('filter') -and $QueryParams['filter'] -eq '' -and
+            $QueryParams.ContainsKey('limit') -and $QueryParams['limit'] -eq 0
+        }
+    }
+
+    It 'sends total_only=true when -TotalOnly is set' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbFileSystemUserQuota -TotalOnly -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['total_only'] -eq 'true'
+        }
+    }
 }

--- a/Tests/Get-PfbUserGroupQuotaPolicy.Tests.ps1
+++ b/Tests/Get-PfbUserGroupQuotaPolicy.Tests.ps1
@@ -16,7 +16,10 @@ Describe 'Get-PfbUserGroupQuotaPolicy' {
     }
 
     It 'GETs user-group-quota-policies with AutoPaginate and no filters by default' {
-        Get-PfbUserGroupQuotaPolicy -Array $fakeArray
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbUserGroupQuotaPolicy -Array $arr
+        }
 
         Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
             $Method -eq 'GET' -and
@@ -27,7 +30,10 @@ Describe 'Get-PfbUserGroupQuotaPolicy' {
     }
 
     It 'joins -Name into a comma-separated names query param' {
-        Get-PfbUserGroupQuotaPolicy -Name 'pol-1', 'pol-2' -Array $fakeArray
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbUserGroupQuotaPolicy -Name 'pol-1', 'pol-2' -Array $arr
+        }
 
         Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
             $QueryParams['names'] -eq 'pol-1,pol-2'
@@ -35,7 +41,10 @@ Describe 'Get-PfbUserGroupQuotaPolicy' {
     }
 
     It 'sends -Id as the ids query param' {
-        Get-PfbUserGroupQuotaPolicy -Id 'id-1' -Array $fakeArray
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbUserGroupQuotaPolicy -Id 'id-1' -Array $arr
+        }
 
         Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
             $QueryParams['ids'] -eq 'id-1' -and -not $QueryParams.ContainsKey('names')
@@ -43,7 +52,10 @@ Describe 'Get-PfbUserGroupQuotaPolicy' {
     }
 
     It 'passes -Filter, -Sort, and -Limit through' {
-        Get-PfbUserGroupQuotaPolicy -Filter "enabled='true'" -Sort 'name-' -Limit 5 -Array $fakeArray
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbUserGroupQuotaPolicy -Filter "enabled='true'" -Sort 'name-' -Limit 5 -Array $arr
+        }
 
         Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
             $QueryParams['filter'] -eq "enabled='true'" -and

--- a/Tests/Get-PfbUserGroupQuotaPolicy.Tests.ps1
+++ b/Tests/Get-PfbUserGroupQuotaPolicy.Tests.ps1
@@ -1,0 +1,54 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    $moduleRoot = Split-Path -Parent $PSScriptRoot
+    $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
+    Import-Module $manifest -Force
+
+    $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.25'; AuthToken = 'x' }
+}
+
+Describe 'Get-PfbUserGroupQuotaPolicy' {
+
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+    }
+
+    It 'GETs user-group-quota-policies with AutoPaginate and no filters by default' {
+        Get-PfbUserGroupQuotaPolicy -Array $fakeArray
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'GET' -and
+            $Endpoint -eq 'user-group-quota-policies' -and
+            $AutoPaginate -eq $true -and
+            $QueryParams.Keys.Count -eq 0
+        }
+    }
+
+    It 'joins -Name into a comma-separated names query param' {
+        Get-PfbUserGroupQuotaPolicy -Name 'pol-1', 'pol-2' -Array $fakeArray
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['names'] -eq 'pol-1,pol-2'
+        }
+    }
+
+    It 'sends -Id as the ids query param' {
+        Get-PfbUserGroupQuotaPolicy -Id 'id-1' -Array $fakeArray
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['ids'] -eq 'id-1' -and -not $QueryParams.ContainsKey('names')
+        }
+    }
+
+    It 'passes -Filter, -Sort, and -Limit through' {
+        Get-PfbUserGroupQuotaPolicy -Filter "enabled='true'" -Sort 'name-' -Limit 5 -Array $fakeArray
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['filter'] -eq "enabled='true'" -and
+            $QueryParams['sort'] -eq 'name-' -and
+            $QueryParams['limit'] -eq 5
+        }
+    }
+}

--- a/Tests/Get-PfbUserGroupQuotaPolicy.Tests.ps1
+++ b/Tests/Get-PfbUserGroupQuotaPolicy.Tests.ps1
@@ -63,4 +63,27 @@ Describe 'Get-PfbUserGroupQuotaPolicy' {
             $QueryParams['limit'] -eq 5
         }
     }
+
+    It 'honors falsy -Limit 0 and empty -Filter instead of dropping them' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbUserGroupQuotaPolicy -Filter '' -Limit 0 -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams.ContainsKey('filter') -and $QueryParams['filter'] -eq '' -and
+            $QueryParams.ContainsKey('limit') -and $QueryParams['limit'] -eq 0
+        }
+    }
+
+    It 'sends total_only=true when -TotalOnly is set' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbUserGroupQuotaPolicy -TotalOnly -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['total_only'] -eq 'true'
+        }
+    }
 }

--- a/Tests/Get-PfbUserGroupQuotaPolicyFileSystem.Tests.ps1
+++ b/Tests/Get-PfbUserGroupQuotaPolicyFileSystem.Tests.ps1
@@ -58,4 +58,27 @@ Describe 'Get-PfbUserGroupQuotaPolicyFileSystem' {
             $QueryParams['filter'] -eq "name='fs1'" -and $QueryParams['sort'] -eq 'name-' -and $QueryParams['limit'] -eq 5
         }
     }
+
+    It 'honors falsy -Limit 0 and empty -Filter instead of dropping them' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbUserGroupQuotaPolicyFileSystem -Filter '' -Limit 0 -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams.ContainsKey('filter') -and $QueryParams['filter'] -eq '' -and
+            $QueryParams.ContainsKey('limit') -and $QueryParams['limit'] -eq 0
+        }
+    }
+
+    It 'sends total_only=true when -TotalOnly is set' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbUserGroupQuotaPolicyFileSystem -TotalOnly -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['total_only'] -eq 'true'
+        }
+    }
 }

--- a/Tests/Get-PfbUserGroupQuotaPolicyFileSystem.Tests.ps1
+++ b/Tests/Get-PfbUserGroupQuotaPolicyFileSystem.Tests.ps1
@@ -1,0 +1,61 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    $moduleRoot = Split-Path -Parent $PSScriptRoot
+    $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
+    Import-Module $manifest -Force
+
+    $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.25'; AuthToken = 'x' }
+}
+
+Describe 'Get-PfbUserGroupQuotaPolicyFileSystem' {
+
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+    }
+
+    It 'GETs user-group-quota-policies/file-systems with AutoPaginate' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbUserGroupQuotaPolicyFileSystem -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'GET' -and $Endpoint -eq 'user-group-quota-policies/file-systems' -and $AutoPaginate -eq $true
+        }
+    }
+
+    It 'filters by -PolicyName and -MemberName' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbUserGroupQuotaPolicyFileSystem -PolicyName 'pol-1' -MemberName 'fs1' -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['policy_names'] -eq 'pol-1' -and $QueryParams['member_names'] -eq 'fs1'
+        }
+    }
+
+    It 'filters by -PolicyId and -MemberId' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbUserGroupQuotaPolicyFileSystem -PolicyId 'pid-1' -MemberId 'mid-1' -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['policy_ids'] -eq 'pid-1' -and $QueryParams['member_ids'] -eq 'mid-1'
+        }
+    }
+
+    It 'passes -Filter, -Sort, and -Limit through' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbUserGroupQuotaPolicyFileSystem -Filter "name='fs1'" -Sort 'name-' -Limit 5 -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['filter'] -eq "name='fs1'" -and $QueryParams['sort'] -eq 'name-' -and $QueryParams['limit'] -eq 5
+        }
+    }
+}

--- a/Tests/Get-PfbUserGroupQuotaPolicyMember.Tests.ps1
+++ b/Tests/Get-PfbUserGroupQuotaPolicyMember.Tests.ps1
@@ -1,0 +1,50 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    $moduleRoot = Split-Path -Parent $PSScriptRoot
+    $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
+    Import-Module $manifest -Force
+
+    $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.25'; AuthToken = 'x' }
+}
+
+Describe 'Get-PfbUserGroupQuotaPolicyMember' {
+
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+    }
+
+    It 'GETs user-group-quota-policies/members with AutoPaginate' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbUserGroupQuotaPolicyMember -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'GET' -and $Endpoint -eq 'user-group-quota-policies/members' -and $AutoPaginate -eq $true
+        }
+    }
+
+    It 'filters by -PolicyName and -MemberName' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbUserGroupQuotaPolicyMember -PolicyName 'pol-1' -MemberName 'fs1' -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['policy_names'] -eq 'pol-1' -and $QueryParams['member_names'] -eq 'fs1'
+        }
+    }
+
+    It 'passes -Limit through' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbUserGroupQuotaPolicyMember -Limit 10 -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['limit'] -eq 10
+        }
+    }
+}

--- a/Tests/Get-PfbUserGroupQuotaPolicyMember.Tests.ps1
+++ b/Tests/Get-PfbUserGroupQuotaPolicyMember.Tests.ps1
@@ -47,4 +47,27 @@ Describe 'Get-PfbUserGroupQuotaPolicyMember' {
             $QueryParams['limit'] -eq 10
         }
     }
+
+    It 'honors falsy -Limit 0 and empty -Filter instead of dropping them' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbUserGroupQuotaPolicyMember -Filter '' -Limit 0 -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams.ContainsKey('filter') -and $QueryParams['filter'] -eq '' -and
+            $QueryParams.ContainsKey('limit') -and $QueryParams['limit'] -eq 0
+        }
+    }
+
+    It 'sends total_only=true when -TotalOnly is set' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbUserGroupQuotaPolicyMember -TotalOnly -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['total_only'] -eq 'true'
+        }
+    }
 }

--- a/Tests/Get-PfbUserGroupQuotaPolicyRule.Tests.ps1
+++ b/Tests/Get-PfbUserGroupQuotaPolicyRule.Tests.ps1
@@ -1,0 +1,83 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    $moduleRoot = Split-Path -Parent $PSScriptRoot
+    $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
+    Import-Module $manifest -Force
+
+    $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.25'; AuthToken = 'x' }
+}
+
+Describe 'Get-PfbUserGroupQuotaPolicyRule' {
+
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+    }
+
+    It 'GETs user-group-quota-policies/rules with AutoPaginate and no filters by default' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbUserGroupQuotaPolicyRule -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'GET' -and $Endpoint -eq 'user-group-quota-policies/rules' -and $AutoPaginate -eq $true
+        }
+    }
+
+    It 'scopes by -PolicyName via the policy_names query param' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbUserGroupQuotaPolicyRule -PolicyName 'pol-1' -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['policy_names'] -eq 'pol-1'
+        }
+    }
+
+    It 'accepts -PolicyName from the pipeline and joins multiple values' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            'pol-1', 'pol-2' | Get-PfbUserGroupQuotaPolicyRule -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['policy_names'] -eq 'pol-1,pol-2'
+        }
+    }
+
+    It 'scopes by -PolicyId via the policy_ids query param' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbUserGroupQuotaPolicyRule -PolicyId 'pid-1' -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['policy_ids'] -eq 'pid-1'
+        }
+    }
+
+    It 'filters by the rule''s own -Name/-Id independent of policy scoping' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbUserGroupQuotaPolicyRule -PolicyName 'pol-1' -Name 'rule-1' -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['policy_names'] -eq 'pol-1' -and $QueryParams['names'] -eq 'rule-1'
+        }
+    }
+
+    It 'passes -Filter, -Sort, and -Limit through' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbUserGroupQuotaPolicyRule -Filter "quota_type='user'" -Sort 'name-' -Limit 5 -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['filter'] -eq "quota_type='user'" -and $QueryParams['sort'] -eq 'name-' -and $QueryParams['limit'] -eq 5
+        }
+    }
+}

--- a/Tests/Get-PfbUserGroupQuotaPolicyRule.Tests.ps1
+++ b/Tests/Get-PfbUserGroupQuotaPolicyRule.Tests.ps1
@@ -80,4 +80,34 @@ Describe 'Get-PfbUserGroupQuotaPolicyRule' {
             $QueryParams['filter'] -eq "quota_type='user'" -and $QueryParams['sort'] -eq 'name-' -and $QueryParams['limit'] -eq 5
         }
     }
+
+    It 'honors falsy -Limit 0 and empty -Filter instead of dropping them' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbUserGroupQuotaPolicyRule -Filter '' -Limit 0 -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams.ContainsKey('filter') -and $QueryParams['filter'] -eq '' -and
+            $QueryParams.ContainsKey('limit') -and $QueryParams['limit'] -eq 0
+        }
+    }
+
+    It 'sends total_only=true when -TotalOnly is set' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbUserGroupQuotaPolicyRule -TotalOnly -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['total_only'] -eq 'true'
+        }
+    }
+
+    It 'rejects supplying both -Name and -Id together' {
+        { InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Get-PfbUserGroupQuotaPolicyRule -Name 'rule-1' -Id 'rid-1' -Array $arr
+        } } | Should -Throw
+    }
 }

--- a/Tests/ModuleManifest.Tests.ps1
+++ b/Tests/ModuleManifest.Tests.ps1
@@ -1,0 +1,36 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+Describe 'Module manifest FunctionsToExport completeness' {
+
+    BeforeAll {
+        $moduleRoot = Split-Path -Parent $PSScriptRoot
+        $manifestPath = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
+        $manifest = Import-PowerShellDataFile -Path $manifestPath
+        $publicFiles = Get-ChildItem -Path (Join-Path $moduleRoot 'Public') -Filter '*.ps1' -Recurse
+        $script:publicNames = $publicFiles.BaseName
+        $script:exported = $manifest.FunctionsToExport
+    }
+
+    It 'exports every cmdlet defined under Public/' {
+        $missing = $publicNames | Where-Object { $_ -notin $exported }
+        $missing | Should -BeNullOrEmpty -Because "these Public/ cmdlets are missing from FunctionsToExport: $($missing -join ', ')"
+    }
+
+    It 'does not export a name with no backing Public/ file' {
+        $stale = $exported | Where-Object { $_ -notin $publicNames }
+        $stale | Should -BeNullOrEmpty -Because "these FunctionsToExport entries have no backing Public/ file: $($stale -join ', ')"
+    }
+
+    It 'includes all 19 new user-group-quota-policy cmdlets' {
+        $expected = @(
+            'Get-PfbUserGroupQuotaPolicy', 'New-PfbUserGroupQuotaPolicy', 'Update-PfbUserGroupQuotaPolicy', 'Remove-PfbUserGroupQuotaPolicy',
+            'Get-PfbUserGroupQuotaPolicyRule', 'New-PfbUserGroupQuotaPolicyRule', 'Update-PfbUserGroupQuotaPolicyRule', 'Remove-PfbUserGroupQuotaPolicyRule',
+            'Get-PfbUserGroupQuotaPolicyFileSystem', 'New-PfbUserGroupQuotaPolicyFileSystem', 'Remove-PfbUserGroupQuotaPolicyFileSystem',
+            'Get-PfbUserGroupQuotaPolicyMember',
+            'Get-PfbFileSystemUserGroupQuotaPolicy', 'New-PfbFileSystemUserGroupQuotaPolicy', 'Remove-PfbFileSystemUserGroupQuotaPolicy',
+            'Get-PfbFileSystemUserQuota', 'Get-PfbFileSystemGroupQuota', 'Get-PfbFileSystemUser', 'Get-PfbFileSystemGroup'
+        )
+        $missing = $expected | Where-Object { $_ -notin $exported }
+        $missing | Should -BeNullOrEmpty -Because "expected new cmdlets missing from FunctionsToExport: $($missing -join ', ')"
+    }
+}

--- a/Tests/ModuleManifest.Tests.ps1
+++ b/Tests/ModuleManifest.Tests.ps1
@@ -21,6 +21,11 @@ Describe 'Module manifest FunctionsToExport completeness' {
         $stale | Should -BeNullOrEmpty -Because "these FunctionsToExport entries have no backing Public/ file: $($stale -join ', ')"
     }
 
+    It 'does not export any name more than once' {
+        $dupes = $exported | Group-Object | Where-Object Count -gt 1 | Select-Object -ExpandProperty Name
+        $dupes | Should -BeNullOrEmpty -Because "duplicate FunctionsToExport entries: $($dupes -join ', ')"
+    }
+
     It 'includes all 19 new user-group-quota-policy cmdlets' {
         $expected = @(
             'Get-PfbUserGroupQuotaPolicy', 'New-PfbUserGroupQuotaPolicy', 'Update-PfbUserGroupQuotaPolicy', 'Remove-PfbUserGroupQuotaPolicy',

--- a/Tests/New-PfbFileSystemUserGroupQuotaPolicy.Tests.ps1
+++ b/Tests/New-PfbFileSystemUserGroupQuotaPolicy.Tests.ps1
@@ -53,4 +53,13 @@ Describe 'New-PfbFileSystemUserGroupQuotaPolicy' {
             New-PfbFileSystemUserGroupQuotaPolicy -PolicyName 'pol-1' -Confirm:$false -Array $fakeArray
         } } | Should -Throw
     }
+
+    It 'does not call the API under -WhatIf' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ fakeArray = $fakeArray } {
+            param($fakeArray)
+            New-PfbFileSystemUserGroupQuotaPolicy -PolicyName 'pol-1' -MemberName 'fs1' -WhatIf -Array $fakeArray
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 0
+    }
 }

--- a/Tests/New-PfbFileSystemUserGroupQuotaPolicy.Tests.ps1
+++ b/Tests/New-PfbFileSystemUserGroupQuotaPolicy.Tests.ps1
@@ -1,0 +1,56 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    $moduleRoot = Split-Path -Parent $PSScriptRoot
+    $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
+    Import-Module $manifest -Force
+
+    $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.25'; AuthToken = 'x' }
+}
+
+Describe 'New-PfbFileSystemUserGroupQuotaPolicy' {
+
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+    }
+
+    It 'POSTs file-systems/user-group-quota-policies with policy and member query params' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ fakeArray = $fakeArray } {
+            param($fakeArray)
+            New-PfbFileSystemUserGroupQuotaPolicy -PolicyName 'pol-1' -MemberName 'fs1' -Confirm:$false -Array $fakeArray
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'POST' -and
+            $Endpoint -eq 'file-systems/user-group-quota-policies' -and
+            $QueryParams['policy_names'] -eq 'pol-1' -and
+            $QueryParams['member_names'] -eq 'fs1'
+        }
+    }
+
+    It 'sends delete_existing_user_group_quota_settings and ignore_usage when requested' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ fakeArray = $fakeArray } {
+            param($fakeArray)
+            New-PfbFileSystemUserGroupQuotaPolicy -PolicyName 'pol-1' -MemberName 'fs1' -DeleteExistingUserGroupQuotaSettings -IgnoreUsage -Confirm:$false -Array $fakeArray
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['delete_existing_user_group_quota_settings'] -eq 'true' -and $QueryParams['ignore_usage'] -eq 'true'
+        }
+    }
+
+    It 'throws when neither -PolicyName nor -PolicyId is supplied' {
+        { InModuleScope PureStorageFlashBladePowerShell -Parameters @{ fakeArray = $fakeArray } {
+            param($fakeArray)
+            New-PfbFileSystemUserGroupQuotaPolicy -MemberName 'fs1' -Confirm:$false -Array $fakeArray
+        } } | Should -Throw
+    }
+
+    It 'throws when neither -MemberName nor -MemberId is supplied' {
+        { InModuleScope PureStorageFlashBladePowerShell -Parameters @{ fakeArray = $fakeArray } {
+            param($fakeArray)
+            New-PfbFileSystemUserGroupQuotaPolicy -PolicyName 'pol-1' -Confirm:$false -Array $fakeArray
+        } } | Should -Throw
+    }
+}

--- a/Tests/New-PfbUserGroupQuotaPolicy.Tests.ps1
+++ b/Tests/New-PfbUserGroupQuotaPolicy.Tests.ps1
@@ -1,0 +1,83 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    $moduleRoot = Split-Path -Parent $PSScriptRoot
+    $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
+    Import-Module $manifest -Force
+
+    $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.25'; AuthToken = 'x' }
+}
+
+Describe 'New-PfbUserGroupQuotaPolicy' {
+
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+    }
+
+    It 'POSTs user-group-quota-policies with the name query param and an empty body by default' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            New-PfbUserGroupQuotaPolicy -Name 'pol-1' -Confirm:$false -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'POST' -and
+            $Endpoint -eq 'user-group-quota-policies' -and
+            $QueryParams['names'] -eq 'pol-1' -and
+            $Body.Keys.Count -eq 0
+        }
+    }
+
+    It 'builds enabled/location/rules into the body from typed params' {
+        $rules = @(@{ quota_type = 'user-default'; quota_limit = 1073741824 })
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray; rules = $rules } {
+            param($arr, $rules)
+            New-PfbUserGroupQuotaPolicy -Name 'pol-1' -Enabled:$false -Rules $rules -Confirm:$false -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $Body['enabled'] -eq $false -and
+            $Body['rules'][0]['quota_type'] -eq 'user-default'
+        }
+    }
+
+    It 'sends file_system_names for the legacy-quota-import path, mutually exclusive with file_system_ids' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            New-PfbUserGroupQuotaPolicy -Name 'pol-1' -FileSystemName 'fs1' -Confirm:$false -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['file_system_names'] -eq 'fs1' -and -not $QueryParams.ContainsKey('file_system_ids')
+        }
+    }
+
+    It 'throws when both -FileSystemName and -FileSystemId are supplied' {
+        { InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            New-PfbUserGroupQuotaPolicy -Name 'pol-1' -FileSystemName 'fs1' -FileSystemId 'id1' -Confirm:$false -Array $arr
+        } } |
+            Should -Throw
+    }
+
+    It '-Attributes overrides the constructed body verbatim' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            New-PfbUserGroupQuotaPolicy -Name 'pol-1' -Attributes @{ enabled = $true } -Confirm:$false -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $Body['enabled'] -eq $true -and $Body.Keys.Count -eq 1
+        }
+    }
+
+    It 'does not call the API under -WhatIf' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            New-PfbUserGroupQuotaPolicy -Name 'pol-1' -WhatIf -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 0
+    }
+}

--- a/Tests/New-PfbUserGroupQuotaPolicyFileSystem.Tests.ps1
+++ b/Tests/New-PfbUserGroupQuotaPolicyFileSystem.Tests.ps1
@@ -1,0 +1,65 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    $moduleRoot = Split-Path -Parent $PSScriptRoot
+    $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
+    Import-Module $manifest -Force
+
+    $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.25'; AuthToken = 'x' }
+}
+
+Describe 'New-PfbUserGroupQuotaPolicyFileSystem' {
+
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+    }
+
+    It 'POSTs user-group-quota-policies/file-systems with policy and member query params' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            New-PfbUserGroupQuotaPolicyFileSystem -PolicyName 'pol-1' -MemberName 'fs1' -Confirm:$false -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'POST' -and
+            $Endpoint -eq 'user-group-quota-policies/file-systems' -and
+            $QueryParams['policy_names'] -eq 'pol-1' -and
+            $QueryParams['member_names'] -eq 'fs1'
+        }
+    }
+
+    It 'sends delete_existing_user_group_quota_settings and ignore_usage when requested' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            New-PfbUserGroupQuotaPolicyFileSystem -PolicyName 'pol-1' -MemberName 'fs1' -DeleteExistingUserGroupQuotaSettings -IgnoreUsage -Confirm:$false -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['delete_existing_user_group_quota_settings'] -eq 'true' -and $QueryParams['ignore_usage'] -eq 'true'
+        }
+    }
+
+    It 'throws when neither -PolicyName nor -PolicyId is supplied' {
+        { InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            New-PfbUserGroupQuotaPolicyFileSystem -MemberName 'fs1' -Confirm:$false -Array $arr
+        } } | Should -Throw
+    }
+
+    It 'throws when neither -MemberName nor -MemberId is supplied' {
+        { InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            New-PfbUserGroupQuotaPolicyFileSystem -PolicyName 'pol-1' -Confirm:$false -Array $arr
+        } } | Should -Throw
+    }
+
+    It 'does not call the API under -WhatIf' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            New-PfbUserGroupQuotaPolicyFileSystem -PolicyName 'pol-1' -MemberName 'fs1' -WhatIf -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 0
+    }
+}

--- a/Tests/New-PfbUserGroupQuotaPolicyRule.Tests.ps1
+++ b/Tests/New-PfbUserGroupQuotaPolicyRule.Tests.ps1
@@ -81,4 +81,27 @@ Describe 'New-PfbUserGroupQuotaPolicyRule' {
             $Body.Keys.Count -eq 1 -and $Body['quota_limit'] -eq 42
         }
     }
+
+    It 'does not call the API under -WhatIf' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ fakeArray = $fakeArray } {
+            param($fakeArray)
+            New-PfbUserGroupQuotaPolicyRule -PolicyName 'pol-1' -QuotaType 'user-default' -QuotaLimit 100 -WhatIf -Array $fakeArray
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 0
+    }
+
+    It 'rejects a -QuotaLimit of 0' {
+        { InModuleScope PureStorageFlashBladePowerShell -Parameters @{ fakeArray = $fakeArray } {
+            param($fakeArray)
+            New-PfbUserGroupQuotaPolicyRule -PolicyName 'pol-1' -QuotaType 'user-default' -QuotaLimit 0 -Confirm:$false -Array $fakeArray
+        } } | Should -Throw
+    }
+
+    It 'rejects -QuotaType user-default combined with -Subject' {
+        { InModuleScope PureStorageFlashBladePowerShell -Parameters @{ fakeArray = $fakeArray } {
+            param($fakeArray)
+            New-PfbUserGroupQuotaPolicyRule -PolicyName 'pol-1' -Subject @{ name = 'jdoe' } -QuotaType 'user-default' -QuotaLimit 100 -Confirm:$false -Array $fakeArray
+        } } | Should -Throw
+    }
 }

--- a/Tests/New-PfbUserGroupQuotaPolicyRule.Tests.ps1
+++ b/Tests/New-PfbUserGroupQuotaPolicyRule.Tests.ps1
@@ -1,0 +1,84 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    $moduleRoot = Split-Path -Parent $PSScriptRoot
+    $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
+    Import-Module $manifest -Force
+
+    $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.25'; AuthToken = 'x' }
+}
+
+Describe 'New-PfbUserGroupQuotaPolicyRule' {
+
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+    }
+
+    It 'POSTs user-group-quota-policies/rules scoped to -PolicyName with a subject/quota body' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ fakeArray = $fakeArray } {
+            param($fakeArray)
+            New-PfbUserGroupQuotaPolicyRule -PolicyName 'pol-1' -Subject @{ name = 'jdoe' } -QuotaType 'user' -QuotaLimit 1073741824 -Confirm:$false -Array $fakeArray
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'POST' -and
+            $Endpoint -eq 'user-group-quota-policies/rules' -and
+            $QueryParams['policy_names'] -eq 'pol-1' -and
+            $Body['subject']['name'] -eq 'jdoe' -and
+            $Body['quota_type'] -eq 'user' -and
+            $Body['quota_limit'] -eq 1073741824
+        }
+    }
+
+    It 'scopes by -PolicyId instead of -PolicyName' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ fakeArray = $fakeArray } {
+            param($fakeArray)
+            New-PfbUserGroupQuotaPolicyRule -PolicyId 'pid-1' -QuotaType 'user-default' -QuotaLimit 100 -Confirm:$false -Array $fakeArray
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['policy_ids'] -eq 'pid-1' -and -not $QueryParams.ContainsKey('policy_names')
+        }
+    }
+
+    It 'sends -Enforced and -Notifications when supplied' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ fakeArray = $fakeArray } {
+            param($fakeArray)
+            New-PfbUserGroupQuotaPolicyRule -PolicyName 'pol-1' -QuotaType 'user-default' -QuotaLimit 100 -Enforced:$true -Notifications 'None' -Confirm:$false -Array $fakeArray
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $Body['enforced'] -eq $true -and $Body['notifications'] -eq 'None'
+        }
+    }
+
+    It 'sends ignore_usage when -IgnoreUsage is set' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ fakeArray = $fakeArray } {
+            param($fakeArray)
+            New-PfbUserGroupQuotaPolicyRule -PolicyName 'pol-1' -QuotaType 'user-default' -QuotaLimit 100 -IgnoreUsage -Confirm:$false -Array $fakeArray
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['ignore_usage'] -eq 'true'
+        }
+    }
+
+    It 'rejects an invalid -QuotaType' {
+        { InModuleScope PureStorageFlashBladePowerShell -Parameters @{ fakeArray = $fakeArray } {
+            param($fakeArray)
+            New-PfbUserGroupQuotaPolicyRule -PolicyName 'pol-1' -QuotaType 'bogus' -QuotaLimit 100 -Confirm:$false -Array $fakeArray
+        } } | Should -Throw
+    }
+
+    It '-Attributes overrides the constructed body verbatim' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ fakeArray = $fakeArray } {
+            param($fakeArray)
+            New-PfbUserGroupQuotaPolicyRule -PolicyName 'pol-1' -Attributes @{ quota_limit = 42 } -Confirm:$false -Array $fakeArray
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $Body.Keys.Count -eq 1 -and $Body['quota_limit'] -eq 42
+        }
+    }
+}

--- a/Tests/Remove-PfbFileSystemUserGroupQuotaPolicy.Tests.ps1
+++ b/Tests/Remove-PfbFileSystemUserGroupQuotaPolicy.Tests.ps1
@@ -49,6 +49,20 @@ Describe 'Remove-PfbFileSystemUserGroupQuotaPolicy' {
         Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 0
     }
 
+    It 'rejects a -PolicyName that looks like a wildcard' {
+        { InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Remove-PfbFileSystemUserGroupQuotaPolicy -PolicyName '*' -MemberName 'fs1' -Confirm:$false -Array $arr
+        } } | Should -Throw
+    }
+
+    It 'rejects a -MemberName that looks like a wildcard' {
+        { InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Remove-PfbFileSystemUserGroupQuotaPolicy -PolicyName 'pol-1' -MemberName '*' -Confirm:$false -Array $arr
+        } } | Should -Throw
+    }
+
     It 'throws if neither -PolicyName nor -PolicyId is supplied' {
         { InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
             param($arr)

--- a/Tests/Remove-PfbFileSystemUserGroupQuotaPolicy.Tests.ps1
+++ b/Tests/Remove-PfbFileSystemUserGroupQuotaPolicy.Tests.ps1
@@ -1,0 +1,65 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    $moduleRoot = Split-Path -Parent $PSScriptRoot
+    $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
+    Import-Module $manifest -Force
+
+    $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.25'; AuthToken = 'x' }
+}
+
+Describe 'Remove-PfbFileSystemUserGroupQuotaPolicy' {
+
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+    }
+
+    It 'DELETEs file-systems/user-group-quota-policies with policy and member query params' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Remove-PfbFileSystemUserGroupQuotaPolicy -PolicyName 'pol-1' -MemberName 'fs1' -Confirm:$false -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'DELETE' -and
+            $Endpoint -eq 'file-systems/user-group-quota-policies' -and
+            $QueryParams['policy_names'] -eq 'pol-1' -and
+            $QueryParams['member_names'] -eq 'fs1'
+        }
+    }
+
+    It 'accepts -PolicyId/-MemberId instead of names' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Remove-PfbFileSystemUserGroupQuotaPolicy -PolicyId 'pid-1' -MemberId 'mid-1' -Confirm:$false -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['policy_ids'] -eq 'pid-1' -and $QueryParams['member_ids'] -eq 'mid-1'
+        }
+    }
+
+    It 'does not call the API under -WhatIf' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Remove-PfbFileSystemUserGroupQuotaPolicy -PolicyName 'pol-1' -MemberName 'fs1' -WhatIf -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 0
+    }
+
+    It 'throws if neither -PolicyName nor -PolicyId is supplied' {
+        { InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Remove-PfbFileSystemUserGroupQuotaPolicy -MemberName 'fs1' -Confirm:$false -Array $arr
+        } } | Should -Throw 'You must supply either -PolicyName or -PolicyId.'
+    }
+
+    It 'throws if neither -MemberName nor -MemberId is supplied' {
+        { InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Remove-PfbFileSystemUserGroupQuotaPolicy -PolicyName 'pol-1' -Confirm:$false -Array $arr
+        } } | Should -Throw 'You must supply either -MemberName or -MemberId.'
+    }
+}

--- a/Tests/Remove-PfbUserGroupQuotaPolicy.Tests.ps1
+++ b/Tests/Remove-PfbUserGroupQuotaPolicy.Tests.ps1
@@ -1,0 +1,66 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    $moduleRoot = Split-Path -Parent $PSScriptRoot
+    $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
+    Import-Module $manifest -Force
+
+    $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.25'; AuthToken = 'x' }
+}
+
+Describe 'Remove-PfbUserGroupQuotaPolicy' {
+
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+    }
+
+    It 'DELETEs user-group-quota-policies by -Name' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Remove-PfbUserGroupQuotaPolicy -Name 'pol-1' -Confirm:$false -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'DELETE' -and $Endpoint -eq 'user-group-quota-policies' -and $QueryParams['names'] -eq 'pol-1'
+        }
+    }
+
+    It 'targets by -Id when supplied' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Remove-PfbUserGroupQuotaPolicy -Id 'id-1' -Confirm:$false -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['ids'] -eq 'id-1' -and -not $QueryParams.ContainsKey('names')
+        }
+    }
+
+    It 'sends -Version as the versions query param' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Remove-PfbUserGroupQuotaPolicy -Name 'pol-1' -Version 'v1' -Confirm:$false -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['versions'] -eq 'v1'
+        }
+    }
+
+    It 'rejects a -Name that looks like a wildcard' {
+        { InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Remove-PfbUserGroupQuotaPolicy -Name '*' -Confirm:$false -Array $arr
+        } } | Should -Throw
+    }
+
+    It 'does not call the API under -WhatIf' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Remove-PfbUserGroupQuotaPolicy -Name 'pol-1' -WhatIf -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 0
+    }
+}

--- a/Tests/Remove-PfbUserGroupQuotaPolicyFileSystem.Tests.ps1
+++ b/Tests/Remove-PfbUserGroupQuotaPolicyFileSystem.Tests.ps1
@@ -49,6 +49,20 @@ Describe 'Remove-PfbUserGroupQuotaPolicyFileSystem' {
         Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 0
     }
 
+    It 'rejects a -PolicyName that looks like a wildcard' {
+        { InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Remove-PfbUserGroupQuotaPolicyFileSystem -PolicyName '*' -MemberName 'fs1' -Confirm:$false -Array $arr
+        } } | Should -Throw
+    }
+
+    It 'rejects a -MemberName that looks like a wildcard' {
+        { InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Remove-PfbUserGroupQuotaPolicyFileSystem -PolicyName 'pol-1' -MemberName '*' -Confirm:$false -Array $arr
+        } } | Should -Throw
+    }
+
     It 'throws when neither -PolicyName nor -PolicyId is supplied' {
         { InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
             param($arr)

--- a/Tests/Remove-PfbUserGroupQuotaPolicyFileSystem.Tests.ps1
+++ b/Tests/Remove-PfbUserGroupQuotaPolicyFileSystem.Tests.ps1
@@ -48,4 +48,18 @@ Describe 'Remove-PfbUserGroupQuotaPolicyFileSystem' {
 
         Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 0
     }
+
+    It 'throws when neither -PolicyName nor -PolicyId is supplied' {
+        { InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Remove-PfbUserGroupQuotaPolicyFileSystem -MemberName 'fs1' -Confirm:$false -Array $arr
+        } } | Should -Throw 'You must supply either -PolicyName or -PolicyId.'
+    }
+
+    It 'throws when neither -MemberName nor -MemberId is supplied' {
+        { InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Remove-PfbUserGroupQuotaPolicyFileSystem -PolicyName 'pol-1' -Confirm:$false -Array $arr
+        } } | Should -Throw 'You must supply either -MemberName or -MemberId.'
+    }
 }

--- a/Tests/Remove-PfbUserGroupQuotaPolicyFileSystem.Tests.ps1
+++ b/Tests/Remove-PfbUserGroupQuotaPolicyFileSystem.Tests.ps1
@@ -1,0 +1,51 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    $moduleRoot = Split-Path -Parent $PSScriptRoot
+    $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
+    Import-Module $manifest -Force
+
+    $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.25'; AuthToken = 'x' }
+}
+
+Describe 'Remove-PfbUserGroupQuotaPolicyFileSystem' {
+
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+    }
+
+    It 'DELETEs user-group-quota-policies/file-systems with policy and member query params' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Remove-PfbUserGroupQuotaPolicyFileSystem -PolicyName 'pol-1' -MemberName 'fs1' -Confirm:$false -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'DELETE' -and
+            $Endpoint -eq 'user-group-quota-policies/file-systems' -and
+            $QueryParams['policy_names'] -eq 'pol-1' -and
+            $QueryParams['member_names'] -eq 'fs1'
+        }
+    }
+
+    It 'accepts -PolicyId/-MemberId instead of names' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Remove-PfbUserGroupQuotaPolicyFileSystem -PolicyId 'pid-1' -MemberId 'mid-1' -Confirm:$false -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['policy_ids'] -eq 'pid-1' -and $QueryParams['member_ids'] -eq 'mid-1'
+        }
+    }
+
+    It 'does not call the API under -WhatIf' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Remove-PfbUserGroupQuotaPolicyFileSystem -PolicyName 'pol-1' -MemberName 'fs1' -WhatIf -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 0
+    }
+}

--- a/Tests/Remove-PfbUserGroupQuotaPolicyRule.Tests.ps1
+++ b/Tests/Remove-PfbUserGroupQuotaPolicyRule.Tests.ps1
@@ -48,6 +48,20 @@ Describe 'Remove-PfbUserGroupQuotaPolicyRule' {
         }
     }
 
+    It 'rejects a -Name that looks like a wildcard' {
+        { InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Remove-PfbUserGroupQuotaPolicyRule -Name '*' -Confirm:$false -Array $arr
+        } } | Should -Throw
+    }
+
+    It 'rejects a -PolicyName that looks like a wildcard' {
+        { InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Remove-PfbUserGroupQuotaPolicyRule -PolicyName '*' -Confirm:$false -Array $arr
+        } } | Should -Throw
+    }
+
     It 'throws when none of -Name/-Id/-PolicyName/-PolicyId is supplied' {
         { InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
             param($arr)
@@ -62,5 +76,25 @@ Describe 'Remove-PfbUserGroupQuotaPolicyRule' {
         }
 
         Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 0
+    }
+
+    It 'validates arguments before connecting when none of -Name/-Id/-PolicyName/-PolicyId is supplied' {
+        { InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Remove-PfbUserGroupQuotaPolicyRule -Confirm:$false -Array $arr
+        } } | Should -Throw
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection -Times 0
+    }
+
+    It 'combines -Name and -PolicyName as AND: both filters are sent in a single request' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Remove-PfbUserGroupQuotaPolicyRule -Name 'rule-1' -PolicyName 'pol-1' -Confirm:$false -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['names'] -eq 'rule-1' -and $QueryParams['policy_names'] -eq 'pol-1'
+        }
     }
 }

--- a/Tests/Remove-PfbUserGroupQuotaPolicyRule.Tests.ps1
+++ b/Tests/Remove-PfbUserGroupQuotaPolicyRule.Tests.ps1
@@ -1,0 +1,66 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    $moduleRoot = Split-Path -Parent $PSScriptRoot
+    $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
+    Import-Module $manifest -Force
+
+    $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.25'; AuthToken = 'x' }
+}
+
+Describe 'Remove-PfbUserGroupQuotaPolicyRule' {
+
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+    }
+
+    It 'DELETEs user-group-quota-policies/rules by -Name' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Remove-PfbUserGroupQuotaPolicyRule -Name 'rule-1' -Confirm:$false -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'DELETE' -and $Endpoint -eq 'user-group-quota-policies/rules' -and $QueryParams['names'] -eq 'rule-1'
+        }
+    }
+
+    It 'deletes by -PolicyName alone (clears all of a policy''s rules)' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Remove-PfbUserGroupQuotaPolicyRule -PolicyName 'pol-1' -Confirm:$false -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['policy_names'] -eq 'pol-1' -and -not $QueryParams.ContainsKey('names')
+        }
+    }
+
+    It 'joins multiple -Id values with commas' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Remove-PfbUserGroupQuotaPolicyRule -Id 'rid-1', 'rid-2' -Confirm:$false -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['ids'] -eq 'rid-1,rid-2'
+        }
+    }
+
+    It 'throws when none of -Name/-Id/-PolicyName/-PolicyId is supplied' {
+        { InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Remove-PfbUserGroupQuotaPolicyRule -Confirm:$false -Array $arr
+        } } | Should -Throw
+    }
+
+    It 'does not call the API under -WhatIf' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Remove-PfbUserGroupQuotaPolicyRule -Name 'rule-1' -WhatIf -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 0
+    }
+}

--- a/Tests/Update-PfbUserGroupQuotaPolicy.Tests.ps1
+++ b/Tests/Update-PfbUserGroupQuotaPolicy.Tests.ps1
@@ -63,6 +63,22 @@ Describe 'Update-PfbUserGroupQuotaPolicy' {
         }
     }
 
+    It 'rejects a -Name that looks like a wildcard' {
+        { InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Update-PfbUserGroupQuotaPolicy -Name '*' -Enabled:$true -Confirm:$false -Array $arr
+        } } | Should -Throw
+    }
+
+    It 'does not call the API under -WhatIf' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Update-PfbUserGroupQuotaPolicy -Name 'pol-1' -Enabled:$true -WhatIf -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 0
+    }
+
     It 'declares -Name and -Id mandatory in mutually exclusive parameter sets (rejects neither being supplied)' {
         InModuleScope PureStorageFlashBladePowerShell {
             $cmd = Get-Command Update-PfbUserGroupQuotaPolicy

--- a/Tests/Update-PfbUserGroupQuotaPolicy.Tests.ps1
+++ b/Tests/Update-PfbUserGroupQuotaPolicy.Tests.ps1
@@ -1,0 +1,78 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    $moduleRoot = Split-Path -Parent $PSScriptRoot
+    $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
+    Import-Module $manifest -Force
+
+    $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.25'; AuthToken = 'x' }
+}
+
+Describe 'Update-PfbUserGroupQuotaPolicy' {
+
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+    }
+
+    It 'PATCHes user-group-quota-policies by -Name' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Update-PfbUserGroupQuotaPolicy -Name 'pol-1' -Enabled:$false -Confirm:$false -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'PATCH' -and
+            $Endpoint -eq 'user-group-quota-policies' -and
+            $QueryParams['names'] -eq 'pol-1' -and
+            $Body['enabled'] -eq $false
+        }
+    }
+
+    It 'targets by -Id when supplied instead of -Name' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Update-PfbUserGroupQuotaPolicy -Id 'id-1' -Rules @(@{ quota_limit = 5 }) -Confirm:$false -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['ids'] -eq 'id-1' -and -not $QueryParams.ContainsKey('names') -and
+            $Body['rules'][0]['quota_limit'] -eq 5
+        }
+    }
+
+    It 'sends ignore_usage and versions when requested' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Update-PfbUserGroupQuotaPolicy -Name 'pol-1' -Enabled:$true -IgnoreUsage -Version 'v1' -Confirm:$false -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['ignore_usage'] -eq 'true' -and $QueryParams['versions'] -eq 'v1'
+        }
+    }
+
+    It '-Attributes overrides the constructed body verbatim' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Update-PfbUserGroupQuotaPolicy -Name 'pol-1' -Attributes @{ enabled = $true } -Confirm:$false -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $Body.Keys.Count -eq 1 -and $Body['enabled'] -eq $true
+        }
+    }
+
+    It 'declares -Name and -Id mandatory in mutually exclusive parameter sets (rejects neither being supplied)' {
+        InModuleScope PureStorageFlashBladePowerShell {
+            $cmd = Get-Command Update-PfbUserGroupQuotaPolicy
+            $nameSet = $cmd.Parameters['Name'].Attributes |
+                Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] -and $_.ParameterSetName -eq 'ByName' }
+            $idSet = $cmd.Parameters['Id'].Attributes |
+                Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] -and $_.ParameterSetName -eq 'ById' }
+
+            $nameSet.Mandatory | Should -BeTrue
+            $idSet.Mandatory | Should -BeTrue
+        }
+    }
+}

--- a/Tests/Update-PfbUserGroupQuotaPolicyRule.Tests.ps1
+++ b/Tests/Update-PfbUserGroupQuotaPolicyRule.Tests.ps1
@@ -63,4 +63,27 @@ Describe 'Update-PfbUserGroupQuotaPolicyRule' {
             $Body.Keys.Count -eq 1 -and $Body['quota_limit'] -eq 7
         }
     }
+
+    It 'rejects a -Name that looks like a wildcard' {
+        { InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Update-PfbUserGroupQuotaPolicyRule -Name '*' -QuotaLimit 100 -Confirm:$false -Array $arr
+        } } | Should -Throw
+    }
+
+    It 'rejects a -QuotaLimit of 0' {
+        { InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Update-PfbUserGroupQuotaPolicyRule -Name 'rule-1' -QuotaLimit 0 -Confirm:$false -Array $arr
+        } } | Should -Throw
+    }
+
+    It 'does not call the API under -WhatIf' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Update-PfbUserGroupQuotaPolicyRule -Name 'rule-1' -QuotaLimit 100 -WhatIf -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 0
+    }
 }

--- a/Tests/Update-PfbUserGroupQuotaPolicyRule.Tests.ps1
+++ b/Tests/Update-PfbUserGroupQuotaPolicyRule.Tests.ps1
@@ -1,0 +1,66 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    $moduleRoot = Split-Path -Parent $PSScriptRoot
+    $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
+    Import-Module $manifest -Force
+
+    $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.25'; AuthToken = 'x' }
+}
+
+Describe 'Update-PfbUserGroupQuotaPolicyRule' {
+
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+    }
+
+    It 'PATCHes user-group-quota-policies/rules by -Name with only quota_limit/notifications in the body' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Update-PfbUserGroupQuotaPolicyRule -Name 'rule-1' -QuotaLimit 2147483648 -Notifications 'None' -Confirm:$false -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'PATCH' -and
+            $Endpoint -eq 'user-group-quota-policies/rules' -and
+            $QueryParams['names'] -eq 'rule-1' -and
+            $Body['quota_limit'] -eq 2147483648 -and
+            $Body['notifications'] -eq 'None' -and
+            $Body.Keys.Count -eq 2
+        }
+    }
+
+    It 'targets by -Id instead of -Name' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Update-PfbUserGroupQuotaPolicyRule -Id 'rid-1' -QuotaLimit 100 -Confirm:$false -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['ids'] -eq 'rid-1' -and -not $QueryParams.ContainsKey('names')
+        }
+    }
+
+    It 'sends ignore_usage when -IgnoreUsage is set' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Update-PfbUserGroupQuotaPolicyRule -Name 'rule-1' -QuotaLimit 100 -IgnoreUsage -Confirm:$false -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['ignore_usage'] -eq 'true'
+        }
+    }
+
+    It '-Attributes overrides the constructed body verbatim' {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ arr = $fakeArray } {
+            param($arr)
+            Update-PfbUserGroupQuotaPolicyRule -Name 'rule-1' -Attributes @{ quota_limit = 7 } -Confirm:$false -Array $arr
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $Body.Keys.Count -eq 1 -and $Body['quota_limit'] -eq 7
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #34. Adds full cmdlet coverage for the FlashBlade REST 2.25 user/group-quota-policy subsystem — the modern policy-based quota model (as opposed to the legacy per-filesystem `purequota`/`purefs` quotas).

- **Policy CRUD:** `Get-`/`New-`/`Update-`/`Remove-PfbUserGroupQuotaPolicy`. `New-` can build a policy from scratch or import an existing file system's legacy quota configuration.
- **Rule CRUD:** `Get-`/`New-`/`Update-`/`Remove-PfbUserGroupQuotaPolicyRule`. A rule targets a specific user/group or sets a policy-wide default.
- **File-system attachment, both directions:** `Get-`/`New-`/`Remove-PfbUserGroupQuotaPolicyFileSystem` and `Get-`/`New-`/`Remove-PfbFileSystemUserGroupQuotaPolicy`.
- **Policy membership:** `Get-PfbUserGroupQuotaPolicyMember` (read-only cross-reference).
- **Reporting reads:** `Get-PfbFileSystemUserQuota`, `Get-PfbFileSystemGroupQuota` (usage/limit per user or group), and `Get-PfbFileSystemUser`/`Get-PfbFileSystemGroup` (identity lookups, distinct from the existing usage-stats `Get-PfbUsageUser`/`Get-PfbUsageGroup`).

19 new cmdlets total, each with its own Pester test file (122+ new `It` blocks). `FunctionsToExport` and a completeness-guard test (`Tests/ModuleManifest.Tests.ps1`) were added in one closing commit so a future cmdlet added without an export update fails CI immediately.

Also fixes a couple of pre-existing bugs surfaced while implementing the mirrored attach/detach pair (`Remove-PfbUserGroupQuotaPolicyFileSystem`/`Remove-PfbFileSystemUserGroupQuotaPolicy`): a missing empty-identifier guard and a broken `ShouldProcess` target string that collapsed to `":"` when IDs were supplied instead of names.

## Test plan

- [x] Full suite green: `Invoke-Pester ./Tests -Output Detailed` → 731 passed, 0 failed, 32 skipped (skips are pre-existing, unrelated to this branch)
- [x] Every new cmdlet has mocked unit tests covering the happy path, `-Id`-instead-of-`-Name` variants, `-WhatIf`, and argument-validation guards
- [x] `Tests/ModuleManifest.Tests.ps1` verifies `FunctionsToExport` completeness (no missing, no stale, no duplicate entries) and that all 19 new cmdlet names are present
- [x] Manual verification against a live FlashBlade array for the query-param shape of `GET user-group-quota-policies/rules` (the OpenAPI spec is missing `policy_ids`/`policy_names` there across versions 2.25-2.28 — implemented against observed live behavior, not the spec)