### PR TITLE
docs: track CLAUDE.md instructions in the repo

### DIFF
--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -1,0 +1,54 @@
+# Authoring GitHub Actions workflows in this repo
+
+Concrete, non-obvious authoring rules -- all discovered the hard way on this
+repo's CI (see the `fb-powershell-ci-infrastructure` / `github-actions-syntax-gotchas`
+memories for the incident history).
+
+## `${{ }}` expressions require single-quoted string literals
+
+`format(" text", x)` or `""` inside a `${{ }}` expression is a parse error
+("Unexpected symbol: '\"'"), even though the *surrounding* YAML scalar can be
+single- or double-quoted however you like.
+
+If the outer YAML value needs to contain the expression's single-quoted
+literals without escaping, make the **outer** YAML scalar double-quoted
+(`title: "...${{ format('...', x) }}..."`) rather than single-quoted (which
+would force doubling every inner `'` per YAML's own escape rule).
+
+## `shell:` cannot read the `matrix` context in a workflow -- but can in a composite action
+
+`shell: ${{ matrix.shell }}` at step level in a **workflow** fails with
+"Unrecognized named-value: 'matrix'" -- only a reduced context set is
+available to `shell:`/`working-directory:` at job or step level, even though
+`matrix` works fine in `runs-on:`, `name:`, `env:`, `run:`, `if:`, etc.
+
+If different matrix entries need different shells, split into separate jobs
+(one non-matrixed job per shell) instead of trying to matrix the shell
+itself.
+
+**Exception:** `shell:` *does* accept `${{ inputs.* }}` inside a **composite
+action** (`.github/actions/*/action.yml`) -- this is how one composite action
+can serve both PowerShell editions across a matrix. Still not `matrix`
+directly, only `inputs.*`.
+
+## Action version pins are not uniform across actions
+
+Don't assume every action's latest major version lines up -- check each one
+individually. Examples seen in this repo: `actions/checkout@v7` exists, but
+`actions/cache` has no v7 (v6 is its latest major); `create-pull-request` v6
+and v7 are both Node 20, so v8 was required to actually clear the Node 20
+deprecation warning, not merely optional.
+
+## Getting GitHub's actual parse error instead of guessing
+
+A workflow file with a syntax/schema problem produces no useful detail in
+the Actions UI or `gh run view` for a `push`-triggered run -- "no jobs were
+run" / "this run likely failed because of a workflow file issue" is all
+you get.
+
+**Reliable diagnostic:** `gh workflow run <file> --repo <owner>/<repo> --ref <branch>`
+-- if the file has a validation problem, the command itself fails with the
+exact parser message and line/column. This requires the workflow to declare
+`workflow_dispatch: {}` as one of its triggers; add it (temporarily, or
+permanently -- it's generally useful) if missing, specifically to unlock this
+diagnostic path.

--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -39,6 +39,23 @@ individually. Examples seen in this repo: `actions/checkout@v7` exists, but
 and v7 are both Node 20, so v8 was required to actually clear the Node 20
 deprecation warning, not merely optional.
 
+## A `pull_request` run tests the MERGE commit, not your branch tip
+
+Two consequences that look like flaky CI and are not:
+
+- A green run **goes stale when `main` moves**, with nothing in the branch
+  changing. If the merge would now fail -- a ceiling that no longer holds, a
+  test `main` just added -- the next run reds on a commit nobody touched.
+- **A manual re-run cannot re-measure a moved base.** Re-running replays the
+  recorded `GITHUB_SHA` against that run's workflow definition, so
+  `actions/checkout@v7` with no `ref:` override checks out the same old merge
+  commit. The re-run looks fresh while testing the same stale tree.
+
+To genuinely re-measure against a moved `main`: `gh pr update-branch` (adds a
+merge commit, harmless if the PR is squash-merged), or close and reopen the PR
+(`reopened` is in the default `pull_request` types, at the cost of a close
+event for watchers).
+
 ## Getting GitHub's actual parse error instead of guessing
 
 A workflow file with a syntax/schema problem produces no useful detail in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,40 @@
+# fb-powershell
+
+`dmann000/fb-powershell` (public GitHub repo, default branch `main`) -- a
+PowerShell module ("PureStorage FlashBlade PowerShell Toolkit") for managing
+Everpure (formerly Pure Storage) FlashBlade arrays via the REST API 2.x.
+~526 cmdlets covering all FlashBlade REST 2.x endpoints, with a
+`Connect-PfbArray` experience mirroring the FlashArray `PureStoragePowerShellSDK2`
+module.
+
+**Two names, on purpose:** the source module's own name is
+`PureStorageFlashBladePowerShell` (repo/build/`Import-Module`-from-source
+identity -- what the README's `Install-Module` instructions currently
+reference). The package actually published to the PowerShell Gallery is
+named **`EverpureFBModule`** (per `scripts/Publish-Gallery.ps1`): a separate
+build step copies the built module, renames the `.psd1`/`.psm1`, assigns a
+stable GUID (`dae38a9b-9885-40ea-a3e5-f7405038ab99`), and rebrands
+Author/Company to "Don Mann, Justin Emerson, Mike Nelson" / "Everpure, Inc."
+before publishing. Don't assume these are interchangeable names for the same
+Gallery listing.
+
+## Regenerate derived reports when cmdlet coverage changes
+
+Any commit that changes which REST query/body parameters or endpoints a
+`Public/` cmdlet covers must regenerate the derived `Reports/` artifacts in
+the same commit -- otherwise they go stale relative to your own change, and
+the drift-report invariant tests (`Tests/Build-PfbApiDriftReport.Tests.ps1`,
+Task 8) will catch it later for whoever next merges `main`, instead of now:
+
+```powershell
+./tools/Build-PfbFieldCmdletMap.ps1   # must run first -- Build-PfbApiDriftReport.ps1 reads its output
+./tools/Build-PfbApiDriftReport.ps1
+```
+
+Merge/rebase onto an up-to-date `main` *before* regenerating. `Build-PfbApiDriftReport.ps1`
+reads most categories from the committed `Data/PfbCapabilityMap.json`, but one
+category re-scans REST-version history straight from `tools/specs/` (gitignored,
+a shared local cache) -- if that cache has picked up a newer spec version than
+your branch's own committed capability-map baseline, regenerating against a
+stale branch silently mixes an unrelated spec-version bump into your diff
+instead of just your own change.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,3 +38,28 @@ a shared local cache) -- if that cache has picked up a newer spec version than
 your branch's own committed capability-map baseline, regenerating against a
 stale branch silently mixes an unrelated spec-version bump into your diff
 instead of just your own change.
+
+Verify by regenerating and diffing rather than by reasoning about whether your
+change could have moved an artifact -- a no-op regeneration costs a minute and
+is the only answer that is not an inference.
+
+## Before you push
+
+```powershell
+pwsh       -NonInteractive -NoProfile -Command "./scripts/Invoke-PfbCiPester.ps1 -Edition pwsh7"
+powershell -NonInteractive -NoProfile -Command "./scripts/Invoke-PfbCiPester.ps1 -Edition winps51"
+```
+
+This is what CI runs, and it applies the coverage gate as well as the tests.
+`-Edition` picks which baseline to measure against, not which interpreter runs
+-- so each edition needs its own host, as above.
+
+See `Tests/CLAUDE.md` for the gate, the two-edition rule, and the spec cache the
+tooling tests depend on; `.github/workflows/CLAUDE.md` for workflow authoring
+rules and why a green CI run can go stale without your branch changing.
+
+## Version and changelog
+
+Don't bump the module version or edit `CHANGELOG.md` as part of a feature or
+fix PR. Releases are a separate, deliberate decision by the maintainer, and a
+version bump inside an unrelated PR pre-empts it.

--- a/Tests/CLAUDE.md
+++ b/Tests/CLAUDE.md
@@ -1,0 +1,47 @@
+# Writing Pester tests in this repo
+
+## Calling a private function
+
+Anything under `Private/` that is **not** listed in `FunctionsToExport` in
+`PureStorageFlashBladePowerShell.psd1` is a private function. After
+`Import-Module -Force`, private functions are not exported into the test
+file's scope -- calling one directly at the top level of a `Describe`/`It`
+block fails with "command not recognized."
+
+**Fix:** wrap only the actual invocation in
+`InModuleScope PureStorageFlashBladePowerShell { <call> }`.
+
+- `Mock -ModuleName PureStorageFlashBladePowerShell <Fn>` calls are fine
+  *outside* `InModuleScope` -- only the real (non-mocked) call into a private
+  function needs the wrapper.
+- Calls to **public** (exported) functions like `Connect-PfbArray` never need
+  this.
+
+## `InModuleScope` does not close over outer-scope variables
+
+`InModuleScope`'s script block does **not** close over local variables from
+the enclosing `It`/`Context` block. Referencing an outer variable (e.g.
+`$array` set earlier in the same `It`) inside
+`InModuleScope PureStorageFlashBladePowerShell { Invoke-PfbApiRequest -Array $array ... }`
+silently binds `$array` to `$null` inside the block, producing a
+`ParameterBindingValidationException` that looks like a correct RED-phase
+failure but is actually failing for the wrong reason.
+
+**Fix:** pass the variable in explicitly via `-Parameters`:
+
+```powershell
+InModuleScope PureStorageFlashBladePowerShell -Parameters @{ array = $array } {
+    Invoke-PfbApiRequest -Array $array ...
+}
+```
+
+Only needed when the wrapped block references an outer-scope variable --
+literal-argument calls don't need it.
+
+## Running Pester non-interactively
+
+Always invoke `pwsh` with **`-NonInteractive`**, not just `-NoProfile`, e.g.
+`pwsh -NonInteractive -NoProfile -Command "Invoke-Pester ..."`. A cmdlet with
+`[Parameter(Mandatory)]` invoked without that parameter throws immediately in
+a non-interactive host, but *prompts and blocks* in an interactive one
+(`-NoProfile` alone does not prevent this).

--- a/Tests/CLAUDE.md
+++ b/Tests/CLAUDE.md
@@ -45,3 +45,63 @@ Always invoke `pwsh` with **`-NonInteractive`**, not just `-NoProfile`, e.g.
 `[Parameter(Mandatory)]` invoked without that parameter throws immediately in
 a non-interactive host, but *prompts and blocks* in an interactive one
 (`-NoProfile` alone does not prevent this).
+
+A related symptom worth recognising: a Pester run that stops with "Supply values
+for the following parameters" is an unbound mandatory parameter, and the fault
+is almost always in the test's invocation rather than in the cmdlet under test.
+
+Destructive cmdlets need `-Confirm:$false` in tests. A `ConfirmImpact = 'High'`
+cmdlet throws on `ShouldProcess` under `-NonInteractive` rather than proceeding.
+
+## Run it the way CI does
+
+```powershell
+pwsh       -NonInteractive -NoProfile -Command "./scripts/Invoke-PfbCiPester.ps1 -Edition pwsh7"
+powershell -NonInteractive -NoProfile -Command "./scripts/Invoke-PfbCiPester.ps1 -Edition winps51"
+```
+
+That wrapper is what the workflow calls, and it runs the coverage gate as well
+as the tests. `Invoke-Pester` on its own skips the gate, so a run that looks
+green locally can still red the build.
+
+**`-Edition` selects the baseline, not the interpreter.** It chooses which
+`Tests/coverage-baseline.psd1` block to apply; the interpreter is whichever host
+is already running the script (in CI, the job's `shell:` key). Passing
+`-Edition winps51` from pwsh 7 measures a 7 run against the 5.1 ceiling, which
+is not a 5.1 run.
+
+**Check both editions before pushing.** A test that passes under PowerShell 7
+can fail under Windows PowerShell 5.1 for reasons that never surface in a 7-only
+run, and CI gates four combinations (Windows 5.1, plus pwsh 7 on Windows, Linux
+and macOS). Two editions is what a Windows box can cover; the platform dimension
+is CI's job and is not worth simulating.
+
+## The coverage gate: `Tests/coverage-baseline.psd1`
+
+Two independent assertions guard against tests silently vanishing:
+
+- **`MaxSkipped`** — a per-edition ceiling on skipped tests, catching a Describe
+  that starts skipping. It is a ceiling *with headroom*, not a pin. Raise it
+  deliberately, in a reviewed diff, and say why in the commit message.
+- **`RequiredDescribes`** — names Describes that must appear in the result tree.
+  Blocks that skip *gracefully* (their guard evaluates false at `BeforeAll`
+  time) contribute neither a pass nor a skip, so a skip ceiling cannot see them
+  disappear at all.
+
+The two editions differ by a wide margin — every Describe in the tooling test
+files carries `-Skip:($PSVersionTable.PSVersion.Major -lt 7)`, so the 5.1 leg
+skips all of them by design. One shared ceiling would be either a permanent
+false red on 5.1 or useless on 7.
+
+One non-obvious way this gate reds without your branch changing: a
+`pull_request` run tests the **merge** commit, so a ceiling measured before an
+unrelated merge to `main` can go stale on its own. That is worth a red build,
+not a suppression.
+
+## Tooling tests need the spec cache
+
+The tests under `Tests/` that exercise `tools/` read `tools/specs/` — a
+gitignored local cache of the REST spec versions. When it is absent those
+Describes skip gracefully, which reads as a healthy green summary while a large
+slice of the suite never ran. A fresh clone or a new worktree starts without it,
+so check the cache is populated before trusting a local pass.


### PR DESCRIPTION
## Summary

`CLAUDE.md` (repo root), `.github/workflows/CLAUDE.md`, and `Tests/CLAUDE.md`
existed only in local working trees -- never committed on any branch, despite
the root file describing itself as repo-committed guidance safe to publish.
This adds all three to version control so they're actually visible to
collaborators.

Also adds one new section to the root file: regenerate `Reports/` drift-report
artifacts in the same commit whenever cmdlet parameter/endpoint coverage
changes, and merge/rebase onto current `main` first (to avoid mixing in an
unrelated spec-version bump) -- a real gap found finishing PR #51 this session.

No code changes.

## Test plan

- [x] Docs-only change, no functional/test impact