### PR TITLE
chore(reports): regenerate stale Public-derived report artifacts

### DIFF
--- a/Reports/PfbApiDriftReport.json
+++ b/Reports/PfbApiDriftReport.json
@@ -319,18 +319,6 @@
       "minVersion": "2.24"
     },
     {
-      "endpoint": "GET /file-systems/user-group-quota-policies",
-      "minVersion": "2.25"
-    },
-    {
-      "endpoint": "POST /file-systems/user-group-quota-policies",
-      "minVersion": "2.25"
-    },
-    {
-      "endpoint": "DELETE /file-systems/user-group-quota-policies",
-      "minVersion": "2.25"
-    },
-    {
       "endpoint": "GET /file-system-junctions",
       "minVersion": "2.25"
     },
@@ -340,22 +328,6 @@
     },
     {
       "endpoint": "DELETE /file-system-junctions",
-      "minVersion": "2.25"
-    },
-    {
-      "endpoint": "GET /file-system-group-quotas",
-      "minVersion": "2.25"
-    },
-    {
-      "endpoint": "GET /file-systems/groups",
-      "minVersion": "2.25"
-    },
-    {
-      "endpoint": "GET /file-system-user-quotas",
-      "minVersion": "2.25"
-    },
-    {
-      "endpoint": "GET /file-systems/users",
       "minVersion": "2.25"
     },
     {
@@ -384,54 +356,6 @@
     },
     {
       "endpoint": "GET /remote-realms",
-      "minVersion": "2.25"
-    },
-    {
-      "endpoint": "GET /user-group-quota-policies",
-      "minVersion": "2.25"
-    },
-    {
-      "endpoint": "POST /user-group-quota-policies",
-      "minVersion": "2.25"
-    },
-    {
-      "endpoint": "PATCH /user-group-quota-policies",
-      "minVersion": "2.25"
-    },
-    {
-      "endpoint": "DELETE /user-group-quota-policies",
-      "minVersion": "2.25"
-    },
-    {
-      "endpoint": "GET /user-group-quota-policies/rules",
-      "minVersion": "2.25"
-    },
-    {
-      "endpoint": "POST /user-group-quota-policies/rules",
-      "minVersion": "2.25"
-    },
-    {
-      "endpoint": "DELETE /user-group-quota-policies/rules",
-      "minVersion": "2.25"
-    },
-    {
-      "endpoint": "PATCH /user-group-quota-policies/rules",
-      "minVersion": "2.25"
-    },
-    {
-      "endpoint": "GET /user-group-quota-policies/file-systems",
-      "minVersion": "2.25"
-    },
-    {
-      "endpoint": "POST /user-group-quota-policies/file-systems",
-      "minVersion": "2.25"
-    },
-    {
-      "endpoint": "DELETE /user-group-quota-policies/file-systems",
-      "minVersion": "2.25"
-    },
-    {
-      "endpoint": "GET /user-group-quota-policies/members",
       "minVersion": "2.25"
     },
     {
@@ -1230,6 +1154,24 @@
         ],
         "escapeHatchOnly": [],
         "caveat": "one or more parameters could not be traced to a wire name and have no -Attributes escape hatch; lists reflect typed-parameter coverage only, not full wire reachability"
+      },
+      "annotations": []
+    },
+    {
+      "endpoint": "DELETE /file-systems/user-group-quota-policies",
+      "cmdlets": [
+        "Remove-PfbFileSystemUserGroupQuotaPolicy"
+      ],
+      "missingQueryParameters": [
+        "context_names"
+      ],
+      "missingBodyProperties": [],
+      "readOnlyFields": [],
+      "confidence": {
+        "level": "high",
+        "unresolvedParameters": [],
+        "escapeHatchOnly": [],
+        "caveat": ""
       },
       "annotations": []
     },
@@ -2066,6 +2008,60 @@
       "endpoint": "DELETE /ssh-certificate-authority-policies/arrays",
       "cmdlets": [
         "Remove-PfbSshCaPolicyArray"
+      ],
+      "missingQueryParameters": [
+        "context_names"
+      ],
+      "missingBodyProperties": [],
+      "readOnlyFields": [],
+      "confidence": {
+        "level": "high",
+        "unresolvedParameters": [],
+        "escapeHatchOnly": [],
+        "caveat": ""
+      },
+      "annotations": []
+    },
+    {
+      "endpoint": "DELETE /user-group-quota-policies",
+      "cmdlets": [
+        "Remove-PfbUserGroupQuotaPolicy"
+      ],
+      "missingQueryParameters": [
+        "context_names"
+      ],
+      "missingBodyProperties": [],
+      "readOnlyFields": [],
+      "confidence": {
+        "level": "high",
+        "unresolvedParameters": [],
+        "escapeHatchOnly": [],
+        "caveat": ""
+      },
+      "annotations": []
+    },
+    {
+      "endpoint": "DELETE /user-group-quota-policies/file-systems",
+      "cmdlets": [
+        "Remove-PfbUserGroupQuotaPolicyFileSystem"
+      ],
+      "missingQueryParameters": [
+        "context_names"
+      ],
+      "missingBodyProperties": [],
+      "readOnlyFields": [],
+      "confidence": {
+        "level": "high",
+        "unresolvedParameters": [],
+        "escapeHatchOnly": [],
+        "caveat": ""
+      },
+      "annotations": []
+    },
+    {
+      "endpoint": "DELETE /user-group-quota-policies/rules",
+      "cmdlets": [
+        "Remove-PfbUserGroupQuotaPolicyRule"
       ],
       "missingQueryParameters": [
         "context_names"
@@ -3285,6 +3281,25 @@
       "annotations": []
     },
     {
+      "endpoint": "GET /file-system-group-quotas",
+      "cmdlets": [
+        "Get-PfbFileSystemGroupQuota"
+      ],
+      "missingQueryParameters": [
+        "allow_errors",
+        "context_names"
+      ],
+      "missingBodyProperties": [],
+      "readOnlyFields": [],
+      "confidence": {
+        "level": "high",
+        "unresolvedParameters": [],
+        "escapeHatchOnly": [],
+        "caveat": ""
+      },
+      "annotations": []
+    },
+    {
       "endpoint": "GET /file-system-replica-links",
       "cmdlets": [
         "Get-PfbFileSystemReplicaLink"
@@ -3416,6 +3431,25 @@
       "annotations": []
     },
     {
+      "endpoint": "GET /file-system-user-quotas",
+      "cmdlets": [
+        "Get-PfbFileSystemUserQuota"
+      ],
+      "missingQueryParameters": [
+        "allow_errors",
+        "context_names"
+      ],
+      "missingBodyProperties": [],
+      "readOnlyFields": [],
+      "confidence": {
+        "level": "high",
+        "unresolvedParameters": [],
+        "escapeHatchOnly": [],
+        "caveat": ""
+      },
+      "annotations": []
+    },
+    {
       "endpoint": "GET /file-systems",
       "cmdlets": [
         "Get-PfbFileSystem"
@@ -3440,6 +3474,25 @@
       "endpoint": "GET /file-systems/audit-policies",
       "cmdlets": [
         "Get-PfbFileSystemAuditPolicy"
+      ],
+      "missingQueryParameters": [
+        "allow_errors",
+        "context_names"
+      ],
+      "missingBodyProperties": [],
+      "readOnlyFields": [],
+      "confidence": {
+        "level": "high",
+        "unresolvedParameters": [],
+        "escapeHatchOnly": [],
+        "caveat": ""
+      },
+      "annotations": []
+    },
+    {
+      "endpoint": "GET /file-systems/groups",
+      "cmdlets": [
+        "Get-PfbFileSystemGroup"
       ],
       "missingQueryParameters": [
         "allow_errors",
@@ -3589,6 +3642,44 @@
       ],
       "missingQueryParameters": [
         "storage_class_names"
+      ],
+      "missingBodyProperties": [],
+      "readOnlyFields": [],
+      "confidence": {
+        "level": "high",
+        "unresolvedParameters": [],
+        "escapeHatchOnly": [],
+        "caveat": ""
+      },
+      "annotations": []
+    },
+    {
+      "endpoint": "GET /file-systems/user-group-quota-policies",
+      "cmdlets": [
+        "Get-PfbFileSystemUserGroupQuotaPolicy"
+      ],
+      "missingQueryParameters": [
+        "allow_errors",
+        "context_names"
+      ],
+      "missingBodyProperties": [],
+      "readOnlyFields": [],
+      "confidence": {
+        "level": "high",
+        "unresolvedParameters": [],
+        "escapeHatchOnly": [],
+        "caveat": ""
+      },
+      "annotations": []
+    },
+    {
+      "endpoint": "GET /file-systems/users",
+      "cmdlets": [
+        "Get-PfbFileSystemUser"
+      ],
+      "missingQueryParameters": [
+        "allow_errors",
+        "context_names"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -5445,6 +5536,97 @@
         "file_system_ids",
         "uids",
         "user_names"
+      ],
+      "missingBodyProperties": [],
+      "readOnlyFields": [],
+      "confidence": {
+        "level": "high",
+        "unresolvedParameters": [],
+        "escapeHatchOnly": [],
+        "caveat": ""
+      },
+      "annotations": []
+    },
+    {
+      "endpoint": "GET /user-group-quota-policies",
+      "cmdlets": [
+        "Get-PfbUserGroupQuotaPolicy"
+      ],
+      "missingQueryParameters": [
+        "allow_errors",
+        "context_names",
+        "ids",
+        "names"
+      ],
+      "missingBodyProperties": [],
+      "readOnlyFields": [],
+      "confidence": {
+        "level": "partial",
+        "unresolvedParameters": [
+          {
+            "parameter": "Id",
+            "surface": "TypedUnresolved",
+            "file": "Public/Policy/Get-PfbUserGroupQuotaPolicy.ps1",
+            "line": 38
+          },
+          {
+            "parameter": "Name",
+            "surface": "TypedUnresolved",
+            "file": "Public/Policy/Get-PfbUserGroupQuotaPolicy.ps1",
+            "line": 35
+          }
+        ],
+        "escapeHatchOnly": [],
+        "caveat": "one or more parameters could not be traced to a wire name and have no -Attributes escape hatch; lists reflect typed-parameter coverage only, not full wire reachability"
+      },
+      "annotations": []
+    },
+    {
+      "endpoint": "GET /user-group-quota-policies/file-systems",
+      "cmdlets": [
+        "Get-PfbUserGroupQuotaPolicyFileSystem"
+      ],
+      "missingQueryParameters": [
+        "allow_errors",
+        "context_names"
+      ],
+      "missingBodyProperties": [],
+      "readOnlyFields": [],
+      "confidence": {
+        "level": "high",
+        "unresolvedParameters": [],
+        "escapeHatchOnly": [],
+        "caveat": ""
+      },
+      "annotations": []
+    },
+    {
+      "endpoint": "GET /user-group-quota-policies/members",
+      "cmdlets": [
+        "Get-PfbUserGroupQuotaPolicyMember"
+      ],
+      "missingQueryParameters": [
+        "allow_errors",
+        "context_names"
+      ],
+      "missingBodyProperties": [],
+      "readOnlyFields": [],
+      "confidence": {
+        "level": "high",
+        "unresolvedParameters": [],
+        "escapeHatchOnly": [],
+        "caveat": ""
+      },
+      "annotations": []
+    },
+    {
+      "endpoint": "GET /user-group-quota-policies/rules",
+      "cmdlets": [
+        "Get-PfbUserGroupQuotaPolicyRule"
+      ],
+      "missingQueryParameters": [
+        "allow_errors",
+        "context_names"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -8894,6 +9076,64 @@
       "annotations": []
     },
     {
+      "endpoint": "PATCH /user-group-quota-policies",
+      "cmdlets": [
+        "Update-PfbUserGroupQuotaPolicy"
+      ],
+      "missingQueryParameters": [
+        "context_names"
+      ],
+      "missingBodyProperties": [
+        "enabled",
+        "name"
+      ],
+      "readOnlyFields": [
+        "context",
+        "id",
+        "is_local",
+        "policy_type",
+        "realms",
+        "version"
+      ],
+      "confidence": {
+        "level": "partial",
+        "unresolvedParameters": [
+          {
+            "parameter": "Enabled",
+            "surface": "AttributesOnly",
+            "file": "Public/Policy/Update-PfbUserGroupQuotaPolicy.ps1",
+            "line": 36
+          }
+        ],
+        "escapeHatchOnly": [
+          "Enabled"
+        ],
+        "caveat": "body reachable only via -Attributes; lists reflect typed-parameter coverage, not wire reachability"
+      },
+      "annotations": []
+    },
+    {
+      "endpoint": "PATCH /user-group-quota-policies/rules",
+      "cmdlets": [
+        "Update-PfbUserGroupQuotaPolicyRule"
+      ],
+      "missingQueryParameters": [
+        "context_names"
+      ],
+      "missingBodyProperties": [],
+      "readOnlyFields": [
+        "id",
+        "name"
+      ],
+      "confidence": {
+        "level": "high",
+        "unresolvedParameters": [],
+        "escapeHatchOnly": [],
+        "caveat": ""
+      },
+      "annotations": []
+    },
+    {
       "endpoint": "PATCH /workloads",
       "cmdlets": [
         "Update-PfbWorkload"
@@ -10674,6 +10914,24 @@
       "endpoint": "POST /file-systems/policies",
       "cmdlets": [
         "New-PfbFileSystemPolicy"
+      ],
+      "missingQueryParameters": [
+        "context_names"
+      ],
+      "missingBodyProperties": [],
+      "readOnlyFields": [],
+      "confidence": {
+        "level": "high",
+        "unresolvedParameters": [],
+        "escapeHatchOnly": [],
+        "caveat": ""
+      },
+      "annotations": []
+    },
+    {
+      "endpoint": "POST /file-systems/user-group-quota-policies",
+      "cmdlets": [
+        "New-PfbFileSystemUserGroupQuotaPolicy"
       ],
       "missingQueryParameters": [
         "context_names"
@@ -13430,6 +13688,88 @@
       "annotations": []
     },
     {
+      "endpoint": "POST /user-group-quota-policies",
+      "cmdlets": [
+        "New-PfbUserGroupQuotaPolicy"
+      ],
+      "missingQueryParameters": [
+        "context_names"
+      ],
+      "missingBodyProperties": [
+        "enabled",
+        "name"
+      ],
+      "readOnlyFields": [
+        "id",
+        "is_local",
+        "policy_type",
+        "realms"
+      ],
+      "confidence": {
+        "level": "partial",
+        "unresolvedParameters": [
+          {
+            "parameter": "Enabled",
+            "surface": "AttributesOnly",
+            "file": "Public/Policy/New-PfbUserGroupQuotaPolicy.ps1",
+            "line": 49
+          }
+        ],
+        "escapeHatchOnly": [
+          "Enabled"
+        ],
+        "caveat": "body reachable only via -Attributes; lists reflect typed-parameter coverage, not wire reachability"
+      },
+      "annotations": []
+    },
+    {
+      "endpoint": "POST /user-group-quota-policies/file-systems",
+      "cmdlets": [
+        "New-PfbUserGroupQuotaPolicyFileSystem"
+      ],
+      "missingQueryParameters": [
+        "context_names"
+      ],
+      "missingBodyProperties": [],
+      "readOnlyFields": [],
+      "confidence": {
+        "level": "high",
+        "unresolvedParameters": [],
+        "escapeHatchOnly": [],
+        "caveat": ""
+      },
+      "annotations": []
+    },
+    {
+      "endpoint": "POST /user-group-quota-policies/rules",
+      "cmdlets": [
+        "New-PfbUserGroupQuotaPolicyRule"
+      ],
+      "missingQueryParameters": [
+        "context_names"
+      ],
+      "missingBodyProperties": [
+        "enforced"
+      ],
+      "readOnlyFields": [],
+      "confidence": {
+        "level": "partial",
+        "unresolvedParameters": [
+          {
+            "parameter": "Enforced",
+            "surface": "AttributesOnly",
+            "file": "Public/Policy/New-PfbUserGroupQuotaPolicyRule.ps1",
+            "line": 57
+          }
+        ],
+        "escapeHatchOnly": [
+          "Enforced"
+        ],
+        "caveat": "body reachable only via -Attributes; lists reflect typed-parameter coverage, not wire reachability"
+      },
+      "annotations": []
+    },
+    {
       "endpoint": "POST /workloads",
       "cmdlets": [
         "New-PfbWorkload"
@@ -13536,8 +13876,8 @@
   "systemicGaps": [
     {
       "name": "context_names",
-      "endpointCount": 254,
-      "queryEndpointCount": 254,
+      "endpointCount": 269,
+      "queryEndpointCount": 269,
       "bodyEndpointCount": 0,
       "endpoints": [
         "DELETE /admins/api-tokens",
@@ -13568,6 +13908,7 @@
         "DELETE /file-systems/audit-policies",
         "DELETE /file-systems/locks",
         "DELETE /file-systems/policies",
+        "DELETE /file-systems/user-group-quota-policies",
         "DELETE /lifecycle-rules",
         "DELETE /log-targets/file-systems",
         "DELETE /log-targets/object-store",
@@ -13603,6 +13944,9 @@
         "DELETE /smb-share-policies/rules",
         "DELETE /ssh-certificate-authority-policies/admins",
         "DELETE /ssh-certificate-authority-policies/arrays",
+        "DELETE /user-group-quota-policies",
+        "DELETE /user-group-quota-policies/file-systems",
+        "DELETE /user-group-quota-policies/rules",
         "DELETE /workloads",
         "DELETE /workloads/tags",
         "DELETE /worm-data-policies",
@@ -13644,18 +13988,23 @@
         "GET /directory-services/test",
         "GET /dns",
         "GET /file-system-exports",
+        "GET /file-system-group-quotas",
         "GET /file-system-replica-links",
         "GET /file-system-replica-links/policies",
         "GET /file-system-replica-links/transfer",
         "GET /file-system-snapshots",
         "GET /file-system-snapshots/policies",
         "GET /file-system-snapshots/transfer",
+        "GET /file-system-user-quotas",
         "GET /file-systems",
         "GET /file-systems/audit-policies",
+        "GET /file-systems/groups",
         "GET /file-systems/locks",
         "GET /file-systems/locks/clients",
         "GET /file-systems/policies",
         "GET /file-systems/sessions",
+        "GET /file-systems/user-group-quota-policies",
+        "GET /file-systems/users",
         "GET /file-systems/worm-data-policies",
         "GET /lifecycle-rules",
         "GET /log-targets/file-systems",
@@ -13712,6 +14061,9 @@
         "GET /targets",
         "GET /usage/groups",
         "GET /usage/users",
+        "GET /user-group-quota-policies/file-systems",
+        "GET /user-group-quota-policies/members",
+        "GET /user-group-quota-policies/rules",
         "GET /workloads",
         "GET /workloads/placement-recommendations",
         "GET /workloads/tags",
@@ -13739,6 +14091,7 @@
         "PATCH /s3-export-policies/rules",
         "PATCH /smb-client-policies/rules",
         "PATCH /smb-share-policies/rules",
+        "PATCH /user-group-quota-policies/rules",
         "PATCH /worm-data-policies",
         "POST /admins/api-tokens",
         "POST /admins/management-access-policies",
@@ -13762,6 +14115,7 @@
         "POST /file-systems/audit-policies",
         "POST /file-systems/locks/nlm-reclamations",
         "POST /file-systems/policies",
+        "POST /file-systems/user-group-quota-policies",
         "POST /lifecycle-rules",
         "POST /log-targets/file-systems",
         "POST /log-targets/object-store",
@@ -13793,6 +14147,7 @@
         "POST /smb-share-policies/rules",
         "POST /ssh-certificate-authority-policies/admins",
         "POST /ssh-certificate-authority-policies/arrays",
+        "POST /user-group-quota-policies/file-systems",
         "POST /workloads"
       ],
       "annotations": [
@@ -13807,8 +14162,8 @@
     },
     {
       "name": "allow_errors",
-      "endpointCount": 110,
-      "queryEndpointCount": 110,
+      "endpointCount": 118,
+      "queryEndpointCount": 118,
       "bodyEndpointCount": 0,
       "endpoints": [
         "GET /active-directory/test",
@@ -13849,18 +14204,23 @@
         "GET /directory-services/test",
         "GET /dns",
         "GET /file-system-exports",
+        "GET /file-system-group-quotas",
         "GET /file-system-replica-links",
         "GET /file-system-replica-links/policies",
         "GET /file-system-replica-links/transfer",
         "GET /file-system-snapshots",
         "GET /file-system-snapshots/policies",
         "GET /file-system-snapshots/transfer",
+        "GET /file-system-user-quotas",
         "GET /file-systems",
         "GET /file-systems/audit-policies",
+        "GET /file-systems/groups",
         "GET /file-systems/locks",
         "GET /file-systems/locks/clients",
         "GET /file-systems/policies",
         "GET /file-systems/sessions",
+        "GET /file-systems/user-group-quota-policies",
+        "GET /file-systems/users",
         "GET /file-systems/worm-data-policies",
         "GET /lifecycle-rules",
         "GET /log-targets/file-systems",
@@ -13916,6 +14276,9 @@
         "GET /targets",
         "GET /usage/groups",
         "GET /usage/users",
+        "GET /user-group-quota-policies/file-systems",
+        "GET /user-group-quota-policies/members",
+        "GET /user-group-quota-policies/rules",
         "GET /workloads",
         "GET /workloads/placement-recommendations",
         "GET /workloads/tags",
@@ -16845,7 +17208,7 @@
   "conventionStrength": [
     {
       "name": "names",
-      "cmdletCount": 308,
+      "cmdletCount": 314,
       "cmdlets": [
         "Get-PfbActiveDirectory",
         "Get-PfbAdmin",
@@ -16968,6 +17331,7 @@
         "Get-PfbTarget",
         "Get-PfbTargetPerformanceReplication",
         "Get-PfbTlsPolicy",
+        "Get-PfbUserGroupQuotaPolicyRule",
         "Get-PfbWorkload",
         "Get-PfbWorkloadPlacementRecommendation",
         "Get-PfbWormPolicy",
@@ -17011,6 +17375,7 @@
         "New-PfbSmbClientPolicy",
         "New-PfbSmbSharePolicy",
         "New-PfbSubnet",
+        "New-PfbUserGroupQuotaPolicy",
         "New-PfbWorkload",
         "Remove-PfbActiveDirectory",
         "Remove-PfbAdminCache",
@@ -17082,6 +17447,8 @@
         "Remove-PfbSyslogServer",
         "Remove-PfbTarget",
         "Remove-PfbTlsPolicy",
+        "Remove-PfbUserGroupQuotaPolicy",
+        "Remove-PfbUserGroupQuotaPolicyRule",
         "Remove-PfbWorkload",
         "Remove-PfbWormPolicy",
         "Set-PfbPresetWorkload",
@@ -17153,13 +17520,15 @@
         "Update-PfbSyslogServer",
         "Update-PfbTarget",
         "Update-PfbTlsPolicy",
+        "Update-PfbUserGroupQuotaPolicy",
+        "Update-PfbUserGroupQuotaPolicyRule",
         "Update-PfbWorkload",
         "Update-PfbWormPolicy"
       ]
     },
     {
       "name": "ids",
-      "cmdletCount": 219,
+      "cmdletCount": 224,
       "cmdlets": [
         "Get-PfbAdmin",
         "Get-PfbAdminCache",
@@ -17250,6 +17619,7 @@
         "Get-PfbSyslogServer",
         "Get-PfbTarget",
         "Get-PfbTlsPolicy",
+        "Get-PfbUserGroupQuotaPolicyRule",
         "Get-PfbWorkload",
         "Get-PfbWorkloadPlacementRecommendation",
         "Get-PfbWormPolicy",
@@ -17315,6 +17685,8 @@
         "Remove-PfbSyslogServer",
         "Remove-PfbTarget",
         "Remove-PfbTlsPolicy",
+        "Remove-PfbUserGroupQuotaPolicy",
+        "Remove-PfbUserGroupQuotaPolicyRule",
         "Remove-PfbWorkload",
         "Remove-PfbWormPolicy",
         "Set-PfbPresetWorkload",
@@ -17378,13 +17750,15 @@
         "Update-PfbSyslogServer",
         "Update-PfbTarget",
         "Update-PfbTlsPolicy",
+        "Update-PfbUserGroupQuotaPolicy",
+        "Update-PfbUserGroupQuotaPolicyRule",
         "Update-PfbWorkload",
         "Update-PfbWormPolicy"
       ]
     },
     {
       "name": "filter",
-      "cmdletCount": 193,
+      "cmdletCount": 202,
       "cmdlets": [
         "Get-PfbActiveDirectory",
         "Get-PfbAdmin",
@@ -17450,7 +17824,9 @@
         "Get-PfbFileSystem",
         "Get-PfbFileSystemAuditPolicy",
         "Get-PfbFileSystemExport",
+        "Get-PfbFileSystemGroup",
         "Get-PfbFileSystemGroupPerformance",
+        "Get-PfbFileSystemGroupQuota",
         "Get-PfbFileSystemPolicy",
         "Get-PfbFileSystemReplicaLink",
         "Get-PfbFileSystemReplicaLinkPolicy",
@@ -17460,7 +17836,10 @@
         "Get-PfbFileSystemSnapshotPolicy",
         "Get-PfbFileSystemSnapshotTransfer",
         "Get-PfbFileSystemStorageClass",
+        "Get-PfbFileSystemUser",
+        "Get-PfbFileSystemUserGroupQuotaPolicy",
         "Get-PfbFileSystemUserPerformance",
+        "Get-PfbFileSystemUserQuota",
         "Get-PfbFileSystemWormPolicy",
         "Get-PfbFleet",
         "Get-PfbFleetKey",
@@ -17575,6 +17954,10 @@
         "Get-PfbTlsPolicyMember",
         "Get-PfbUsageGroup",
         "Get-PfbUsageUser",
+        "Get-PfbUserGroupQuotaPolicy",
+        "Get-PfbUserGroupQuotaPolicyFileSystem",
+        "Get-PfbUserGroupQuotaPolicyMember",
+        "Get-PfbUserGroupQuotaPolicyRule",
         "Get-PfbWorkload",
         "Get-PfbWorkloadPlacementRecommendation",
         "Get-PfbWormPolicy",
@@ -17583,7 +17966,7 @@
     },
     {
       "name": "limit",
-      "cmdletCount": 190,
+      "cmdletCount": 199,
       "cmdlets": [
         "Get-PfbAdmin",
         "Get-PfbAdminCache",
@@ -17647,7 +18030,9 @@
         "Get-PfbFileSystem",
         "Get-PfbFileSystemAuditPolicy",
         "Get-PfbFileSystemExport",
+        "Get-PfbFileSystemGroup",
         "Get-PfbFileSystemGroupPerformance",
+        "Get-PfbFileSystemGroupQuota",
         "Get-PfbFileSystemPolicy",
         "Get-PfbFileSystemReplicaLink",
         "Get-PfbFileSystemReplicaLinkPolicy",
@@ -17657,7 +18042,10 @@
         "Get-PfbFileSystemSnapshotPolicy",
         "Get-PfbFileSystemSnapshotTransfer",
         "Get-PfbFileSystemStorageClass",
+        "Get-PfbFileSystemUser",
+        "Get-PfbFileSystemUserGroupQuotaPolicy",
         "Get-PfbFileSystemUserPerformance",
+        "Get-PfbFileSystemUserQuota",
         "Get-PfbFileSystemWormPolicy",
         "Get-PfbFleet",
         "Get-PfbFleetKey",
@@ -17771,6 +18159,10 @@
         "Get-PfbTlsPolicyMember",
         "Get-PfbUsageGroup",
         "Get-PfbUsageUser",
+        "Get-PfbUserGroupQuotaPolicy",
+        "Get-PfbUserGroupQuotaPolicyFileSystem",
+        "Get-PfbUserGroupQuotaPolicyMember",
+        "Get-PfbUserGroupQuotaPolicyRule",
         "Get-PfbWorkload",
         "Get-PfbWorkloadPlacementRecommendation",
         "Get-PfbWormPolicy",
@@ -17779,7 +18171,7 @@
     },
     {
       "name": "sort",
-      "cmdletCount": 171,
+      "cmdletCount": 180,
       "cmdlets": [
         "Get-PfbAdmin",
         "Get-PfbAdminCache",
@@ -17838,7 +18230,9 @@
         "Get-PfbFileSystem",
         "Get-PfbFileSystemAuditPolicy",
         "Get-PfbFileSystemExport",
+        "Get-PfbFileSystemGroup",
         "Get-PfbFileSystemGroupPerformance",
+        "Get-PfbFileSystemGroupQuota",
         "Get-PfbFileSystemPolicy",
         "Get-PfbFileSystemReplicaLink",
         "Get-PfbFileSystemReplicaLinkPolicy",
@@ -17848,7 +18242,10 @@
         "Get-PfbFileSystemSnapshotPolicy",
         "Get-PfbFileSystemSnapshotTransfer",
         "Get-PfbFileSystemStorageClass",
+        "Get-PfbFileSystemUser",
+        "Get-PfbFileSystemUserGroupQuotaPolicy",
         "Get-PfbFileSystemUserPerformance",
+        "Get-PfbFileSystemUserQuota",
         "Get-PfbFileSystemWormPolicy",
         "Get-PfbFleet",
         "Get-PfbFleetKey",
@@ -17949,6 +18346,10 @@
         "Get-PfbTlsPolicy",
         "Get-PfbUsageGroup",
         "Get-PfbUsageUser",
+        "Get-PfbUserGroupQuotaPolicy",
+        "Get-PfbUserGroupQuotaPolicyFileSystem",
+        "Get-PfbUserGroupQuotaPolicyMember",
+        "Get-PfbUserGroupQuotaPolicyRule",
         "Get-PfbWorkload",
         "Get-PfbWorkloadPlacementRecommendation",
         "Get-PfbWormPolicy"
@@ -17956,7 +18357,7 @@
     },
     {
       "name": "policy_names",
-      "cmdletCount": 108,
+      "cmdletCount": 118,
       "cmdlets": [
         "Add-PfbDataEvictionPolicyFileSystem",
         "Get-PfbAdminManagementAccessPolicy",
@@ -17975,6 +18376,7 @@
         "Get-PfbFileSystemPolicy",
         "Get-PfbFileSystemReplicaLinkPolicy",
         "Get-PfbFileSystemSnapshotPolicy",
+        "Get-PfbFileSystemUserGroupQuotaPolicy",
         "Get-PfbFileSystemWormPolicy",
         "Get-PfbManagementAccessPolicyAdmin",
         "Get-PfbManagementAccessPolicyDirectoryRole",
@@ -18003,6 +18405,9 @@
         "Get-PfbSshCaPolicyMember",
         "Get-PfbStorageClassTieringPolicyMember",
         "Get-PfbTlsPolicyMember",
+        "Get-PfbUserGroupQuotaPolicyFileSystem",
+        "Get-PfbUserGroupQuotaPolicyMember",
+        "Get-PfbUserGroupQuotaPolicyRule",
         "Get-PfbWormPolicyMember",
         "New-PfbAdminManagementAccessPolicy",
         "New-PfbAdminSshCaPolicy",
@@ -18017,6 +18422,7 @@
         "New-PfbFileSystemExport",
         "New-PfbFileSystemPolicy",
         "New-PfbFileSystemReplicaLinkPolicy",
+        "New-PfbFileSystemUserGroupQuotaPolicy",
         "New-PfbManagementAccessPolicyAdmin",
         "New-PfbManagementAccessPolicyDirectoryRole",
         "New-PfbNetworkAccessRule",
@@ -18035,6 +18441,8 @@
         "New-PfbSmbShareRule",
         "New-PfbSshCaPolicyAdmin",
         "New-PfbSshCaPolicyArray",
+        "New-PfbUserGroupQuotaPolicyFileSystem",
+        "New-PfbUserGroupQuotaPolicyRule",
         "Remove-PfbAdminManagementAccessPolicy",
         "Remove-PfbAdminSshCaPolicy",
         "Remove-PfbArraySshCaPolicy",
@@ -18048,6 +18456,7 @@
         "Remove-PfbFileSystemPolicy",
         "Remove-PfbFileSystemReplicaLinkPolicy",
         "Remove-PfbFileSystemSnapshotPolicy",
+        "Remove-PfbFileSystemUserGroupQuotaPolicy",
         "Remove-PfbManagementAccessPolicyAdmin",
         "Remove-PfbManagementAccessPolicyDirectoryRole",
         "Remove-PfbNetworkAccessRule",
@@ -18065,12 +18474,14 @@
         "Remove-PfbSmbClientRule",
         "Remove-PfbSmbShareRule",
         "Remove-PfbSshCaPolicyAdmin",
-        "Remove-PfbSshCaPolicyArray"
+        "Remove-PfbSshCaPolicyArray",
+        "Remove-PfbUserGroupQuotaPolicyFileSystem",
+        "Remove-PfbUserGroupQuotaPolicyRule"
       ]
     },
     {
       "name": "member_names",
-      "cmdletCount": 98,
+      "cmdletCount": 105,
       "cmdlets": [
         "Add-PfbDataEvictionPolicyFileSystem",
         "Get-PfbAdminManagementAccessPolicy",
@@ -18090,6 +18501,7 @@
         "Get-PfbFileSystemPolicy",
         "Get-PfbFileSystemReplicaLinkPolicy",
         "Get-PfbFileSystemSnapshotPolicy",
+        "Get-PfbFileSystemUserGroupQuotaPolicy",
         "Get-PfbFileSystemWormPolicy",
         "Get-PfbFleetMember",
         "Get-PfbLegalHoldEntity",
@@ -18116,6 +18528,8 @@
         "Get-PfbSshCaPolicyMember",
         "Get-PfbStorageClassTieringPolicyMember",
         "Get-PfbTlsPolicyMember",
+        "Get-PfbUserGroupQuotaPolicyFileSystem",
+        "Get-PfbUserGroupQuotaPolicyMember",
         "Get-PfbWormPolicyMember",
         "New-PfbAdminManagementAccessPolicy",
         "New-PfbAdminSshCaPolicy",
@@ -18130,6 +18544,7 @@
         "New-PfbFileSystemAuditPolicy",
         "New-PfbFileSystemExport",
         "New-PfbFileSystemPolicy",
+        "New-PfbFileSystemUserGroupQuotaPolicy",
         "New-PfbManagementAccessPolicyAdmin",
         "New-PfbManagementAccessPolicyDirectoryRole",
         "New-PfbNetworkInterfaceTlsPolicy",
@@ -18141,6 +18556,7 @@
         "New-PfbQosPolicyMember",
         "New-PfbSshCaPolicyAdmin",
         "New-PfbSshCaPolicyArray",
+        "New-PfbUserGroupQuotaPolicyFileSystem",
         "Remove-PfbAdminManagementAccessPolicy",
         "Remove-PfbAdminSshCaPolicy",
         "Remove-PfbArraySshCaPolicy",
@@ -18155,6 +18571,7 @@
         "Remove-PfbFileSystemPolicy",
         "Remove-PfbFileSystemReplicaLinkPolicy",
         "Remove-PfbFileSystemSnapshotPolicy",
+        "Remove-PfbFileSystemUserGroupQuotaPolicy",
         "Remove-PfbFleetMember",
         "Remove-PfbLocalGroupMember",
         "Remove-PfbManagementAccessPolicyAdmin",
@@ -18169,12 +18586,13 @@
         "Remove-PfbPolicyFileSystemReplicaLink",
         "Remove-PfbQosPolicyMember",
         "Remove-PfbSshCaPolicyAdmin",
-        "Remove-PfbSshCaPolicyArray"
+        "Remove-PfbSshCaPolicyArray",
+        "Remove-PfbUserGroupQuotaPolicyFileSystem"
       ]
     },
     {
       "name": "policy_ids",
-      "cmdletCount": 88,
+      "cmdletCount": 98,
       "cmdlets": [
         "Add-PfbDataEvictionPolicyFileSystem",
         "Get-PfbAdminManagementAccessPolicy",
@@ -18190,6 +18608,7 @@
         "Get-PfbFileSystemPolicy",
         "Get-PfbFileSystemReplicaLinkPolicy",
         "Get-PfbFileSystemSnapshotPolicy",
+        "Get-PfbFileSystemUserGroupQuotaPolicy",
         "Get-PfbFileSystemWormPolicy",
         "Get-PfbManagementAccessPolicyAdmin",
         "Get-PfbManagementAccessPolicyDirectoryRole",
@@ -18218,6 +18637,9 @@
         "Get-PfbSshCaPolicyMember",
         "Get-PfbStorageClassTieringPolicyMember",
         "Get-PfbTlsPolicyMember",
+        "Get-PfbUserGroupQuotaPolicyFileSystem",
+        "Get-PfbUserGroupQuotaPolicyMember",
+        "Get-PfbUserGroupQuotaPolicyRule",
         "Get-PfbWormPolicyMember",
         "New-PfbAdminManagementAccessPolicy",
         "New-PfbAdminSshCaPolicy",
@@ -18228,6 +18650,7 @@
         "New-PfbFileSystemAuditPolicy",
         "New-PfbFileSystemPolicy",
         "New-PfbFileSystemReplicaLinkPolicy",
+        "New-PfbFileSystemUserGroupQuotaPolicy",
         "New-PfbManagementAccessPolicyAdmin",
         "New-PfbManagementAccessPolicyDirectoryRole",
         "New-PfbNetworkAccessRule",
@@ -18241,6 +18664,8 @@
         "New-PfbSmbShareRule",
         "New-PfbSshCaPolicyAdmin",
         "New-PfbSshCaPolicyArray",
+        "New-PfbUserGroupQuotaPolicyFileSystem",
+        "New-PfbUserGroupQuotaPolicyRule",
         "Remove-PfbAdminManagementAccessPolicy",
         "Remove-PfbAdminSshCaPolicy",
         "Remove-PfbArraySshCaPolicy",
@@ -18252,6 +18677,7 @@
         "Remove-PfbFileSystemPolicy",
         "Remove-PfbFileSystemReplicaLinkPolicy",
         "Remove-PfbFileSystemSnapshotPolicy",
+        "Remove-PfbFileSystemUserGroupQuotaPolicy",
         "Remove-PfbManagementAccessPolicyAdmin",
         "Remove-PfbManagementAccessPolicyDirectoryRole",
         "Remove-PfbNetworkAccessRule",
@@ -18263,12 +18689,14 @@
         "Remove-PfbSmbClientRule",
         "Remove-PfbSmbShareRule",
         "Remove-PfbSshCaPolicyAdmin",
-        "Remove-PfbSshCaPolicyArray"
+        "Remove-PfbSshCaPolicyArray",
+        "Remove-PfbUserGroupQuotaPolicyFileSystem",
+        "Remove-PfbUserGroupQuotaPolicyRule"
       ]
     },
     {
       "name": "member_ids",
-      "cmdletCount": 78,
+      "cmdletCount": 85,
       "cmdlets": [
         "Add-PfbDataEvictionPolicyFileSystem",
         "Get-PfbAdminManagementAccessPolicy",
@@ -18286,6 +18714,7 @@
         "Get-PfbFileSystemPolicy",
         "Get-PfbFileSystemReplicaLinkPolicy",
         "Get-PfbFileSystemSnapshotPolicy",
+        "Get-PfbFileSystemUserGroupQuotaPolicy",
         "Get-PfbFileSystemWormPolicy",
         "Get-PfbLegalHoldEntity",
         "Get-PfbManagementAccessPolicyAdmin",
@@ -18310,6 +18739,8 @@
         "Get-PfbSshCaPolicyMember",
         "Get-PfbStorageClassTieringPolicyMember",
         "Get-PfbTlsPolicyMember",
+        "Get-PfbUserGroupQuotaPolicyFileSystem",
+        "Get-PfbUserGroupQuotaPolicyMember",
         "Get-PfbWormPolicyMember",
         "New-PfbAdminManagementAccessPolicy",
         "New-PfbAdminSshCaPolicy",
@@ -18320,6 +18751,7 @@
         "New-PfbFileSystemAuditPolicy",
         "New-PfbFileSystemPolicy",
         "New-PfbFileSystemReplicaLinkPolicy",
+        "New-PfbFileSystemUserGroupQuotaPolicy",
         "New-PfbManagementAccessPolicyAdmin",
         "New-PfbManagementAccessPolicyDirectoryRole",
         "New-PfbNetworkInterfaceTlsPolicy",
@@ -18328,6 +18760,7 @@
         "New-PfbQosPolicyMember",
         "New-PfbSshCaPolicyAdmin",
         "New-PfbSshCaPolicyArray",
+        "New-PfbUserGroupQuotaPolicyFileSystem",
         "Remove-PfbAdminManagementAccessPolicy",
         "Remove-PfbAdminSshCaPolicy",
         "Remove-PfbArraySshCaPolicy",
@@ -18341,18 +18774,20 @@
         "Remove-PfbFileSystemPolicy",
         "Remove-PfbFileSystemReplicaLinkPolicy",
         "Remove-PfbFileSystemSnapshotPolicy",
+        "Remove-PfbFileSystemUserGroupQuotaPolicy",
         "Remove-PfbManagementAccessPolicyAdmin",
         "Remove-PfbManagementAccessPolicyDirectoryRole",
         "Remove-PfbPolicyFileSystem",
         "Remove-PfbPolicyFileSystemReplicaLink",
         "Remove-PfbQosPolicyMember",
         "Remove-PfbSshCaPolicyAdmin",
-        "Remove-PfbSshCaPolicyArray"
+        "Remove-PfbSshCaPolicyArray",
+        "Remove-PfbUserGroupQuotaPolicyFileSystem"
       ]
     },
     {
       "name": "total_only",
-      "cmdletCount": 30,
+      "cmdletCount": 39,
       "cmdlets": [
         "Get-PfbBucket",
         "Get-PfbBucketPerformance",
@@ -18361,13 +18796,18 @@
         "Get-PfbFileLockClient",
         "Get-PfbFileSystem",
         "Get-PfbFileSystemExport",
+        "Get-PfbFileSystemGroup",
         "Get-PfbFileSystemGroupPerformance",
+        "Get-PfbFileSystemGroupQuota",
         "Get-PfbFileSystemReplicaLinkTransfer",
         "Get-PfbFileSystemSession",
         "Get-PfbFileSystemSnapshot",
         "Get-PfbFileSystemSnapshotTransfer",
         "Get-PfbFileSystemStorageClass",
+        "Get-PfbFileSystemUser",
+        "Get-PfbFileSystemUserGroupQuotaPolicy",
         "Get-PfbFileSystemUserPerformance",
+        "Get-PfbFileSystemUserQuota",
         "Get-PfbObjectStoreAccessPolicy",
         "Get-PfbObjectStoreAccessPolicyAction",
         "Get-PfbObjectStoreAccessPolicyRole",
@@ -18383,7 +18823,11 @@
         "Get-PfbObjectStoreUserAccessPolicy",
         "Get-PfbOpenFile",
         "Get-PfbRealm",
-        "Get-PfbServer"
+        "Get-PfbServer",
+        "Get-PfbUserGroupQuotaPolicy",
+        "Get-PfbUserGroupQuotaPolicyFileSystem",
+        "Get-PfbUserGroupQuotaPolicyMember",
+        "Get-PfbUserGroupQuotaPolicyRule"
       ]
     },
     {
@@ -18480,6 +18924,25 @@
       ]
     },
     {
+      "name": "file_system_names",
+      "cmdletCount": 13,
+      "cmdlets": [
+        "Get-PfbFileSystemGroup",
+        "Get-PfbFileSystemGroupPerformance",
+        "Get-PfbFileSystemGroupQuota",
+        "Get-PfbFileSystemUser",
+        "Get-PfbFileSystemUserPerformance",
+        "Get-PfbFileSystemUserQuota",
+        "Get-PfbQuotaGroup",
+        "Get-PfbQuotaUser",
+        "Get-PfbUsageGroup",
+        "Get-PfbUsageUser",
+        "New-PfbLegalHoldEntity",
+        "New-PfbUserGroupQuotaPolicy",
+        "Update-PfbLegalHoldEntity"
+      ]
+    },
+    {
       "name": "enabled",
       "cmdletCount": 10,
       "cmdlets": [
@@ -18496,17 +18959,45 @@
       ]
     },
     {
-      "name": "file_system_names",
+      "name": "file_system_ids",
+      "cmdletCount": 9,
+      "cmdlets": [
+        "Get-PfbFileSystemGroup",
+        "Get-PfbFileSystemGroupPerformance",
+        "Get-PfbFileSystemGroupQuota",
+        "Get-PfbFileSystemUser",
+        "Get-PfbFileSystemUserPerformance",
+        "Get-PfbFileSystemUserQuota",
+        "New-PfbLegalHoldEntity",
+        "New-PfbUserGroupQuotaPolicy",
+        "Update-PfbLegalHoldEntity"
+      ]
+    },
+    {
+      "name": "location",
       "cmdletCount": 8,
       "cmdlets": [
-        "Get-PfbFileSystemGroupPerformance",
-        "Get-PfbFileSystemUserPerformance",
-        "Get-PfbQuotaGroup",
-        "Get-PfbQuotaUser",
-        "Get-PfbUsageGroup",
-        "Get-PfbUsageUser",
-        "New-PfbLegalHoldEntity",
-        "Update-PfbLegalHoldEntity"
+        "New-PfbUserGroupQuotaPolicy",
+        "Update-PfbManagementAccessPolicy",
+        "Update-PfbQosPolicy",
+        "Update-PfbSshCaPolicy",
+        "Update-PfbStorageClassTieringPolicy",
+        "Update-PfbTlsPolicy",
+        "Update-PfbUserGroupQuotaPolicy",
+        "Update-PfbWormPolicy"
+      ]
+    },
+    {
+      "name": "group_names",
+      "cmdletCount": 7,
+      "cmdlets": [
+        "Get-PfbFileSystemGroup",
+        "Get-PfbFileSystemGroupQuota",
+        "Get-PfbLocalGroupMember",
+        "Get-PfbNodeGroupNode",
+        "New-PfbLocalGroupMember",
+        "Remove-PfbLocalGroupMember",
+        "Remove-PfbNodeGroupNode"
       ]
     },
     {
@@ -18519,18 +19010,6 @@
         "Update-PfbDns",
         "Update-PfbKmip",
         "Update-PfbTarget"
-      ]
-    },
-    {
-      "name": "location",
-      "cmdletCount": 6,
-      "cmdlets": [
-        "Update-PfbManagementAccessPolicy",
-        "Update-PfbQosPolicy",
-        "Update-PfbSshCaPolicy",
-        "Update-PfbStorageClassTieringPolicy",
-        "Update-PfbTlsPolicy",
-        "Update-PfbWormPolicy"
       ]
     },
     {
@@ -18557,17 +19036,6 @@
       ]
     },
     {
-      "name": "group_names",
-      "cmdletCount": 5,
-      "cmdlets": [
-        "Get-PfbLocalGroupMember",
-        "Get-PfbNodeGroupNode",
-        "New-PfbLocalGroupMember",
-        "Remove-PfbLocalGroupMember",
-        "Remove-PfbNodeGroupNode"
-      ]
-    },
-    {
       "name": "local_file_system_names",
       "cmdletCount": 5,
       "cmdlets": [
@@ -18590,13 +19058,35 @@
       ]
     },
     {
-      "name": "file_system_ids",
+      "name": "rules",
+      "cmdletCount": 5,
+      "cmdlets": [
+        "New-PfbPolicy",
+        "New-PfbUserGroupQuotaPolicy",
+        "Update-PfbManagementAccessPolicy",
+        "Update-PfbPolicy",
+        "Update-PfbUserGroupQuotaPolicy"
+      ]
+    },
+    {
+      "name": "versions",
+      "cmdletCount": 5,
+      "cmdlets": [
+        "New-PfbNetworkAccessRule",
+        "New-PfbNfsExportRule",
+        "New-PfbSmbClientRule",
+        "Remove-PfbUserGroupQuotaPolicy",
+        "Update-PfbUserGroupQuotaPolicy"
+      ]
+    },
+    {
+      "name": "quota_limit",
       "cmdletCount": 4,
       "cmdlets": [
-        "Get-PfbFileSystemGroupPerformance",
-        "Get-PfbFileSystemUserPerformance",
-        "New-PfbLegalHoldEntity",
-        "Update-PfbLegalHoldEntity"
+        "New-PfbBucket",
+        "New-PfbUserGroupQuotaPolicyRule",
+        "Update-PfbBucket",
+        "Update-PfbUserGroupQuotaPolicyRule"
       ]
     },
     {
@@ -18755,24 +19245,6 @@
       ]
     },
     {
-      "name": "rules",
-      "cmdletCount": 3,
-      "cmdlets": [
-        "New-PfbPolicy",
-        "Update-PfbManagementAccessPolicy",
-        "Update-PfbPolicy"
-      ]
-    },
-    {
-      "name": "versions",
-      "cmdletCount": 3,
-      "cmdlets": [
-        "New-PfbNetworkAccessRule",
-        "New-PfbNfsExportRule",
-        "New-PfbSmbClientRule"
-      ]
-    },
-    {
       "name": "actions",
       "cmdletCount": 2,
       "cmdlets": [
@@ -18818,6 +19290,14 @@
       "cmdlets": [
         "New-PfbQuotaGroup",
         "Update-PfbLogTargetFileSystem"
+      ]
+    },
+    {
+      "name": "gids",
+      "cmdletCount": 2,
+      "cmdlets": [
+        "Get-PfbFileSystemGroup",
+        "Get-PfbFileSystemGroupQuota"
       ]
     },
     {
@@ -18877,14 +19357,6 @@
       ]
     },
     {
-      "name": "quota_limit",
-      "cmdletCount": 2,
-      "cmdlets": [
-        "New-PfbBucket",
-        "Update-PfbBucket"
-      ]
-    },
-    {
       "name": "recursive",
       "cmdletCount": 2,
       "cmdlets": [
@@ -18906,6 +19378,22 @@
       "cmdlets": [
         "New-PfbFileSystemExport",
         "Update-PfbFileSystemExport"
+      ]
+    },
+    {
+      "name": "uids",
+      "cmdletCount": 2,
+      "cmdlets": [
+        "Get-PfbFileSystemUser",
+        "Get-PfbFileSystemUserQuota"
+      ]
+    },
+    {
+      "name": "user_names",
+      "cmdletCount": 2,
+      "cmdlets": [
+        "Get-PfbFileSystemUser",
+        "Get-PfbFileSystemUserQuota"
       ]
     },
     {
@@ -19626,11 +20114,6 @@
       "cmdlets": []
     },
     {
-      "name": "gids",
-      "cmdletCount": 0,
-      "cmdlets": []
-    },
-    {
       "name": "group_gids",
       "cmdletCount": 0,
       "cmdlets": []
@@ -19976,17 +20459,7 @@
       "cmdlets": []
     },
     {
-      "name": "uids",
-      "cmdletCount": 0,
-      "cmdlets": []
-    },
-    {
       "name": "unreachable",
-      "cmdletCount": 0,
-      "cmdlets": []
-    },
-    {
-      "name": "user_names",
       "cmdletCount": 0,
       "cmdlets": []
     },

--- a/Reports/PfbApiDriftReport.md
+++ b/Reports/PfbApiDriftReport.md
@@ -20,13 +20,13 @@ This report accepts **false positives in order to eliminate false negatives**. A
 
 ## Summary
 
-- Uncovered endpoints: 117
-- Endpoints with parameter gaps: 417
-- Missing body properties (addable): 403
-- Missing query parameters (addable): 924
-- Read-only body fields (not addable -- see the Read-only fields section below): 367
+- Uncovered endpoints: 98
+- Endpoints with parameter gaps: 436
+- Missing body properties (addable): 408
+- Missing query parameters (addable): 954
+- Read-only body fields (not addable -- see the Read-only fields section below): 379
 - Phantom fields silently excluded (accumulated in the capability map, absent from the newest analysed spec): 40
-- Partial-confidence endpoints (see `How to read this report` above, and each row's marker in the Parameter gaps table): 54
+- Partial-confidence endpoints (see `How to read this report` above, and each row's marker in the Parameter gaps table): 58
 - Systemic gaps (distinct field names collapsed across high-confidence endpoints, detailed below): 252
 - ValidateSet drift: 0
 - New ValidateSet candidates: 1
@@ -39,27 +39,27 @@ Showing the top 25 of 252 findings by endpoint count -- the full list is in the 
 
 | Field name | Endpoints | Query | Body | Cmdlets already using this name | Annotation |
 |---|---|---|---|---|---|
-| `context_names` | 254 | 254 | 0 | 0 | not yet implemented |
-| `allow_errors` | 110 | 110 | 0 | 0 | not yet implemented |
-| `ids` | 43 | 43 | 0 | 219 |  |
-| `names` | 31 | 31 | 0 | 308 |  |
-| `sort` | 28 | 28 | 0 | 171 |  |
+| `context_names` | 269 | 269 | 0 | 0 | not yet implemented |
+| `allow_errors` | 118 | 118 | 0 | 0 | not yet implemented |
+| `ids` | 43 | 43 | 0 | 224 |  |
+| `names` | 31 | 31 | 0 | 314 |  |
+| `sort` | 28 | 28 | 0 | 180 |  |
 | `bucket_ids` | 17 | 17 | 0 | 2 |  |
-| `policy_ids` | 17 | 17 | 0 | 88 |  |
-| `total_only` | 17 | 17 | 0 | 30 |  |
+| `policy_ids` | 17 | 17 | 0 | 98 |  |
+| `total_only` | 17 | 17 | 0 | 39 |  |
 | `bucket_names` | 16 | 16 | 0 | 3 |  |
-| `member_ids` | 15 | 15 | 0 | 78 |  |
+| `member_ids` | 15 | 15 | 0 | 85 |  |
 | `remote_ids` | 15 | 15 | 0 | 3 |  |
 | `remote_names` | 13 | 13 | 0 | 5 |  |
-| `policy_names` | 11 | 11 | 0 | 108 |  |
-| `file_system_ids` | 9 | 9 | 0 | 4 |  |
+| `policy_names` | 11 | 11 | 0 | 118 |  |
+| `file_system_ids` | 9 | 9 | 0 | 9 |  |
 | `local_file_system_ids` | 8 | 8 | 0 | 2 |  |
 | `actions` | 7 | 0 | 7 | 2 |  |
-| `limit` | 7 | 7 | 0 | 190 |  |
-| `versions` | 7 | 7 | 0 | 3 |  |
+| `limit` | 7 | 7 | 0 | 199 |  |
+| `versions` | 7 | 7 | 0 | 5 |  |
 | `enabled` | 6 | 0 | 6 | 10 |  |
-| `filter` | 6 | 6 | 0 | 193 |  |
-| `gids` | 6 | 6 | 0 | 0 |  |
+| `filter` | 6 | 6 | 0 | 202 |  |
+| `gids` | 6 | 6 | 0 | 2 |  |
 | `name` | 6 | 0 | 6 | 20 |  |
 | `role_ids` | 6 | 6 | 0 | 2 |  |
 | `role_names` | 6 | 6 | 0 | 4 |  |
@@ -105,6 +105,7 @@ Endpoints an existing cmdlet already calls, where the capability map knows of a 
 | `DELETE /file-systems/locks` | Remove-PfbFileLock | client_names, context_names, file_system_ids, file_system_names, inodes, paths, recursive |  | `high` |  |
 | `DELETE /file-systems/policies` | Remove-PfbFileSystemPolicy | context_names |  | `high` |  |
 | `DELETE /file-systems/sessions` | Remove-PfbFileSystemSession | client_names, context_names, disruptive, user_names |  | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
+| `DELETE /file-systems/user-group-quota-policies` | Remove-PfbFileSystemUserGroupQuotaPolicy | context_names |  | `high` |  |
 | `DELETE /fleets/members` | Remove-PfbFleetMember | member_ids, unreachable |  | `high` |  |
 | `DELETE /lifecycle-rules` | Remove-PfbLifecycleRule | bucket_ids, bucket_names, context_names |  | `high` |  |
 | `DELETE /log-targets/file-systems` | Remove-PfbLogTargetFileSystem | context_names |  | `high` |  |
@@ -147,6 +148,9 @@ Endpoints an existing cmdlet already calls, where the capability map knows of a 
 | `DELETE /smb-share-policies/rules` | Remove-PfbSmbShareRule | context_names, ids |  | `high` |  |
 | `DELETE /ssh-certificate-authority-policies/admins` | Remove-PfbSshCaPolicyAdmin | context_names |  | `high` |  |
 | `DELETE /ssh-certificate-authority-policies/arrays` | Remove-PfbSshCaPolicyArray | context_names |  | `high` |  |
+| `DELETE /user-group-quota-policies` | Remove-PfbUserGroupQuotaPolicy | context_names |  | `high` |  |
+| `DELETE /user-group-quota-policies/file-systems` | Remove-PfbUserGroupQuotaPolicyFileSystem | context_names |  | `high` |  |
+| `DELETE /user-group-quota-policies/rules` | Remove-PfbUserGroupQuotaPolicyRule | context_names |  | `high` |  |
 | `DELETE /workloads` | Remove-PfbWorkload | context_names |  | `high` |  |
 | `DELETE /workloads/tags` | Remove-PfbWorkloadTag | context_names |  | `high` |  |
 | `DELETE /worm-data-policies` | Remove-PfbWormPolicy | context_names |  | `high` |  |
@@ -206,14 +210,17 @@ Endpoints an existing cmdlet already calls, where the capability map knows of a 
 | `GET /dns` | Get-PfbDns | allow_errors, context_names, ids, names |  | `high` |  |
 | `GET /drives` | Get-PfbDrive | total_only |  | `high` |  |
 | `GET /file-system-exports` | Get-PfbFileSystemExport | allow_errors, context_names, workload_ids, workload_names |  | `high` |  |
+| `GET /file-system-group-quotas` | Get-PfbFileSystemGroupQuota | allow_errors, context_names |  | `high` |  |
 | `GET /file-system-replica-links` | Get-PfbFileSystemReplicaLink | allow_errors, context_names, ids, local_file_system_ids, remote_file_system_ids, remote_ids, remote_names |  | `high` |  |
 | `GET /file-system-replica-links/policies` | Get-PfbFileSystemReplicaLinkPolicy | allow_errors, context_names, local_file_system_ids, local_file_system_names, remote_file_system_ids, remote_file_system_names, remote_ids, remote_names |  | `high` |  |
 | `GET /file-system-replica-links/transfer` | Get-PfbFileSystemReplicaLinkTransfer | allow_errors, context_names, names_or_owner_names, remote_ids, remote_names |  | `high` |  |
 | `GET /file-system-snapshots` | Get-PfbFileSystemSnapshot | allow_errors, context_names, names_or_owner_names, owner_ids |  | `high` |  |
 | `GET /file-system-snapshots/policies` | Get-PfbFileSystemSnapshotPolicy | allow_errors, context_names |  | `high` |  |
 | `GET /file-system-snapshots/transfer` | Get-PfbFileSystemSnapshotTransfer | allow_errors, context_names, names_or_owner_names |  | `high` |  |
+| `GET /file-system-user-quotas` | Get-PfbFileSystemUserQuota | allow_errors, context_names |  | `high` |  |
 | `GET /file-systems` | Get-PfbFileSystem | allow_errors, context_names, workload_ids, workload_names |  | `high` |  |
 | `GET /file-systems/audit-policies` | Get-PfbFileSystemAuditPolicy | allow_errors, context_names |  | `high` |  |
+| `GET /file-systems/groups` | Get-PfbFileSystemGroup | allow_errors, context_names |  | `high` |  |
 | `GET /file-systems/groups/performance` | Get-PfbFileSystemGroupPerformance | gids, group_names, names |  | `high` |  |
 | `GET /file-systems/locks` | Get-PfbFileLock | allow_errors, client_names, context_names, file_system_ids, file_system_names, inodes, paths |  | `high` |  |
 | `GET /file-systems/locks/clients` | Get-PfbFileLockClient | allow_errors, context_names |  | `high` |  |
@@ -221,6 +228,8 @@ Endpoints an existing cmdlet already calls, where the capability map knows of a 
 | `GET /file-systems/policies` | Get-PfbFileSystemPolicy | allow_errors, context_names |  | `high` |  |
 | `GET /file-systems/sessions` | Get-PfbFileSystemSession | allow_errors, client_names, context_names, user_names |  | `high` |  |
 | `GET /file-systems/space/storage-classes` | Get-PfbFileSystemStorageClass | storage_class_names |  | `high` |  |
+| `GET /file-systems/user-group-quota-policies` | Get-PfbFileSystemUserGroupQuotaPolicy | allow_errors, context_names |  | `high` |  |
+| `GET /file-systems/users` | Get-PfbFileSystemUser | allow_errors, context_names |  | `high` |  |
 | `GET /file-systems/users/performance` | Get-PfbFileSystemUserPerformance | names, uids, user_names |  | `high` |  |
 | `GET /file-systems/worm-data-policies` | Get-PfbFileSystemWormPolicy | allow_errors, context_names |  | `high` |  |
 | `GET /fleets` | Get-PfbFleet | total_only |  | `high` |  |
@@ -313,6 +322,10 @@ Endpoints an existing cmdlet already calls, where the capability map knows of a 
 | `GET /tls-policies/members` | Get-PfbTlsPolicyMember | sort |  | `high` |  |
 | `GET /usage/groups` | Get-PfbUsageGroup | allow_errors, context_names, file_system_ids, gids, group_names |  | `high` |  |
 | `GET /usage/users` | Get-PfbUsageUser | allow_errors, context_names, file_system_ids, uids, user_names |  | `high` |  |
+| `GET /user-group-quota-policies` | Get-PfbUserGroupQuotaPolicy | allow_errors, context_names, ids, names |  | `partial` -- /!\ 2 unresolved params (see Partial-confidence detail below) |  |
+| `GET /user-group-quota-policies/file-systems` | Get-PfbUserGroupQuotaPolicyFileSystem | allow_errors, context_names |  | `high` |  |
+| `GET /user-group-quota-policies/members` | Get-PfbUserGroupQuotaPolicyMember | allow_errors, context_names |  | `high` |  |
+| `GET /user-group-quota-policies/rules` | Get-PfbUserGroupQuotaPolicyRule | allow_errors, context_names |  | `high` |  |
 | `GET /workloads` | Get-PfbWorkload | allow_errors, context_names |  | `high` |  |
 | `GET /workloads/placement-recommendations` | Get-PfbWorkloadPlacementRecommendation | allow_errors, context_names |  | `high` |  |
 | `GET /workloads/tags` | Get-PfbWorkloadTag | allow_errors, context_names |  | `high` |  |
@@ -388,6 +401,8 @@ Endpoints an existing cmdlet already calls, where the capability map knows of a 
 | `PATCH /syslog-servers/settings` | Update-PfbSyslogServerSettings | ids, names | ca_certificate, ca_certificate_group | `high` |  |
 | `PATCH /targets` | Update-PfbTarget |  |  | `high` |  |
 | `PATCH /tls-policies` | Update-PfbTlsPolicy |  |  | `high` |  |
+| `PATCH /user-group-quota-policies` | Update-PfbUserGroupQuotaPolicy | context_names | enabled, name | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
+| `PATCH /user-group-quota-policies/rules` | Update-PfbUserGroupQuotaPolicyRule | context_names |  | `high` |  |
 | `PATCH /workloads` | Update-PfbWorkload | context_names | destroyed | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
 | `PATCH /worm-data-policies` | Update-PfbWormPolicy | context_names |  | `high` |  |
 | `POST /active-directory` | New-PfbActiveDirectory | join_existing_account, names | ca_certificate, ca_certificate_group, computer_name, directory_servers, domain, encryption_types, fqdns, global_catalog_servers, join_ou, kerberos_servers, password, service_principal_names, user | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
@@ -425,6 +440,7 @@ Endpoints an existing cmdlet already calls, where the capability map knows of a 
 | `POST /file-systems/audit-policies` | New-PfbFileSystemAuditPolicy | context_names |  | `high` |  |
 | `POST /file-systems/locks/nlm-reclamations` | New-PfbNlmReclamation | context_names |  | `high` |  |
 | `POST /file-systems/policies` | New-PfbFileSystemPolicy | context_names |  | `high` |  |
+| `POST /file-systems/user-group-quota-policies` | New-PfbFileSystemUserGroupQuotaPolicy | context_names |  | `high` |  |
 | `POST /fleets` | New-PfbFleet | names |  | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
 | `POST /keytabs` | New-PfbKeytab | name_prefixes | source | `high` |  |
 | `POST /keytabs/upload` | New-PfbKeytabUpload | name_prefixes | keytab_file | `high` |  |
@@ -485,6 +501,9 @@ Endpoints an existing cmdlet already calls, where the capability map knows of a 
 | `POST /syslog-servers` | New-PfbSyslogServer | names | services, sources, uri | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
 | `POST /targets` | New-PfbTarget | names | address | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
 | `POST /tls-policies` | New-PfbTlsPolicy | names | appliance_certificate, client_certificates_required, disabled_tls_ciphers, enabled, enabled_tls_ciphers, location, min_tls_version, name, trusted_client_certificate_authority, verify_client_certificate_trust | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
+| `POST /user-group-quota-policies` | New-PfbUserGroupQuotaPolicy | context_names | enabled, name | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
+| `POST /user-group-quota-policies/file-systems` | New-PfbUserGroupQuotaPolicyFileSystem | context_names |  | `high` |  |
+| `POST /user-group-quota-policies/rules` | New-PfbUserGroupQuotaPolicyRule | context_names | enforced | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
 | `POST /workloads` | New-PfbWorkload | context_names |  | `high` |  |
 | `POST /workloads/placement-recommendations` | New-PfbWorkloadPlacementRecommendation | context_names | additional_constraints, parameters, preset, projection_months, recommendation_engine, results_limit | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
 | `POST /worm-data-policies` | New-PfbWormPolicy | context_names, names | default_retention, enabled, location, max_retention, min_retention, mode, retention_lock | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
@@ -505,6 +524,8 @@ Per the decision-6 procedure above: open each parameter at its `file:line` and f
 | `DELETE /quotas/users` | `-UserName` | TypedUnresolved | `Public/Quota/Remove-PfbQuotaUser.ps1:26` | one or more parameters could not be traced to a wire name and have no -Attributes escape hatch; lists reflect typed-parameter coverage only, not full wire reachability |
 | `DELETE /servers` | `-Eradicate` | TypedUnresolved | `Public/Server/Remove-PfbServer.ps1:35` | one or more parameters could not be traced to a wire name and have no -Attributes escape hatch; lists reflect typed-parameter coverage only, not full wire reachability |
 | `GET /arrays` | `-Endpoint` | TypedUnresolved | `Public/Connection/Test-PfbConnection.ps1:31` | one or more parameters could not be traced to a wire name and have no -Attributes escape hatch; lists reflect typed-parameter coverage only, not full wire reachability |
+| `GET /user-group-quota-policies` | `-Id` | TypedUnresolved | `Public/Policy/Get-PfbUserGroupQuotaPolicy.ps1:38` | one or more parameters could not be traced to a wire name and have no -Attributes escape hatch; lists reflect typed-parameter coverage only, not full wire reachability |
+| `GET /user-group-quota-policies` | `-Name` | TypedUnresolved | `Public/Policy/Get-PfbUserGroupQuotaPolicy.ps1:35` | one or more parameters could not be traced to a wire name and have no -Attributes escape hatch; lists reflect typed-parameter coverage only, not full wire reachability |
 | `PATCH /alert-watchers` | `-Enabled` | AttributesOnly | `Public/Alert/Update-PfbAlertWatcher.ps1:32` | body reachable only via -Attributes; lists reflect typed-parameter coverage, not wire reachability |
 | `PATCH /alerts` | `-Flagged` | AttributesOnly | `Public/Alert/Update-PfbAlert.ps1:26` | body reachable only via -Attributes; lists reflect typed-parameter coverage, not wire reachability |
 | `PATCH /audit-file-systems-policies` | `-Enabled` | AttributesOnly | `Public/Policy/Update-PfbAuditFileSystemPolicy.ps1:40` | body reachable only via -Attributes; lists reflect typed-parameter coverage, not wire reachability |
@@ -536,6 +557,7 @@ Per the decision-6 procedure above: open each parameter at its `file:line` and f
 | `PATCH /s3-export-policies` | `-Enabled` | AttributesOnly | `Public/Policy/Update-PfbS3ExportPolicy.ps1:42` | body reachable only via -Attributes; lists reflect typed-parameter coverage, not wire reachability |
 | `PATCH /smb-client-policies` | `-Enabled` | AttributesOnly | `Public/Policy/Update-PfbSmbClientPolicy.ps1:42` | body reachable only via -Attributes; lists reflect typed-parameter coverage, not wire reachability |
 | `PATCH /smb-share-policies` | `-Enabled` | AttributesOnly | `Public/Policy/Update-PfbSmbSharePolicy.ps1:42` | body reachable only via -Attributes; lists reflect typed-parameter coverage, not wire reachability |
+| `PATCH /user-group-quota-policies` | `-Enabled` | AttributesOnly | `Public/Policy/Update-PfbUserGroupQuotaPolicy.ps1:36` | body reachable only via -Attributes; lists reflect typed-parameter coverage, not wire reachability |
 | `PATCH /workloads` | `-Destroyed` | TypedUnresolved | `Public/Workloads/Update-PfbWorkload.ps1:36` | one or more parameters could not be traced to a wire name and have no -Attributes escape hatch; lists reflect typed-parameter coverage only, not full wire reachability |
 | `POST /active-directory` | `-Name` | AttributesOnly | `Public/DirectoryService/New-PfbActiveDirectory.ps1:40` | body reachable only via -Attributes; lists reflect typed-parameter coverage, not wire reachability |
 | `POST /audit-file-systems-policies` | `-Enabled` | AttributesOnly | `Public/Policy/New-PfbAuditFileSystemPolicy.ps1:35` | body reachable only via -Attributes; lists reflect typed-parameter coverage, not wire reachability |
@@ -578,6 +600,8 @@ Per the decision-6 procedure above: open each parameter at its `file:line` and f
 | `POST /syslog-servers` | `-Name` | AttributesOnly | `Public/Monitoring/New-PfbSyslogServer.ps1:32` | body reachable only via -Attributes; lists reflect typed-parameter coverage, not wire reachability |
 | `POST /targets` | `-Name` | AttributesOnly | `Public/Replication/New-PfbTarget.ps1:31` | body reachable only via -Attributes; lists reflect typed-parameter coverage, not wire reachability |
 | `POST /tls-policies` | `-Name` | AttributesOnly | `Public/Policy/New-PfbTlsPolicy.ps1:29` | body reachable only via -Attributes; lists reflect typed-parameter coverage, not wire reachability |
+| `POST /user-group-quota-policies` | `-Enabled` | AttributesOnly | `Public/Policy/New-PfbUserGroupQuotaPolicy.ps1:49` | body reachable only via -Attributes; lists reflect typed-parameter coverage, not wire reachability |
+| `POST /user-group-quota-policies/rules` | `-Enforced` | AttributesOnly | `Public/Policy/New-PfbUserGroupQuotaPolicyRule.ps1:57` | body reachable only via -Attributes; lists reflect typed-parameter coverage, not wire reachability |
 | `POST /workloads/placement-recommendations` | `-Inputs` | TypedUnresolved | `Public/Workloads/New-PfbWorkloadPlacementRecommendation.ps1:29` | one or more parameters could not be traced to a wire name and have no -Attributes escape hatch; lists reflect typed-parameter coverage only, not full wire reachability |
 | `POST /worm-data-policies` | `-Name` | AttributesOnly | `Public/Policy/New-PfbWormPolicy.ps1:30` | body reachable only via -Attributes; lists reflect typed-parameter coverage, not wire reachability |
 
@@ -644,6 +668,8 @@ The capability map knows these body properties exist, but the newest analysed sp
 | `PATCH /syslog-servers/settings` | Update-PfbSyslogServerSettings | id, name |
 | `PATCH /targets` | Update-PfbTarget | id, status, status_details |
 | `PATCH /tls-policies` | Update-PfbTlsPolicy | id, is_local, policy_type, realms |
+| `PATCH /user-group-quota-policies` | Update-PfbUserGroupQuotaPolicy | context, id, is_local, policy_type, realms, version |
+| `PATCH /user-group-quota-policies/rules` | Update-PfbUserGroupQuotaPolicyRule | id, name |
 | `PATCH /worm-data-policies` | Update-PfbWormPolicy | context, id, is_local, name, policy_type, realms |
 | `POST /array-connections` | New-PfbArrayConnection | context, id, os, status, type, version |
 | `POST /audit-file-systems-policies` | New-PfbAuditFileSystemPolicy | id, is_local, policy_type, realms |
@@ -679,6 +705,7 @@ The capability map knows these body properties exist, but the newest analysed sp
 | `POST /storage-class-tiering-policies` | New-PfbStorageClassTieringPolicy | id, is_local, policy_type, realms |
 | `POST /subnets` | New-PfbSubnet | enabled, id, interfaces, name, services |
 | `POST /tls-policies` | New-PfbTlsPolicy | id, is_local, policy_type, realms |
+| `POST /user-group-quota-policies` | New-PfbUserGroupQuotaPolicy | id, is_local, policy_type, realms |
 | `POST /workloads/placement-recommendations` | New-PfbWorkloadPlacementRecommendation | context, created, expires, id, more_results_available, name, progress, results, status |
 | `POST /worm-data-policies` | New-PfbWormPolicy | context, id, is_local, name, policy_type, realms |
 
@@ -749,16 +776,9 @@ The capability map knows these body properties exist, but the newest analysed sp
 | `POST /software-bundle` | 2.24 |
 | `GET /software-patches` | 2.24 |
 | `POST /software-patches` | 2.24 |
-| `GET /file-systems/user-group-quota-policies` | 2.25 |
-| `POST /file-systems/user-group-quota-policies` | 2.25 |
-| `DELETE /file-systems/user-group-quota-policies` | 2.25 |
 | `GET /file-system-junctions` | 2.25 |
 | `POST /file-system-junctions` | 2.25 |
 | `DELETE /file-system-junctions` | 2.25 |
-| `GET /file-system-group-quotas` | 2.25 |
-| `GET /file-systems/groups` | 2.25 |
-| `GET /file-system-user-quotas` | 2.25 |
-| `GET /file-systems/users` | 2.25 |
 | `GET /realm-connections` | 2.25 |
 | `POST /realm-connections` | 2.25 |
 | `DELETE /realm-connections` | 2.25 |
@@ -766,18 +786,6 @@ The capability map knows these body properties exist, but the newest analysed sp
 | `POST /realm-connections/connection-key` | 2.25 |
 | `DELETE /realm-connections/connection-key` | 2.25 |
 | `GET /remote-realms` | 2.25 |
-| `GET /user-group-quota-policies` | 2.25 |
-| `POST /user-group-quota-policies` | 2.25 |
-| `PATCH /user-group-quota-policies` | 2.25 |
-| `DELETE /user-group-quota-policies` | 2.25 |
-| `GET /user-group-quota-policies/rules` | 2.25 |
-| `POST /user-group-quota-policies/rules` | 2.25 |
-| `DELETE /user-group-quota-policies/rules` | 2.25 |
-| `PATCH /user-group-quota-policies/rules` | 2.25 |
-| `GET /user-group-quota-policies/file-systems` | 2.25 |
-| `POST /user-group-quota-policies/file-systems` | 2.25 |
-| `DELETE /user-group-quota-policies/file-systems` | 2.25 |
-| `GET /user-group-quota-policies/members` | 2.25 |
 | `GET /management-access-policies/roles` | 2.26 |
 | `POST /management-access-policies/roles` | 2.26 |
 | `DELETE /management-access-policies/roles` | 2.26 |

--- a/Reports/PfbFieldCmdletMap.json
+++ b/Reports/PfbFieldCmdletMap.json
@@ -5513,6 +5513,86 @@
       "recommendation": null
     },
     {
+      "cmdlet": "Get-PfbFileSystemGroup",
+      "parameter": "FileSystemName",
+      "wireName": "file_system_names",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbFileSystemGroup",
+      "parameter": "FileSystemId",
+      "wireName": "file_system_ids",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbFileSystemGroup",
+      "parameter": "GroupName",
+      "wireName": "group_names",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbFileSystemGroup",
+      "parameter": "GroupId",
+      "wireName": "gids",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbFileSystemGroup",
+      "parameter": "Filter",
+      "wireName": "filter",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbFileSystemGroup",
+      "parameter": "Sort",
+      "wireName": "sort",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbFileSystemGroup",
+      "parameter": "Limit",
+      "wireName": "limit",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbFileSystemGroup",
+      "parameter": "TotalOnly",
+      "wireName": "total_only",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
       "cmdlet": "Get-PfbFileSystemGroupPerformance",
       "parameter": "Name",
       "wireName": "file_system_names",
@@ -5596,6 +5676,86 @@
       "cmdlet": "Get-PfbFileSystemGroupPerformance",
       "parameter": "Resolution",
       "wireName": "resolution",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbFileSystemGroupQuota",
+      "parameter": "FileSystemName",
+      "wireName": "file_system_names",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbFileSystemGroupQuota",
+      "parameter": "FileSystemId",
+      "wireName": "file_system_ids",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbFileSystemGroupQuota",
+      "parameter": "GroupName",
+      "wireName": "group_names",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbFileSystemGroupQuota",
+      "parameter": "GroupId",
+      "wireName": "gids",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbFileSystemGroupQuota",
+      "parameter": "Filter",
+      "wireName": "filter",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbFileSystemGroupQuota",
+      "parameter": "Sort",
+      "wireName": "sort",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbFileSystemGroupQuota",
+      "parameter": "Limit",
+      "wireName": "limit",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbFileSystemGroupQuota",
+      "parameter": "TotalOnly",
+      "wireName": "total_only",
       "status": "no-spec-enum-found",
       "matchedKey": null,
       "specValues": null,
@@ -5783,6 +5943,176 @@
       "recommendation": null
     },
     {
+      "cmdlet": "Get-PfbFileSystemUser",
+      "parameter": "FileSystemName",
+      "wireName": "file_system_names",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbFileSystemUser",
+      "parameter": "FileSystemId",
+      "wireName": "file_system_ids",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbFileSystemUser",
+      "parameter": "UserName",
+      "wireName": "user_names",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbFileSystemUser",
+      "parameter": "UserId",
+      "wireName": "uids",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbFileSystemUser",
+      "parameter": "UserSid",
+      "wireName": "user_sids",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbFileSystemUser",
+      "parameter": "Filter",
+      "wireName": "filter",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbFileSystemUser",
+      "parameter": "Sort",
+      "wireName": "sort",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbFileSystemUser",
+      "parameter": "Limit",
+      "wireName": "limit",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbFileSystemUser",
+      "parameter": "TotalOnly",
+      "wireName": "total_only",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbFileSystemUserGroupQuotaPolicy",
+      "parameter": "PolicyName",
+      "wireName": "policy_names",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbFileSystemUserGroupQuotaPolicy",
+      "parameter": "PolicyId",
+      "wireName": "policy_ids",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbFileSystemUserGroupQuotaPolicy",
+      "parameter": "MemberName",
+      "wireName": "member_names",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbFileSystemUserGroupQuotaPolicy",
+      "parameter": "MemberId",
+      "wireName": "member_ids",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbFileSystemUserGroupQuotaPolicy",
+      "parameter": "Filter",
+      "wireName": "filter",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbFileSystemUserGroupQuotaPolicy",
+      "parameter": "Sort",
+      "wireName": "sort",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbFileSystemUserGroupQuotaPolicy",
+      "parameter": "Limit",
+      "wireName": "limit",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbFileSystemUserGroupQuotaPolicy",
+      "parameter": "TotalOnly",
+      "wireName": "total_only",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
       "cmdlet": "Get-PfbFileSystemUserPerformance",
       "parameter": "Name",
       "wireName": "file_system_names",
@@ -5866,6 +6196,96 @@
       "cmdlet": "Get-PfbFileSystemUserPerformance",
       "parameter": "Resolution",
       "wireName": "resolution",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbFileSystemUserQuota",
+      "parameter": "FileSystemName",
+      "wireName": "file_system_names",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbFileSystemUserQuota",
+      "parameter": "FileSystemId",
+      "wireName": "file_system_ids",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbFileSystemUserQuota",
+      "parameter": "UserName",
+      "wireName": "user_names",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbFileSystemUserQuota",
+      "parameter": "UserId",
+      "wireName": "uids",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbFileSystemUserQuota",
+      "parameter": "UserSid",
+      "wireName": "user_sids",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbFileSystemUserQuota",
+      "parameter": "Filter",
+      "wireName": "filter",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbFileSystemUserQuota",
+      "parameter": "Sort",
+      "wireName": "sort",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbFileSystemUserQuota",
+      "parameter": "Limit",
+      "wireName": "limit",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbFileSystemUserQuota",
+      "parameter": "TotalOnly",
+      "wireName": "total_only",
       "status": "no-spec-enum-found",
       "matchedKey": null,
       "specValues": null,
@@ -6193,6 +6613,66 @@
       "recommendation": null
     },
     {
+      "cmdlet": "New-PfbFileSystemUserGroupQuotaPolicy",
+      "parameter": "PolicyName",
+      "wireName": "policy_names",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "New-PfbFileSystemUserGroupQuotaPolicy",
+      "parameter": "PolicyId",
+      "wireName": "policy_ids",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "New-PfbFileSystemUserGroupQuotaPolicy",
+      "parameter": "MemberName",
+      "wireName": "member_names",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "New-PfbFileSystemUserGroupQuotaPolicy",
+      "parameter": "MemberId",
+      "wireName": "member_ids",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "New-PfbFileSystemUserGroupQuotaPolicy",
+      "parameter": "DeleteExistingUserGroupQuotaSettings",
+      "wireName": "delete_existing_user_group_quota_settings",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "New-PfbFileSystemUserGroupQuotaPolicy",
+      "parameter": "IgnoreUsage",
+      "wireName": "ignore_usage",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
       "cmdlet": "New-PfbNlmReclamation",
       "parameter": "Name",
       "wireName": "names",
@@ -6356,6 +6836,46 @@
       "cmdlet": "Remove-PfbFileSystemSession",
       "parameter": "Name",
       "wireName": "names",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Remove-PfbFileSystemUserGroupQuotaPolicy",
+      "parameter": "PolicyName",
+      "wireName": "policy_names",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Remove-PfbFileSystemUserGroupQuotaPolicy",
+      "parameter": "PolicyId",
+      "wireName": "policy_ids",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Remove-PfbFileSystemUserGroupQuotaPolicy",
+      "parameter": "MemberName",
+      "wireName": "member_names",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Remove-PfbFileSystemUserGroupQuotaPolicy",
+      "parameter": "MemberId",
+      "wireName": "member_ids",
       "status": "no-spec-enum-found",
       "matchedKey": null,
       "specValues": null,
@@ -14278,6 +14798,286 @@
       "recommendation": null
     },
     {
+      "cmdlet": "Get-PfbUserGroupQuotaPolicy",
+      "parameter": "Filter",
+      "wireName": "filter",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbUserGroupQuotaPolicy",
+      "parameter": "Sort",
+      "wireName": "sort",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbUserGroupQuotaPolicy",
+      "parameter": "Limit",
+      "wireName": "limit",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbUserGroupQuotaPolicy",
+      "parameter": "TotalOnly",
+      "wireName": "total_only",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbUserGroupQuotaPolicyFileSystem",
+      "parameter": "PolicyName",
+      "wireName": "policy_names",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbUserGroupQuotaPolicyFileSystem",
+      "parameter": "PolicyId",
+      "wireName": "policy_ids",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbUserGroupQuotaPolicyFileSystem",
+      "parameter": "MemberName",
+      "wireName": "member_names",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbUserGroupQuotaPolicyFileSystem",
+      "parameter": "MemberId",
+      "wireName": "member_ids",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbUserGroupQuotaPolicyFileSystem",
+      "parameter": "Filter",
+      "wireName": "filter",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbUserGroupQuotaPolicyFileSystem",
+      "parameter": "Sort",
+      "wireName": "sort",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbUserGroupQuotaPolicyFileSystem",
+      "parameter": "Limit",
+      "wireName": "limit",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbUserGroupQuotaPolicyFileSystem",
+      "parameter": "TotalOnly",
+      "wireName": "total_only",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbUserGroupQuotaPolicyMember",
+      "parameter": "PolicyName",
+      "wireName": "policy_names",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbUserGroupQuotaPolicyMember",
+      "parameter": "PolicyId",
+      "wireName": "policy_ids",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbUserGroupQuotaPolicyMember",
+      "parameter": "MemberName",
+      "wireName": "member_names",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbUserGroupQuotaPolicyMember",
+      "parameter": "MemberId",
+      "wireName": "member_ids",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbUserGroupQuotaPolicyMember",
+      "parameter": "Filter",
+      "wireName": "filter",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbUserGroupQuotaPolicyMember",
+      "parameter": "Sort",
+      "wireName": "sort",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbUserGroupQuotaPolicyMember",
+      "parameter": "Limit",
+      "wireName": "limit",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbUserGroupQuotaPolicyMember",
+      "parameter": "TotalOnly",
+      "wireName": "total_only",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbUserGroupQuotaPolicyRule",
+      "parameter": "PolicyName",
+      "wireName": "policy_names",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbUserGroupQuotaPolicyRule",
+      "parameter": "PolicyId",
+      "wireName": "policy_ids",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbUserGroupQuotaPolicyRule",
+      "parameter": "Name",
+      "wireName": "names",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbUserGroupQuotaPolicyRule",
+      "parameter": "Id",
+      "wireName": "ids",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbUserGroupQuotaPolicyRule",
+      "parameter": "Filter",
+      "wireName": "filter",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbUserGroupQuotaPolicyRule",
+      "parameter": "Sort",
+      "wireName": "sort",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbUserGroupQuotaPolicyRule",
+      "parameter": "Limit",
+      "wireName": "limit",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbUserGroupQuotaPolicyRule",
+      "parameter": "TotalOnly",
+      "wireName": "total_only",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
       "cmdlet": "Get-PfbWormPolicy",
       "parameter": "Name",
       "wireName": "names",
@@ -15168,6 +15968,166 @@
       "recommendation": null
     },
     {
+      "cmdlet": "New-PfbUserGroupQuotaPolicy",
+      "parameter": "Name",
+      "wireName": "names",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "New-PfbUserGroupQuotaPolicy",
+      "parameter": "FileSystemName",
+      "wireName": "file_system_names",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "New-PfbUserGroupQuotaPolicy",
+      "parameter": "FileSystemId",
+      "wireName": "file_system_ids",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "New-PfbUserGroupQuotaPolicy",
+      "parameter": "Location",
+      "wireName": "location",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "New-PfbUserGroupQuotaPolicy",
+      "parameter": "Rules",
+      "wireName": "rules",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "New-PfbUserGroupQuotaPolicyFileSystem",
+      "parameter": "PolicyName",
+      "wireName": "policy_names",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "New-PfbUserGroupQuotaPolicyFileSystem",
+      "parameter": "PolicyId",
+      "wireName": "policy_ids",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "New-PfbUserGroupQuotaPolicyFileSystem",
+      "parameter": "MemberName",
+      "wireName": "member_names",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "New-PfbUserGroupQuotaPolicyFileSystem",
+      "parameter": "MemberId",
+      "wireName": "member_ids",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "New-PfbUserGroupQuotaPolicyFileSystem",
+      "parameter": "DeleteExistingUserGroupQuotaSettings",
+      "wireName": "delete_existing_user_group_quota_settings",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "New-PfbUserGroupQuotaPolicyFileSystem",
+      "parameter": "IgnoreUsage",
+      "wireName": "ignore_usage",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "New-PfbUserGroupQuotaPolicyRule",
+      "parameter": "PolicyName",
+      "wireName": "policy_names",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "New-PfbUserGroupQuotaPolicyRule",
+      "parameter": "PolicyId",
+      "wireName": "policy_ids",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "New-PfbUserGroupQuotaPolicyRule",
+      "parameter": "Subject",
+      "wireName": "subject",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "New-PfbUserGroupQuotaPolicyRule",
+      "parameter": "QuotaLimit",
+      "wireName": "quota_limit",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "New-PfbUserGroupQuotaPolicyRule",
+      "parameter": "IgnoreUsage",
+      "wireName": "ignore_usage",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
       "cmdlet": "Remove-PfbAuditFileSystemPolicy",
       "parameter": "Name",
       "wireName": "names",
@@ -15811,6 +16771,116 @@
       "cmdlet": "Remove-PfbTlsPolicy",
       "parameter": "Id",
       "wireName": "ids",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Remove-PfbUserGroupQuotaPolicy",
+      "parameter": "Name",
+      "wireName": "names",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Remove-PfbUserGroupQuotaPolicy",
+      "parameter": "Id",
+      "wireName": "ids",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Remove-PfbUserGroupQuotaPolicy",
+      "parameter": "Version",
+      "wireName": "versions",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Remove-PfbUserGroupQuotaPolicyFileSystem",
+      "parameter": "PolicyName",
+      "wireName": "policy_names",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Remove-PfbUserGroupQuotaPolicyFileSystem",
+      "parameter": "PolicyId",
+      "wireName": "policy_ids",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Remove-PfbUserGroupQuotaPolicyFileSystem",
+      "parameter": "MemberName",
+      "wireName": "member_names",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Remove-PfbUserGroupQuotaPolicyFileSystem",
+      "parameter": "MemberId",
+      "wireName": "member_ids",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Remove-PfbUserGroupQuotaPolicyRule",
+      "parameter": "Name",
+      "wireName": "names",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Remove-PfbUserGroupQuotaPolicyRule",
+      "parameter": "Id",
+      "wireName": "ids",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Remove-PfbUserGroupQuotaPolicyRule",
+      "parameter": "PolicyName",
+      "wireName": "policy_names",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Remove-PfbUserGroupQuotaPolicyRule",
+      "parameter": "PolicyId",
+      "wireName": "policy_ids",
       "status": "no-spec-enum-found",
       "matchedKey": null,
       "specValues": null,
@@ -16381,6 +17451,106 @@
       "cmdlet": "Update-PfbTlsPolicy",
       "parameter": "VerifyClientCertificateTrust",
       "wireName": "verify_client_certificate_trust",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Update-PfbUserGroupQuotaPolicy",
+      "parameter": "Name",
+      "wireName": "names",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Update-PfbUserGroupQuotaPolicy",
+      "parameter": "Id",
+      "wireName": "ids",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Update-PfbUserGroupQuotaPolicy",
+      "parameter": "Location",
+      "wireName": "location",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Update-PfbUserGroupQuotaPolicy",
+      "parameter": "Rules",
+      "wireName": "rules",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Update-PfbUserGroupQuotaPolicy",
+      "parameter": "IgnoreUsage",
+      "wireName": "ignore_usage",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Update-PfbUserGroupQuotaPolicy",
+      "parameter": "Version",
+      "wireName": "versions",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Update-PfbUserGroupQuotaPolicyRule",
+      "parameter": "Name",
+      "wireName": "names",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Update-PfbUserGroupQuotaPolicyRule",
+      "parameter": "Id",
+      "wireName": "ids",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Update-PfbUserGroupQuotaPolicyRule",
+      "parameter": "QuotaLimit",
+      "wireName": "quota_limit",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Update-PfbUserGroupQuotaPolicyRule",
+      "parameter": "IgnoreUsage",
+      "wireName": "ignore_usage",
       "status": "no-spec-enum-found",
       "matchedKey": null,
       "specValues": null,
@@ -19200,6 +20370,14 @@
       "parameter": "Name"
     },
     {
+      "cmdlet": "New-PfbUserGroupQuotaPolicy",
+      "parameter": "Enabled"
+    },
+    {
+      "cmdlet": "New-PfbUserGroupQuotaPolicyRule",
+      "parameter": "Enforced"
+    },
+    {
       "cmdlet": "New-PfbWormPolicy",
       "parameter": "Name"
     },
@@ -19233,6 +20411,10 @@
     },
     {
       "cmdlet": "Update-PfbSmbSharePolicy",
+      "parameter": "Enabled"
+    },
+    {
+      "cmdlet": "Update-PfbUserGroupQuotaPolicy",
       "parameter": "Enabled"
     },
     {
@@ -19392,6 +20574,14 @@
     {
       "cmdlet": "Get-PfbHardwareTemperature",
       "parameter": "Limit"
+    },
+    {
+      "cmdlet": "Get-PfbUserGroupQuotaPolicy",
+      "parameter": "Name"
+    },
+    {
+      "cmdlet": "Get-PfbUserGroupQuotaPolicy",
+      "parameter": "Id"
     },
     {
       "cmdlet": "Remove-PfbQuotaGroup",

--- a/Reports/PfbFieldCmdletMapping.md
+++ b/Reports/PfbFieldCmdletMapping.md
@@ -9,7 +9,7 @@ Reporting only -- no `Public/` cmdlet is edited by this script. Every `matched` 
 - matched: 1
 - collision: 1
 - not-found-in-resource: 29
-- no-spec-enum-found: 1867
+- no-spec-enum-found: 1984
 
 | Cmdlet | Parameter | Wire name | Status | Spec values | Recommendation |
 |---|---|---|---|---|---|
@@ -45,7 +45,7 @@ Reporting only -- no `Public/` cmdlet is edited by this script. Every `matched` 
 | `Update-PfbTarget` | `-NewName` | name | not-found-in-resource |  |  |
 | `Update-PfbWorkload` | `-NewName` | name | not-found-in-resource |  |  |
 
-## Attributes-only parameters (no typed field to attach either mechanism to): 65
+## Attributes-only parameters (no typed field to attach either mechanism to): 68
 
 - `Update-PfbAlert -Flagged`
 - `Update-PfbAlertWatcher -Enabled`
@@ -92,6 +92,8 @@ Reporting only -- no `Public/` cmdlet is edited by this script. Every `matched` 
 - `New-PfbSshCaPolicy -Name`
 - `New-PfbStorageClassTieringPolicy -Name`
 - `New-PfbTlsPolicy -Name`
+- `New-PfbUserGroupQuotaPolicy -Enabled`
+- `New-PfbUserGroupQuotaPolicyRule -Enforced`
 - `New-PfbWormPolicy -Name`
 - `Update-PfbAuditFileSystemPolicy -Enabled`
 - `Update-PfbAuditObjectStorePolicy -Enabled`
@@ -101,6 +103,7 @@ Reporting only -- no `Public/` cmdlet is edited by this script. Every `matched` 
 - `Update-PfbS3ExportPolicy -Enabled`
 - `Update-PfbSmbClientPolicy -Enabled`
 - `Update-PfbSmbSharePolicy -Enabled`
+- `Update-PfbUserGroupQuotaPolicy -Enabled`
 - `New-PfbQuotaUser -FileSystemName`
 - `New-PfbQuotaUser -UserName`
 - `New-PfbQuotaUser -UserId`
@@ -113,7 +116,7 @@ Reporting only -- no `Public/` cmdlet is edited by this script. Every `matched` 
 - `New-PfbTarget -Name`
 - `New-PfbServer -CreateDirectoryService`
 
-## Typed but unresolved wire name (needs manual inspection): 37
+## Typed but unresolved wire name (needs manual inspection): 39
 
 - `Get-PfbAlert -Flagged`
 - `Get-PfbApiVersion -Endpoint`
@@ -143,6 +146,8 @@ Reporting only -- no `Public/` cmdlet is edited by this script. Every `matched` 
 - `New-PfbFileSystemSnapshot -SourceName`
 - `Remove-PfbFileSystemSnapshot -Eradicate`
 - `Get-PfbHardwareTemperature -Limit`
+- `Get-PfbUserGroupQuotaPolicy -Name`
+- `Get-PfbUserGroupQuotaPolicy -Id`
 - `Remove-PfbQuotaGroup -FileSystemName`
 - `Remove-PfbQuotaGroup -GroupName`
 - `Remove-PfbQuotaUser -FileSystemName`


### PR DESCRIPTION
## What

Regenerates the `Public/`-derived report artifacts, which have been stale on `main`.

## Why

PR #68 (`d42a22f`, "Add user & group quota policy cmdlets") added cmdlets **without** regenerating the committed report artifacts. PR #66 (`18f8ed7`) did regenerate, but from a base that predated #68.

The result is a **currently-failing test on `main`**: `Tests/Build-PfbApiDriftReport.Tests.ps1:780` asserts the in-memory report matches the committed `Reports/PfbApiDriftReport.json` exactly, and it reports a 47-item divergence on an unmodified checkout. This will fail CI for any PR branched from `main`, not just this one.

## What was run

```
tools/Build-PfbFieldCmdletMap.ps1
tools/Build-PfbApiDriftReport.ps1
```

`Data/PfbCapabilityMap.json` is spec-derived and already covers all 29 cached specs (2.0-2.28), so it needs no rebuild. `tools/Update-PfbApiSpecs.ps1` was **deliberately not run** -- without `-Force` it still re-hits the network for the version index, and a newly published REST version would silently change every count and confound the before/after comparison this verification depends on.

## Net effect

The quota cmdlets are now recognised as covered, which exposes their parameter gaps:

| Measure | Before | After |
|---|---|---|
| uncovered endpoints | 117 | **98** |
| endpoints with gaps | 417 | **436** |
| query-parameter gaps | 924 | **954** |
| body-property gaps | 403 | **408** |

Every newly-reported field is on a `user-group-quota-policies` / quota endpoint -- i.e. exactly PR #68's surface.

## Verification

- **Nothing vanished** -- verified programmatically over the two JSON files: 0 fields present before and absent after.
- **Deterministic** -- regenerated to a second path; SHA256 of both the `.json` and the `.md` match the committed artifacts byte-for-byte.
- **Scoped Pester run green** -- `Build-PfbApiDriftReport.Tests.ps1` + `PfbApiDriftTools.Tests.ps1`: **165 passed, 0 failed** (was 1 failed before this change). Full-suite coverage is CI's job per the repo convention.
- **Live-array testing: not applicable.** No `Public/` or `Private/` change and no runtime surface -- this is `Reports/` only. The equivalent verification is the whole-report diff plus the determinism check above.

## Scope

`Reports/` only. No logic change. No version bump, no CHANGELOG entry -- those are maintainer decisions.

---

Found while establishing a clean baseline for upcoming response-shape drift work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
