### PR TITLE
tools: check the Fusion context_names cardinality assumption against the spec

### DIFF
--- a/Private/Test-PfbContextMultiValueCapable.ps1
+++ b/Private/Test-PfbContextMultiValueCapable.ps1
@@ -1,0 +1,73 @@
+function Test-PfbContextMultiValueCapable {
+    <#
+    .SYNOPSIS
+        THE single declared home of the Fusion `context_names` cardinality rule: is an
+        endpoint with the given HTTP method able to accept MANY context names, or exactly
+        one?
+    .DESCRIPTION
+        The rule:
+
+            GET is multi-context-capable. POST / PATCH / DELETE are single-context-only.
+
+        This function is deliberately the ONLY place that rule is expressed. Context
+        injection (PR #22) must call this rather than testing the verb inline, and the
+        spec-vs-module-assumption check in tools/lib/PfbContextRuleTools.ps1 dot-sources
+        THIS FILE and executes THIS function rather than re-deriving the rule. A check
+        that re-implements the rule it is checking verifies nothing, so the two must never
+        drift into separate copies.
+
+        Why a verb rule rather than reading cardinality out of the OpenAPI spec: the
+        cardinality is NOT machine-readable. The spec expresses it only through which
+        component a parameter `$ref`s -- `Context_names_get` (multi-value) versus
+        `Context_names` (size-1) -- and those two components have *identical* schemas.
+        There is no `maxItems`; the size-1 restriction lives only in free-text
+        `description`. The component name is therefore the sole mechanical signal, and it
+        has been observed to be wrong (see below).
+
+        This rule is GROUND TRUTH -- live-tested against a FlashBlade plus upstream
+        confirmation. It is deliberately NOT derived from the spec, and must not be
+        "corrected" to match the spec when the two disagree. Where they disagreed, the
+        spec was the side that was wrong:
+
+          - fb2.26 and fb2.27 had `DELETE /management-access-policies` referencing
+            `Context_names_get` (multi-value), contradicting this rule. Investigated and
+            confirmed an upstream documentation/spec defect. NO exception was ever
+            implemented here -- the clean verb rule was kept.
+          - REST 2.28 fixed it: that endpoint now references `Context_names`. As of fb2.28
+            the spec and this rule agree on every endpoint carrying `context_names`.
+
+        The check exists so that a FUTURE divergence -- in particular a genuine
+        multi-context mutation endpoint, the case where this rule would be the wrong side
+        -- gets noticed instead of silently mis-serving callers.
+    .PARAMETER Method
+        The endpoint's HTTP method. Case-insensitive.
+    .OUTPUTS
+        [bool] -- $true when the method may carry multiple context names (fan-out),
+        $false when it accepts exactly one.
+    .NOTES
+        Throws on a method the rule has no verdict for. Returning $false for an
+        unrecognized verb would quietly assume "size-1" for a verb nobody has reasoned
+        about -- precisely the silent-wrongness this rule's verification is meant to
+        prevent. Failing loudly forces a human decision.
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Method
+    )
+
+    switch ($Method.ToUpperInvariant()) {
+        'GET' { return $true }
+        'POST' { return $false }
+        'PATCH' { return $false }
+        'PUT' { return $false }
+        'DELETE' { return $false }
+        default {
+            throw ("Test-PfbContextMultiValueCapable: no context-cardinality verdict is " +
+                "defined for HTTP method '$Method'. The Fusion context_names verb rule " +
+                'covers GET/POST/PUT/PATCH/DELETE only -- extend this function ' +
+                'deliberately rather than assuming a default.')
+        }
+    }
+}

--- a/Private/Test-PfbContextMultiValueCapable.ps1
+++ b/Private/Test-PfbContextMultiValueCapable.ps1
@@ -1,62 +1,94 @@
 function Test-PfbContextMultiValueCapable {
     <#
     .SYNOPSIS
-        THE single declared home of the Fusion `context_names` cardinality rule: is an
-        endpoint with the given HTTP method able to accept MANY context names, or exactly
-        one?
+        THE single declared home of the Fusion `context_names` cardinality rule: can this
+        endpoint accept MANY context names, or exactly one?
     .DESCRIPTION
-        The rule:
+        The rule, ratified in rev 3 of docs/design/fusion-context-injection.md (section 8):
 
-            GET is multi-context-capable. POST / PATCH / DELETE are single-context-only.
+            An endpoint is multi-context-capable if and only if its `context_names`
+            parameter resolves to component `Context_names_get` AND the endpoint also
+            declares `allow_errors`.
 
-        This function is deliberately the ONLY place that rule is expressed. Context
-        injection (PR #22) must call this rather than testing the verb inline, and the
-        spec-vs-module-assumption check in tools/lib/PfbContextRuleTools.ps1 dot-sources
-        THIS FILE and executes THIS function rather than re-deriving the rule. A check
-        that re-implements the rule it is checking verifies nothing, so the two must never
-        drift into separate copies.
+        Both facts are recorded per endpoint in Data/PfbCapabilityMap.json, so at runtime
+        this is a lookup, not a derivation. Against the committed map (generatedFrom
+        2.0-2.28) the rule yields 135 capable endpoints of the 139 referencing the
+        multi-value component; against fb2.27, 134 of 139.
 
-        Why a verb rule rather than reading cardinality out of the OpenAPI spec: the
-        cardinality is NOT machine-readable. The spec expresses it only through which
-        component a parameter `$ref`s -- `Context_names_get` (multi-value) versus
-        `Context_names` (size-1) -- and those two components have *identical* schemas.
-        There is no `maxItems`; the size-1 restriction lives only in free-text
-        `description`. The component name is therefore the sole mechanical signal, and it
-        has been observed to be wrong (see below).
+        This function is deliberately PURE -- no map loading, no file I/O. Each caller
+        supplies facts from its own source: the maintainer drift check from the capability
+        map or from a single spec version, the context-injection path from the map entry it
+        has already resolved. That is what lets both execute the same rule instead of
+        re-deriving it.
 
-        This rule is GROUND TRUTH -- live-tested against a FlashBlade plus upstream
-        confirmation. It is deliberately NOT derived from the spec, and must not be
-        "corrected" to match the spec when the two disagree. Where they disagreed, the
-        spec was the side that was wrong:
+        WHY NOT THE HTTP VERB. Rev 2 proposed a clean verb split -- GET multi-value,
+        mutations size-1 -- and this file previously described it as ground truth. It is
+        not, and that claim has been withdrawn. Live testing on 2026-08-01 against FB-A
+        (Purity//FB 4.8.2, REST 2.26, coordinator of fleet `cc-test-fleet` with FB-C as a
+        remote member) disproved it: four fleet-scoped GETs reject any two-name context
+        with `400 code 15 "Multiple location contexts are not allowed."` --
+        `GET /presets/workload`, `GET /topology-groups`, `GET /topology-groups/arrays`,
+        `GET /topology-groups/members`. `code 15` fires BEFORE the cross-array
+        authorization gate that yields `code 20` on control endpoints, so it is structural
+        to the endpoint, not a permission artifact. A fleet-scoped endpoint has exactly one
+        meaningful context -- the fleet -- so multi-value is not merely restricted there,
+        it is meaningless. Their spec entries reference `Context_names_get` in error
+        (upstream defect, in review; still present at 2.28). See Appendix A of the design
+        doc for the full evidence and Appendix B for the defect registry.
 
-          - fb2.26 and fb2.27 had `DELETE /management-access-policies` referencing
-            `Context_names_get` (multi-value), contradicting this rule. Investigated and
-            confirmed an upstream documentation/spec defect. NO exception was ever
-            implemented here -- the clean verb rule was kept.
-          - REST 2.28 fixed it: that endpoint now references `Context_names`. As of fb2.28
-            the spec and this rule agree on every endpoint carrying `context_names`.
+        WHY `allow_errors` RATHER THAN THE COMPONENT NAME ALONE. The component reference is
+        wrong for five endpoints (those four plus `DELETE /management-access-policies` in
+        2.26/2.27, since fixed in 2.28), while `allow_errors` is correct on every case for
+        which evidence exists. A genuinely multi-context endpoint needs a partial-failure
+        story, so its absence is strong evidence the endpoint cannot fan out -- which is
+        how the upstream bug report characterizes the defect ("missing e.g. `allow_errors`
+        / HTTP 207 / `_context`").
 
-        The check exists so that a FUTURE divergence -- in particular a genuine
-        multi-context mutation endpoint, the case where this rule would be the wrong side
-        -- gets noticed instead of silently mis-serving callers.
+        WHY NOT HTTP 207. It is the strictest and most accurate signal, and the one
+        upstream tooling uses, but the capability map records the request surface only and
+        holds no response data at all, so it is unavailable at runtime. Gating on it would
+        also treat 11 endpoints of unknown status as size-1 on no evidence. It serves as a
+        corroborating signal for the maintainer drift check, sourced from tools/specs, and
+        never as a runtime gate.
+
+        The verb survives ONLY as a fallback for an endpoint with no component signal at
+        all -- i.e. absent from the capability map entirely. It is not the rule.
     .PARAMETER Method
-        The endpoint's HTTP method. Case-insensitive.
+        The endpoint's HTTP method. Case-insensitive. Used only in the no-signal fallback.
+    .PARAMETER ContextComponent
+        The component the endpoint's `context_names` parameter resolves to, e.g.
+        'Context_names_get' or 'Context_names'. Pass $null or omit when no component is
+        known -- that, and only that, selects the verb fallback.
+    .PARAMETER DeclaresAllowErrors
+        Whether the endpoint declares an `allow_errors` parameter.
     .OUTPUTS
-        [bool] -- $true when the method may carry multiple context names (fan-out),
-        $false when it accepts exactly one.
+        [bool] -- $true when the endpoint may carry multiple context names, $false when it
+        accepts exactly one.
     .NOTES
-        Throws on a method the rule has no verdict for. Returning $false for an
-        unrecognized verb would quietly assume "size-1" for a verb nobody has reasoned
-        about -- precisely the silent-wrongness this rule's verification is meant to
-        prevent. Failing loudly forces a human decision.
+        The fallback throws on a method it has no verdict for. Returning $false there would
+        quietly assume "size-1" for a verb nobody has reasoned about; failing loudly forces
+        a human decision.
     #>
     [CmdletBinding()]
     [OutputType([bool])]
     param(
         [Parameter(Mandatory)]
-        [string]$Method
+        [string]$Method,
+
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string]$ContextComponent,
+
+        [Parameter(Mandatory)]
+        [bool]$DeclaresAllowErrors
     )
 
+    if (-not [string]::IsNullOrWhiteSpace($ContextComponent)) {
+        return ($ContextComponent -eq 'Context_names_get') -and $DeclaresAllowErrors
+    }
+
+    # No component signal at all -- the endpoint is not in the capability map. Fall back to
+    # the verb, which is a guess, not the rule.
     switch ($Method.ToUpperInvariant()) {
         'GET' { return $true }
         'POST' { return $false }
@@ -65,9 +97,10 @@ function Test-PfbContextMultiValueCapable {
         'DELETE' { return $false }
         default {
             throw ("Test-PfbContextMultiValueCapable: no context-cardinality verdict is " +
-                "defined for HTTP method '$Method'. The Fusion context_names verb rule " +
-                'covers GET/POST/PUT/PATCH/DELETE only -- extend this function ' +
-                'deliberately rather than assuming a default.')
+                "defined for HTTP method '$Method', and no component signal was supplied " +
+                'to decide it on evidence. The verb fallback covers GET/POST/PUT/PATCH/' +
+                'DELETE only -- extend this function deliberately rather than assuming a ' +
+                'default.')
         }
     }
 }

--- a/Reports/PfbApiDriftReport.json
+++ b/Reports/PfbApiDriftReport.json
@@ -20508,5 +20508,183 @@
       ],
       "recommendation": "ArgumentCompleter"
     }
-  ]
+  ],
+  "contextCardinality": {
+    "componentSourceVersion": "2.28",
+    "http207SignalAvailable": true,
+    "endpointsWithContextNames": 376,
+    "multiContextCapable": 135,
+    "signalDisagreements": [
+      {
+        "endpoint": "GET /arrays/ssh-certificate-authority-policies",
+        "method": "GET",
+        "contextComponent": "Context_names_get",
+        "shape": "rule-says-capable-but-declares-no-207",
+        "ruleSaysMultiValue": true,
+        "componentSaysMultiValue": true,
+        "declaresAllowErrors": true,
+        "declaresHttp207": false,
+        "multiValueSignals": [
+          "allow_errors",
+          "component"
+        ],
+        "sizeOneSignals": [
+          "http207"
+        ],
+        "summary": "signals split -- multi-value: allow_errors, component; size-1: http207; module rule says multi-value"
+      },
+      {
+        "endpoint": "GET /audit-file-systems-policy-operations",
+        "method": "GET",
+        "contextComponent": "Context_names_get",
+        "shape": "rule-says-capable-but-declares-no-207",
+        "ruleSaysMultiValue": true,
+        "componentSaysMultiValue": true,
+        "declaresAllowErrors": true,
+        "declaresHttp207": false,
+        "multiValueSignals": [
+          "allow_errors",
+          "component"
+        ],
+        "sizeOneSignals": [
+          "http207"
+        ],
+        "summary": "signals split -- multi-value: allow_errors, component; size-1: http207; module rule says multi-value"
+      },
+      {
+        "endpoint": "GET /log-targets/file-systems",
+        "method": "GET",
+        "contextComponent": "Context_names_get",
+        "shape": "rule-says-capable-but-declares-no-207",
+        "ruleSaysMultiValue": true,
+        "componentSaysMultiValue": true,
+        "declaresAllowErrors": true,
+        "declaresHttp207": false,
+        "multiValueSignals": [
+          "allow_errors",
+          "component"
+        ],
+        "sizeOneSignals": [
+          "http207"
+        ],
+        "summary": "signals split -- multi-value: allow_errors, component; size-1: http207; module rule says multi-value"
+      },
+      {
+        "endpoint": "GET /presets/workload",
+        "method": "GET",
+        "contextComponent": "Context_names_get",
+        "shape": "component-says-multi-value-but-no-allow-errors",
+        "ruleSaysMultiValue": false,
+        "componentSaysMultiValue": true,
+        "declaresAllowErrors": false,
+        "declaresHttp207": false,
+        "multiValueSignals": [
+          "component"
+        ],
+        "sizeOneSignals": [
+          "allow_errors",
+          "http207"
+        ],
+        "summary": "signals split -- multi-value: component; size-1: allow_errors, http207; module rule says size-1"
+      },
+      {
+        "endpoint": "GET /realms",
+        "method": "GET",
+        "contextComponent": "Context_names_get",
+        "shape": "rule-says-capable-but-declares-no-207",
+        "ruleSaysMultiValue": true,
+        "componentSaysMultiValue": true,
+        "declaresAllowErrors": true,
+        "declaresHttp207": false,
+        "multiValueSignals": [
+          "allow_errors",
+          "component"
+        ],
+        "sizeOneSignals": [
+          "http207"
+        ],
+        "summary": "signals split -- multi-value: allow_errors, component; size-1: http207; module rule says multi-value"
+      },
+      {
+        "endpoint": "GET /topology-groups",
+        "method": "GET",
+        "contextComponent": "Context_names_get",
+        "shape": "component-says-multi-value-but-no-allow-errors",
+        "ruleSaysMultiValue": false,
+        "componentSaysMultiValue": true,
+        "declaresAllowErrors": false,
+        "declaresHttp207": false,
+        "multiValueSignals": [
+          "component"
+        ],
+        "sizeOneSignals": [
+          "allow_errors",
+          "http207"
+        ],
+        "summary": "signals split -- multi-value: component; size-1: allow_errors, http207; module rule says size-1"
+      },
+      {
+        "endpoint": "GET /topology-groups/arrays",
+        "method": "GET",
+        "contextComponent": "Context_names_get",
+        "shape": "component-says-multi-value-but-no-allow-errors",
+        "ruleSaysMultiValue": false,
+        "componentSaysMultiValue": true,
+        "declaresAllowErrors": false,
+        "declaresHttp207": false,
+        "multiValueSignals": [
+          "component"
+        ],
+        "sizeOneSignals": [
+          "allow_errors",
+          "http207"
+        ],
+        "summary": "signals split -- multi-value: component; size-1: allow_errors, http207; module rule says size-1"
+      },
+      {
+        "endpoint": "GET /topology-groups/members",
+        "method": "GET",
+        "contextComponent": "Context_names_get",
+        "shape": "component-says-multi-value-but-no-allow-errors",
+        "ruleSaysMultiValue": false,
+        "componentSaysMultiValue": true,
+        "declaresAllowErrors": false,
+        "declaresHttp207": false,
+        "multiValueSignals": [
+          "component"
+        ],
+        "sizeOneSignals": [
+          "allow_errors",
+          "http207"
+        ],
+        "summary": "signals split -- multi-value: component; size-1: allow_errors, http207; module rule says size-1"
+      },
+      {
+        "endpoint": "PATCH /directory-services/test",
+        "method": "PATCH",
+        "contextComponent": "Context_names",
+        "shape": "size-1-component-but-declares-allow-errors",
+        "ruleSaysMultiValue": false,
+        "componentSaysMultiValue": false,
+        "declaresAllowErrors": true,
+        "declaresHttp207": false,
+        "multiValueSignals": [
+          "allow_errors"
+        ],
+        "sizeOneSignals": [
+          "component",
+          "http207"
+        ],
+        "summary": "signals split -- multi-value: allow_errors; size-1: component, http207; module rule says size-1"
+      }
+    ],
+    "sizeOneWithAllowErrors": [
+      {
+        "endpoint": "PATCH /directory-services/test",
+        "method": "PATCH",
+        "contextComponent": "Context_names"
+      }
+    ],
+    "unresolvedComponents": []
+  }
 }

--- a/Reports/PfbApiDriftReport.md
+++ b/Reports/PfbApiDriftReport.md
@@ -30,6 +30,7 @@ This report accepts **false positives in order to eliminate false negatives**. A
 - Systemic gaps (distinct field names collapsed across high-confidence endpoints, detailed below): 252
 - ValidateSet drift: 0
 - New ValidateSet candidates: 1
+- Context cardinality signal disagreements (fb2.28): 9
 
 ## Systemic gaps
 
@@ -817,4 +818,59 @@ The capability map knows these body properties exist, but the newest analysed sp
 | Cmdlet | Parameter | Spec values |
 |---|---|---|
 | `Get-PfbPolicyAllMember` | `-MemberType` | file-systems, file-system-snapshots, file-system-replica-links, object-store-users |
+
+## Spec-vs-module assumptions: `context_names` cardinality
+
+Every category above asks *"does the module cover what the API offers?"*. This one asks a different question: *"is an assumption baked into the module still true?"*
+
+The module's cardinality rule -- **an endpoint is multi-context-capable if and only if its `context_names` resolves to component `Context_names_get` AND the endpoint declares `allow_errors`** -- is declared in exactly one place, `Private/Test-PfbContextMultiValueCapable.ps1`, which this check *executes* rather than re-derives. The HTTP verb is not the rule; it survives only as a fallback for an endpoint absent from the capability map. See section 8 of `docs/design/fusion-context-injection.md`.
+
+This is a **cross-signal** check, not a rule-versus-spec one. The earlier two-signal shape was structurally unable to see the defect that actually exists: four fleet-scoped GETs reference the multi-value component *and* are size-1 on the wire, so the rule and the component agreed while both were wrong. Any endpoint whose available signals do not all agree is reported below, including the case where the component agrees with the rule but the remaining signals dissent.
+
+Measured against **fb2.28** (the newest analysed version; the capability map's component data is last-seen-wins, so it describes that version's wire shape). 376 endpoints declare `context_names`, of which **135** satisfy the rule.
+
+The HTTP 207 signal is read from `tools/specs/fb2.28.json` -- the capability map records the request surface only and holds no response data, so 207 is a corroborating signal for this report and never a runtime gate.
+
+**A disagreement is not automatically a spec defect.** The case worth catching is a genuine future multi-context endpoint, where the *module* would be the wrong side. A human decides which signal is wrong, each time.
+
+**9 endpoint(s) with disagreeing signals**, grouped by shape.
+
+#### `component-says-multi-value-but-no-allow-errors` (4)
+
+The component claims fan-out while the endpoint offers no partial-failure story. Strong evidence of a spec defect: this is the shape of the four fleet-scoped GETs confirmed size-1 on the wire, and of `DELETE /management-access-policies` before its 2.28 correction.
+
+| Endpoint | Method | Component | Declares `allow_errors` | Declares 207 | Module rule |
+|---|---|---|---|---|---|
+| `GET /presets/workload` | GET | `Context_names_get` | no | no | size-1 |
+| `GET /topology-groups` | GET | `Context_names_get` | no | no | size-1 |
+| `GET /topology-groups/arrays` | GET | `Context_names_get` | no | no | size-1 |
+| `GET /topology-groups/members` | GET | `Context_names_get` | no | no | size-1 |
+
+#### `rule-says-capable-but-declares-no-207` (4)
+
+Component and `allow_errors` both say fan-out, but no HTTP 207 is declared, so partial failure has no documented response shape. Status genuinely unknown -- which is precisely why 207 is a corroborating signal here and never a runtime gate: treating these as size-1 would block calls that may well work.
+
+| Endpoint | Method | Component | Declares `allow_errors` | Declares 207 | Module rule |
+|---|---|---|---|---|---|
+| `GET /arrays/ssh-certificate-authority-policies` | GET | `Context_names_get` | yes | no | multi-value |
+| `GET /audit-file-systems-policy-operations` | GET | `Context_names_get` | yes | no | multi-value |
+| `GET /log-targets/file-systems` | GET | `Context_names_get` | yes | no | multi-value |
+| `GET /realms` | GET | `Context_names_get` | yes | no | multi-value |
+
+#### `size-1-component-but-declares-allow-errors` (1)
+
+The mirror case -- a size-1 component on an endpoint that nonetheless declares `allow_errors`. Named again below.
+
+| Endpoint | Method | Component | Declares `allow_errors` | Declares 207 | Module rule |
+|---|---|---|---|---|---|
+| `PATCH /directory-services/test` | PATCH | `Context_names` | yes | no | size-1 |
+
+
+### Named case: size-1 component declaring `allow_errors`
+
+A **subset** of the findings above (shape `size-1-component-but-declares-allow-errors`), not an additional finding. Called out by name because it is a known, characterized case.
+
+- `PATCH /directory-services/test`
+
+Not live-verified: these carry mutating verbs and were not probed during the 2026-08-01 testing (Appendix A, "Not verified").
 

--- a/Tests/PfbContextRuleTools.Tests.ps1
+++ b/Tests/PfbContextRuleTools.Tests.ps1
@@ -1,0 +1,272 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+<#
+.SYNOPSIS
+    Unit tests for tools/lib/PfbContextRuleTools.ps1 and the module's single declared
+    context-cardinality rule, Private/Test-PfbContextMultiValueCapable.ps1.
+.DESCRIPTION
+    Note on InModuleScope: deliberately NOT used. PfbContextRuleTools.ps1 is dot-sourced
+    from tools/lib/ and its functions are therefore directly callable, and it in turn
+    dot-sources the Private/ predicate itself -- so the predicate is in scope here without
+    importing the module at all. That is the point of the design: the rule has exactly one
+    home, and both the check and these tests reach the same copy.
+#>
+
+BeforeAll {
+    $repoRoot = Split-Path -Parent $PSScriptRoot
+    . (Join-Path $repoRoot 'tools/lib/PfbSpecTools.ps1')
+    . (Join-Path $repoRoot 'tools/lib/PfbContextRuleTools.ps1')
+
+    $script:repoRoot = $repoRoot
+
+    # Synthetic capability map exercising every branch of the documented
+    # defaults/overrides resolution contract.
+    $script:fixtureMap = [PSCustomObject]@{
+        parameterComponentDefaults = [PSCustomObject]@{
+            context_names = 'Context_names'
+            allow_errors  = 'Allow_errors'
+        }
+        endpoints                  = [PSCustomObject]@{
+            # Falls back to the default component (size-1) and agrees with the rule.
+            'DELETE /widgets'          = [PSCustomObject]@{
+                parameters = [PSCustomObject]@{ context_names = '2.26'; ids = '2.0' }
+            }
+            # Override to the multi-value component; GET, so rule and spec agree.
+            'GET /widgets'             = [PSCustomObject]@{
+                parameters                  = [PSCustomObject]@{ context_names = '2.26'; allow_errors = '2.26' }
+                parameterComponentOverrides = [PSCustomObject]@{ context_names = 'Context_names_get' }
+            }
+            # THE disagreement shape: a mutation verb referencing the multi-value
+            # component, and (corroboratingly) not declaring allow_errors.
+            'DELETE /gadgets'          = [PSCustomObject]@{
+                parameters                  = [PSCustomObject]@{ context_names = '2.26' }
+                parameterComponentOverrides = [PSCustomObject]@{ context_names = 'Context_names_get' }
+            }
+            # Agreed multi-value but no allow_errors -- the SEPARATE anomaly.
+            'GET /sprockets'           = [PSCustomObject]@{
+                parameters                  = [PSCustomObject]@{ context_names = '2.26' }
+                parameterComponentOverrides = [PSCustomObject]@{ context_names = 'Context_names_get' }
+            }
+            # Agreed size-1 but declares allow_errors -- the mirror-image anomaly.
+            'PATCH /cogs'              = [PSCustomObject]@{
+                parameters = [PSCustomObject]@{ context_names = '2.26'; allow_errors = '2.26' }
+            }
+            # Override key PRESENT with a null value == "no component here", which must be
+            # honoured over the default rather than silently falling through to it.
+            'GET /inline-context'      = [PSCustomObject]@{
+                parameters                  = [PSCustomObject]@{ context_names = '2.26' }
+                parameterComponentOverrides = [PSCustomObject]@{ context_names = $null }
+            }
+            # No context_names at all -- must be ignored entirely.
+            'GET /unrelated'           = [PSCustomObject]@{
+                parameters = [PSCustomObject]@{ ids = '2.0'; allow_errors = '2.26' }
+            }
+        }
+    }
+
+    $script:fixtureFacts = @(Get-PfbContextParameterFact -CapabilityMap $script:fixtureMap)
+}
+
+Describe 'Test-PfbContextMultiValueCapable (the single declared rule)' {
+    It 'treats GET as multi-context-capable' {
+        Test-PfbContextMultiValueCapable -Method 'GET' | Should -BeTrue
+    }
+
+    It 'treats <Method> as single-context-only' -ForEach @(
+        @{ Method = 'POST' }
+        @{ Method = 'PUT' }
+        @{ Method = 'PATCH' }
+        @{ Method = 'DELETE' }
+    ) {
+        Test-PfbContextMultiValueCapable -Method $Method | Should -BeFalse
+    }
+
+    It 'is case-insensitive' {
+        Test-PfbContextMultiValueCapable -Method 'get' | Should -BeTrue
+        Test-PfbContextMultiValueCapable -Method 'delete' | Should -BeFalse
+    }
+
+    It 'throws rather than assuming a default for a verb it has no verdict for' {
+        # A silent $false here would quietly assume "size-1" for a verb nobody has
+        # reasoned about -- exactly the silent wrongness this rule's verification exists
+        # to catch. (-Method is supplied, so no interactive mandatory-parameter prompt.)
+        { Test-PfbContextMultiValueCapable -Method 'TRACE' } | Should -Throw -ExpectedMessage '*no context-cardinality verdict*'
+    }
+}
+
+Describe 'Get-PfbContextParameterFact' {
+    It 'returns only endpoints declaring context_names' {
+        $script:fixtureFacts.Endpoint | Should -Not -Contain 'GET /unrelated'
+        $script:fixtureFacts.Count | Should -Be 6
+    }
+
+    It 'falls back to parameterComponentDefaults when no override is present' {
+        $fact = $script:fixtureFacts | Where-Object Endpoint -EQ 'DELETE /widgets'
+        $fact.ContextComponent | Should -Be 'Context_names'
+        $fact.SpecSaysMultiValue | Should -BeFalse
+    }
+
+    It 'prefers a per-endpoint override over the default' {
+        $fact = $script:fixtureFacts | Where-Object Endpoint -EQ 'GET /widgets'
+        $fact.ContextComponent | Should -Be 'Context_names_get'
+        $fact.SpecSaysMultiValue | Should -BeTrue
+    }
+
+    It 'honours an override key present with a null value as "no component"' {
+        $fact = $script:fixtureFacts | Where-Object Endpoint -EQ 'GET /inline-context'
+        $fact.ContextComponent | Should -BeNullOrEmpty
+        $fact.SpecSaysMultiValue | Should -BeNullOrEmpty
+    }
+
+    It 'splits the endpoint key on the first space only' {
+        $fact = $script:fixtureFacts | Where-Object Endpoint -EQ 'PATCH /cogs'
+        $fact.Method | Should -Be 'PATCH'
+        $fact.Path | Should -Be '/cogs'
+    }
+
+    It 'records the module rule verdict from the declared predicate' {
+        ($script:fixtureFacts | Where-Object Endpoint -EQ 'GET /widgets').RuleSaysMultiValue | Should -BeTrue
+        ($script:fixtureFacts | Where-Object Endpoint -EQ 'DELETE /gadgets').RuleSaysMultiValue | Should -BeFalse
+    }
+
+    It 'emits a deterministically sorted collection' {
+        $sorted = @($script:fixtureFacts.Endpoint | Sort-Object)
+        @($script:fixtureFacts.Endpoint) | Should -Be $sorted
+    }
+}
+
+Describe 'Get-PfbContextVerbRuleDisagreement' {
+    BeforeAll {
+        $script:fixtureDisagreements = @(Get-PfbContextVerbRuleDisagreement -Fact $script:fixtureFacts)
+    }
+
+    It 'reports exactly the endpoint where the rule and the component identity differ' {
+        $script:fixtureDisagreements.Count | Should -Be 1
+        $script:fixtureDisagreements[0].Endpoint | Should -Be 'DELETE /gadgets'
+    }
+
+    It 'carries the referenced component, both verdicts, and the allow_errors signal' {
+        $d = $script:fixtureDisagreements[0]
+        $d.ContextComponent | Should -Be 'Context_names_get'
+        $d.RuleSaysMultiValue | Should -BeFalse
+        $d.SpecSaysMultiValue | Should -BeTrue
+        $d.DeclaresAllowErrors | Should -BeFalse
+    }
+
+    It 'words the summary neutrally, without prejudging which side is wrong' {
+        $summary = $script:fixtureDisagreements[0].Summary
+        $summary | Should -BeLike '*module rule says*'
+        $summary | Should -BeLike '*spec references*'
+        # A future disagreement may be a real API change rather than a spec defect.
+        $summary | Should -Not -BeLike '*bug*'
+        $summary | Should -Not -BeLike '*wrong*'
+    }
+
+    It 'excludes endpoints whose component could not be resolved rather than scoring them size-1' {
+        # GET /inline-context has no component. Scored as size-1 it would look like a
+        # disagreement against the GET rule; it must simply not be compared.
+        $script:fixtureDisagreements.Endpoint | Should -Not -Contain 'GET /inline-context'
+    }
+
+    It 'returns an empty collection when every endpoint agrees' {
+        $agreeing = @($script:fixtureFacts | Where-Object { $_.Endpoint -ne 'DELETE /gadgets' })
+        @(Get-PfbContextVerbRuleDisagreement -Fact $agreeing).Count | Should -Be 0
+    }
+}
+
+Describe 'Get-PfbContextAllowErrorsAnomaly' {
+    BeforeAll {
+        $script:fixtureAnomalies = Get-PfbContextAllowErrorsAnomaly -Fact $script:fixtureFacts
+    }
+
+    It 'reports agreed multi-value endpoints that do not declare allow_errors' {
+        @($script:fixtureAnomalies.MultiValueWithoutAllowErrors).Endpoint | Should -Be @('GET /sprockets')
+    }
+
+    It 'reports the mirror image: agreed size-1 endpoints that do declare allow_errors' {
+        @($script:fixtureAnomalies.SingleValueWithAllowErrors).Endpoint | Should -Be @('PATCH /cogs')
+    }
+
+    It 'never double-counts a cardinality disagreement as an allow_errors anomaly' {
+        # DELETE /gadgets is spec-multi-value AND lacks allow_errors, so a naive
+        # spec-only filter would list it here too -- inflating one defect into two
+        # findings. It belongs to the disagreement category alone.
+        @($script:fixtureAnomalies.MultiValueWithoutAllowErrors).Endpoint | Should -Not -Contain 'DELETE /gadgets'
+    }
+
+    It 'emits deterministically sorted collections' {
+        $multi = @($script:fixtureAnomalies.MultiValueWithoutAllowErrors.Endpoint)
+        $multi | Should -Be @($multi | Sort-Object)
+    }
+}
+
+Describe 'Get-PfbContextUnresolvedComponent' {
+    It 'surfaces endpoints whose context_names has no resolvable component' {
+        @(Get-PfbContextUnresolvedComponent -Fact $script:fixtureFacts).Endpoint |
+            Should -Be @('GET /inline-context')
+    }
+}
+
+Describe 'Non-vacuity against real specs' {
+    BeforeAll {
+        # tools/specs/ is gitignored, so these are skipped wherever the cache is absent
+        # (a fresh clone, or CI without the spec-fetch step) rather than failing.
+        $script:spec227Path = Join-Path $script:repoRoot 'tools/specs/fb2.27.json'
+        $script:spec228Path = Join-Path $script:repoRoot 'tools/specs/fb2.28.json'
+        $script:haveSpecs = (Test-Path $script:spec227Path) -and (Test-Path $script:spec228Path)
+    }
+
+    It 'finds exactly one disagreement in fb2.27: DELETE /management-access-policies' -Skip:(-not (Test-Path (Join-Path (Split-Path -Parent $PSScriptRoot) 'tools/specs/fb2.27.json'))) {
+        # This is the proof the check is not vacuous. fb2.27 contains a KNOWN, confirmed
+        # upstream spec defect -- a multi-value component on a DELETE -- and the check
+        # must rediscover it mechanically, with no prior knowledge encoded anywhere.
+        $spec = Get-Content -Path $script:spec227Path -Raw | ConvertFrom-Json
+        $facts = @(Get-PfbContextParameterFact -SpecCapabilities @(Get-PfbSpecCapabilities -Spec $spec))
+        $disagreements = @(Get-PfbContextVerbRuleDisagreement -Fact $facts)
+
+        $disagreements.Count | Should -Be 1
+        $disagreements[0].Endpoint | Should -Be 'DELETE /management-access-policies'
+        $disagreements[0].ContextComponent | Should -Be 'Context_names_get'
+        $disagreements[0].DeclaresAllowErrors | Should -BeFalse
+    }
+
+    It 'finds no disagreement in fb2.28, where the defect was fixed upstream' -Skip:(-not (Test-Path (Join-Path (Split-Path -Parent $PSScriptRoot) 'tools/specs/fb2.28.json'))) {
+        # Pins the observed upstream fix: the same endpoint's reference changed to
+        # Context_names. Together with the fb2.27 case above, this proves the check
+        # tracks the spec rather than reporting a constant.
+        $spec = Get-Content -Path $script:spec228Path -Raw | ConvertFrom-Json
+        $facts = @(Get-PfbContextParameterFact -SpecCapabilities @(Get-PfbSpecCapabilities -Spec $spec))
+
+        @(Get-PfbContextVerbRuleDisagreement -Fact $facts).Count | Should -Be 0
+        ($facts | Where-Object Endpoint -EQ 'DELETE /management-access-policies').ContextComponent |
+            Should -Be 'Context_names'
+    }
+
+    It 'keeps the four multi-value GETs without allow_errors separate in fb2.27' -Skip:(-not (Test-Path (Join-Path (Split-Path -Parent $PSScriptRoot) 'tools/specs/fb2.27.json'))) {
+        $spec = Get-Content -Path $script:spec227Path -Raw | ConvertFrom-Json
+        $facts = @(Get-PfbContextParameterFact -SpecCapabilities @(Get-PfbSpecCapabilities -Spec $spec))
+        $anomalies = Get-PfbContextAllowErrorsAnomaly -Fact $facts
+
+        @($anomalies.MultiValueWithoutAllowErrors).Endpoint | Should -Be @(
+            'GET /presets/workload'
+            'GET /topology-groups'
+            'GET /topology-groups/arrays'
+            'GET /topology-groups/members'
+        )
+        # The fb2.27 spec defect is a cardinality disagreement, not an allow_errors
+        # anomaly, even though it also lacks allow_errors.
+        @($anomalies.MultiValueWithoutAllowErrors).Endpoint |
+            Should -Not -Contain 'DELETE /management-access-policies'
+        @($anomalies.SingleValueWithAllowErrors).Endpoint | Should -Be @('PATCH /directory-services/test')
+    }
+}
+
+Describe 'Committed capability map' {
+    It 'resolves every context_names component (none unresolved)' {
+        $mapPath = Join-Path $script:repoRoot 'Data/PfbCapabilityMap.json'
+        $map = Get-Content -Path $mapPath -Raw | ConvertFrom-Json
+        $facts = @(Get-PfbContextParameterFact -CapabilityMap $map)
+
+        $facts.Count | Should -BeGreaterThan 0
+        @(Get-PfbContextUnresolvedComponent -Fact $facts).Count | Should -Be 0
+    }
+}

--- a/Tests/PfbContextRuleTools.Tests.ps1
+++ b/Tests/PfbContextRuleTools.Tests.ps1
@@ -9,6 +9,12 @@
     dot-sources the Private/ predicate itself -- so the predicate is in scope here without
     importing the module at all. That is the point of the design: the rule has exactly one
     home, and both the check and these tests reach the same copy.
+
+    Note on what is asserted: SPECIFIC ENDPOINTS and STRUCTURE, never population totals.
+    The capability map is regenerated whenever specs are refreshed, so a test pinning "135
+    capable" or "376 endpoints" would break on unrelated maintenance. The four fleet-scoped
+    endpoints confirmed size-1 on the wire on 2026-08-01 are stable fixtures and are used
+    as such.
 #>
 
 BeforeAll {
@@ -18,255 +24,472 @@ BeforeAll {
 
     $script:repoRoot = $repoRoot
 
+    # The four fleet-scoped GETs that reference the multi-value component but reject a
+    # two-name context with 400 code 15. Upstream defect, still present at fb2.28.
+    $script:defectiveFleetScopedGets = @(
+        'GET /presets/workload'
+        'GET /topology-groups'
+        'GET /topology-groups/arrays'
+        'GET /topology-groups/members'
+    )
+
     # Synthetic capability map exercising every branch of the documented
-    # defaults/overrides resolution contract.
+    # defaults/overrides resolution contract and every disagreement shape.
     $script:fixtureMap = [PSCustomObject]@{
         parameterComponentDefaults = [PSCustomObject]@{
             context_names = 'Context_names'
             allow_errors  = 'Allow_errors'
         }
         endpoints                  = [PSCustomObject]@{
-            # Falls back to the default component (size-1) and agrees with the rule.
-            'DELETE /widgets'          = [PSCustomObject]@{
-                parameters = [PSCustomObject]@{ context_names = '2.26'; ids = '2.0' }
-            }
-            # Override to the multi-value component; GET, so rule and spec agree.
-            'GET /widgets'             = [PSCustomObject]@{
+            # Multi-value component + allow_errors + 207 -> capable, all signals agree.
+            'GET /widgets'            = [PSCustomObject]@{
                 parameters                  = [PSCustomObject]@{ context_names = '2.26'; allow_errors = '2.26' }
                 parameterComponentOverrides = [PSCustomObject]@{ context_names = 'Context_names_get' }
             }
-            # THE disagreement shape: a mutation verb referencing the multi-value
-            # component, and (corroboratingly) not declaring allow_errors.
-            'DELETE /gadgets'          = [PSCustomObject]@{
+            # Default component (size-1), no allow_errors -> not capable, signals agree.
+            'DELETE /widgets'         = [PSCustomObject]@{
+                parameters = [PSCustomObject]@{ context_names = '2.26'; ids = '2.0' }
+            }
+            # The defective shape: multi-value component, no allow_errors. A GET, so the
+            # withdrawn verb rule would have called this capable; the ratified rule does not.
+            'GET /fleet-scoped'       = [PSCustomObject]@{
                 parameters                  = [PSCustomObject]@{ context_names = '2.26' }
                 parameterComponentOverrides = [PSCustomObject]@{ context_names = 'Context_names_get' }
             }
-            # Agreed multi-value but no allow_errors -- the SEPARATE anomaly.
-            'GET /sprockets'           = [PSCustomObject]@{
-                parameters                  = [PSCustomObject]@{ context_names = '2.26' }
-                parameterComponentOverrides = [PSCustomObject]@{ context_names = 'Context_names_get' }
-            }
-            # Agreed size-1 but declares allow_errors -- the mirror-image anomaly.
-            'PATCH /cogs'              = [PSCustomObject]@{
+            # The mirror: size-1 component that declares allow_errors.
+            'PATCH /mirror'           = [PSCustomObject]@{
                 parameters = [PSCustomObject]@{ context_names = '2.26'; allow_errors = '2.26' }
+            }
+            # Capable by the rule, but declares no 207.
+            'GET /capable-no-207'     = [PSCustomObject]@{
+                parameters                  = [PSCustomObject]@{ context_names = '2.26'; allow_errors = '2.26' }
+                parameterComponentOverrides = [PSCustomObject]@{ context_names = 'Context_names_get' }
+            }
+            # Nothing says it fans out, yet it declares a partial-failure response.
+            'GET /size1-with-207'     = [PSCustomObject]@{
+                parameters = [PSCustomObject]@{ context_names = '2.26' }
             }
             # Override key PRESENT with a null value == "no component here", which must be
             # honoured over the default rather than silently falling through to it.
-            'GET /inline-context'      = [PSCustomObject]@{
+            'GET /inline-context'     = [PSCustomObject]@{
                 parameters                  = [PSCustomObject]@{ context_names = '2.26' }
                 parameterComponentOverrides = [PSCustomObject]@{ context_names = $null }
             }
             # No context_names at all -- must be ignored entirely.
-            'GET /unrelated'           = [PSCustomObject]@{
+            'GET /unrelated'          = [PSCustomObject]@{
                 parameters = [PSCustomObject]@{ ids = '2.0'; allow_errors = '2.26' }
             }
         }
     }
 
-    $script:fixtureFacts = @(Get-PfbContextParameterFact -CapabilityMap $script:fixtureMap)
+    # 'GET /capable-no-207' is deliberately absent from this set; 'GET /size1-with-207' is
+    # deliberately in it despite having no other multi-value signal.
+    $script:fixture207 = @('GET /widgets', 'GET /size1-with-207')
+
+    $script:facts = @(Get-PfbContextParameterFact -CapabilityMap $script:fixtureMap -Http207Endpoint $script:fixture207)
+    $script:factsNo207 = @(Get-PfbContextParameterFact -CapabilityMap $script:fixtureMap)
 }
 
 Describe 'Test-PfbContextMultiValueCapable (the single declared rule)' {
-    It 'treats GET as multi-context-capable' {
-        Test-PfbContextMultiValueCapable -Method 'GET' | Should -BeTrue
+    It 'is capable only when the multi-value component AND allow_errors are both present' {
+        Test-PfbContextMultiValueCapable -Method 'GET' -ContextComponent 'Context_names_get' -DeclaresAllowErrors $true |
+            Should -BeTrue
     }
 
-    It 'treats <Method> as single-context-only' -ForEach @(
+    It 'is not capable when the component says multi-value but allow_errors is absent' {
+        # The four fleet-scoped GETs. Under the withdrawn verb rule this returned $true.
+        Test-PfbContextMultiValueCapable -Method 'GET' -ContextComponent 'Context_names_get' -DeclaresAllowErrors $false |
+            Should -BeFalse
+    }
+
+    It 'is not capable when allow_errors is present but the component is size-1' {
+        Test-PfbContextMultiValueCapable -Method 'PATCH' -ContextComponent 'Context_names' -DeclaresAllowErrors $true |
+            Should -BeFalse
+    }
+
+    It 'does not let the verb override an evidence-backed verdict' {
+        # A mutation verb with both signals present is capable; a GET without them is not.
+        Test-PfbContextMultiValueCapable -Method 'DELETE' -ContextComponent 'Context_names_get' -DeclaresAllowErrors $true |
+            Should -BeTrue
+        Test-PfbContextMultiValueCapable -Method 'GET' -ContextComponent 'Context_names' -DeclaresAllowErrors $false |
+            Should -BeFalse
+    }
+
+    It 'falls back to the verb only when no component signal exists' -ForEach @(
+        @{ Component = $null; Expected = $true }
+        @{ Component = ''; Expected = $true }
+    ) {
+        Test-PfbContextMultiValueCapable -Method 'GET' -ContextComponent $Component -DeclaresAllowErrors $false |
+            Should -Be $Expected
+    }
+
+    It 'treats <Method> as size-1 in the no-signal fallback' -ForEach @(
         @{ Method = 'POST' }
         @{ Method = 'PUT' }
         @{ Method = 'PATCH' }
         @{ Method = 'DELETE' }
     ) {
-        Test-PfbContextMultiValueCapable -Method $Method | Should -BeFalse
+        Test-PfbContextMultiValueCapable -Method $Method -ContextComponent $null -DeclaresAllowErrors $true |
+            Should -BeFalse
     }
 
-    It 'is case-insensitive' {
-        Test-PfbContextMultiValueCapable -Method 'get' | Should -BeTrue
-        Test-PfbContextMultiValueCapable -Method 'delete' | Should -BeFalse
+    It 'is case-insensitive in both the component test and the fallback' {
+        Test-PfbContextMultiValueCapable -Method 'get' -ContextComponent $null -DeclaresAllowErrors $false | Should -BeTrue
+        Test-PfbContextMultiValueCapable -Method 'delete' -ContextComponent 'Context_names_get' -DeclaresAllowErrors $true | Should -BeTrue
     }
 
     It 'throws rather than assuming a default for a verb it has no verdict for' {
-        # A silent $false here would quietly assume "size-1" for a verb nobody has
-        # reasoned about -- exactly the silent wrongness this rule's verification exists
-        # to catch. (-Method is supplied, so no interactive mandatory-parameter prompt.)
-        { Test-PfbContextMultiValueCapable -Method 'TRACE' } | Should -Throw -ExpectedMessage '*no context-cardinality verdict*'
+        # Only reachable on the fallback path. A silent $false would quietly assume
+        # "size-1" for a verb nobody has reasoned about. (-Method is supplied, so no
+        # interactive mandatory-parameter prompt.)
+        { Test-PfbContextMultiValueCapable -Method 'TRACE' -ContextComponent $null -DeclaresAllowErrors $false } |
+            Should -Throw -ExpectedMessage '*no context-cardinality verdict*'
+    }
+
+    It 'does not throw for an unknown verb when a component signal decides it' {
+        { Test-PfbContextMultiValueCapable -Method 'TRACE' -ContextComponent 'Context_names' -DeclaresAllowErrors $false } |
+            Should -Not -Throw
     }
 }
 
 Describe 'Get-PfbContextParameterFact' {
     It 'returns only endpoints declaring context_names' {
-        $script:fixtureFacts.Endpoint | Should -Not -Contain 'GET /unrelated'
-        $script:fixtureFacts.Count | Should -Be 6
+        $script:facts.Endpoint | Should -Not -Contain 'GET /unrelated'
     }
 
     It 'falls back to parameterComponentDefaults when no override is present' {
-        $fact = $script:fixtureFacts | Where-Object Endpoint -EQ 'DELETE /widgets'
-        $fact.ContextComponent | Should -Be 'Context_names'
-        $fact.SpecSaysMultiValue | Should -BeFalse
+        $f = $script:facts | Where-Object Endpoint -EQ 'DELETE /widgets'
+        $f.ContextComponent | Should -Be 'Context_names'
+        $f.ComponentSaysMultiValue | Should -BeFalse
     }
 
     It 'prefers a per-endpoint override over the default' {
-        $fact = $script:fixtureFacts | Where-Object Endpoint -EQ 'GET /widgets'
-        $fact.ContextComponent | Should -Be 'Context_names_get'
-        $fact.SpecSaysMultiValue | Should -BeTrue
+        $f = $script:facts | Where-Object Endpoint -EQ 'GET /widgets'
+        $f.ContextComponent | Should -Be 'Context_names_get'
+        $f.ComponentSaysMultiValue | Should -BeTrue
     }
 
     It 'honours an override key present with a null value as "no component"' {
-        $fact = $script:fixtureFacts | Where-Object Endpoint -EQ 'GET /inline-context'
-        $fact.ContextComponent | Should -BeNullOrEmpty
-        $fact.SpecSaysMultiValue | Should -BeNullOrEmpty
+        $f = $script:facts | Where-Object Endpoint -EQ 'GET /inline-context'
+        $f.ContextComponent | Should -BeNullOrEmpty
+        $f.ComponentSaysMultiValue | Should -BeNullOrEmpty
     }
 
     It 'splits the endpoint key on the first space only' {
-        $fact = $script:fixtureFacts | Where-Object Endpoint -EQ 'PATCH /cogs'
-        $fact.Method | Should -Be 'PATCH'
-        $fact.Path | Should -Be '/cogs'
+        $f = $script:facts | Where-Object Endpoint -EQ 'PATCH /mirror'
+        $f.Method | Should -Be 'PATCH'
+        $f.Path | Should -Be '/mirror'
     }
 
-    It 'records the module rule verdict from the declared predicate' {
-        ($script:fixtureFacts | Where-Object Endpoint -EQ 'GET /widgets').RuleSaysMultiValue | Should -BeTrue
-        ($script:fixtureFacts | Where-Object Endpoint -EQ 'DELETE /gadgets').RuleSaysMultiValue | Should -BeFalse
+    It 'records the rule verdict from the declared predicate, not from the verb' {
+        # A GET with a multi-value component but no allow_errors must NOT be capable.
+        ($script:facts | Where-Object Endpoint -EQ 'GET /fleet-scoped').RuleSaysMultiValue | Should -BeFalse
+        ($script:facts | Where-Object Endpoint -EQ 'GET /widgets').RuleSaysMultiValue | Should -BeTrue
+    }
+
+    It 'carries the 207 signal when supplied' {
+        ($script:facts | Where-Object Endpoint -EQ 'GET /widgets').DeclaresHttp207 | Should -BeTrue
+        ($script:facts | Where-Object Endpoint -EQ 'GET /capable-no-207').DeclaresHttp207 | Should -BeFalse
+    }
+
+    It 'carries 207 as $null (UNKNOWN) when not supplied, never as false' {
+        # Unknown must stay distinguishable from "declares no 207" -- scoring unknown as
+        # false would invent disagreements that the data does not support.
+        foreach ($f in $script:factsNo207) { $f.DeclaresHttp207 | Should -BeNullOrEmpty }
     }
 
     It 'emits a deterministically sorted collection' {
-        $sorted = @($script:fixtureFacts.Endpoint | Sort-Object)
-        @($script:fixtureFacts.Endpoint) | Should -Be $sorted
+        @($script:facts.Endpoint) | Should -Be @($script:facts.Endpoint | Sort-Object)
     }
 }
 
-Describe 'Get-PfbContextVerbRuleDisagreement' {
+Describe 'Get-PfbContextSignalDisagreement' {
     BeforeAll {
-        $script:fixtureDisagreements = @(Get-PfbContextVerbRuleDisagreement -Fact $script:fixtureFacts)
+        $script:findings = @(Get-PfbContextSignalDisagreement -Fact $script:facts)
+        $script:findingsNo207 = @(Get-PfbContextSignalDisagreement -Fact $script:factsNo207)
     }
 
-    It 'reports exactly the endpoint where the rule and the component identity differ' {
-        $script:fixtureDisagreements.Count | Should -Be 1
-        $script:fixtureDisagreements[0].Endpoint | Should -Be 'DELETE /gadgets'
+    It 'reports nothing for an endpoint whose signals all agree' {
+        $script:findings.Endpoint | Should -Not -Contain 'GET /widgets'
+        $script:findings.Endpoint | Should -Not -Contain 'DELETE /widgets'
     }
 
-    It 'carries the referenced component, both verdicts, and the allow_errors signal' {
-        $d = $script:fixtureDisagreements[0]
-        $d.ContextComponent | Should -Be 'Context_names_get'
-        $d.RuleSaysMultiValue | Should -BeFalse
-        $d.SpecSaysMultiValue | Should -BeTrue
-        $d.DeclaresAllowErrors | Should -BeFalse
+    It 'reports a multi-value component that declares no allow_errors' {
+        $f = $script:findings | Where-Object Endpoint -EQ 'GET /fleet-scoped'
+        $f | Should -Not -BeNullOrEmpty
+        $f.Shape | Should -Be 'component-says-multi-value-but-no-allow-errors'
     }
 
-    It 'words the summary neutrally, without prejudging which side is wrong' {
-        $summary = $script:fixtureDisagreements[0].Summary
-        $summary | Should -BeLike '*module rule says*'
-        $summary | Should -BeLike '*spec references*'
-        # A future disagreement may be a real API change rather than a spec defect.
+    It 'reports the size-1-component-declaring-allow_errors mirror' {
+        ($script:findings | Where-Object Endpoint -EQ 'PATCH /mirror').Shape |
+            Should -Be 'size-1-component-but-declares-allow-errors'
+    }
+
+    It 'reports an endpoint declaring a 207 while nothing else says it fans out' {
+        ($script:findings | Where-Object Endpoint -EQ 'GET /size1-with-207').Shape |
+            Should -Be 'size-1-but-declares-207'
+    }
+
+    It 'covers every disagreement shape, so none goes untested' {
+        @($script:findings.Shape | Sort-Object -Unique) | Should -Be @(
+            'component-says-multi-value-but-no-allow-errors'
+            'rule-says-capable-but-declares-no-207'
+            'size-1-but-declares-207'
+            'size-1-component-but-declares-allow-errors'
+        )
+    }
+
+    It 'reports a rule-capable endpoint that declares no 207' {
+        # THE CASE THE OLD TWO-SIGNAL DESIGN COULD NOT SEE: rule and component agree,
+        # and the remaining signal dissents.
+        $f = $script:findings | Where-Object Endpoint -EQ 'GET /capable-no-207'
+        $f | Should -Not -BeNullOrEmpty
+        $f.Shape | Should -Be 'rule-says-capable-but-declares-no-207'
+        $f.RuleSaysMultiValue | Should -BeTrue
+        $f.ComponentSaysMultiValue | Should -BeTrue
+    }
+
+    It 'excludes the 207 signal from comparison when it is unknown' {
+        # Without 207 data, GET /capable-no-207's remaining signals are unanimous, so it
+        # must not be reported -- an unknown signal narrows the check, never invents a
+        # finding.
+        $script:findingsNo207.Endpoint | Should -Not -Contain 'GET /capable-no-207'
+        $script:findingsNo207.Endpoint | Should -Contain 'GET /fleet-scoped'
+    }
+
+    It 'records which signals fell on each side' {
+        $f = $script:findings | Where-Object Endpoint -EQ 'GET /fleet-scoped'
+        @($f.MultiValueSignals) | Should -Be @('component')
+        @($f.SizeOneSignals) | Should -Be @('allow_errors', 'http207')
+    }
+
+    It 'words the summary neutrally, without prejudging which signal is wrong' {
+        $summary = ($script:findings | Where-Object Endpoint -EQ 'GET /fleet-scoped').Summary
+        $summary | Should -BeLike '*signals split*'
         $summary | Should -Not -BeLike '*bug*'
-        $summary | Should -Not -BeLike '*wrong*'
+        $summary | Should -Not -BeLike '*defect*'
     }
 
-    It 'excludes endpoints whose component could not be resolved rather than scoring them size-1' {
-        # GET /inline-context has no component. Scored as size-1 it would look like a
-        # disagreement against the GET rule; it must simply not be compared.
-        $script:fixtureDisagreements.Endpoint | Should -Not -Contain 'GET /inline-context'
+    It 'excludes endpoints whose component could not be resolved' {
+        $script:findings.Endpoint | Should -Not -Contain 'GET /inline-context'
     }
 
-    It 'returns an empty collection when every endpoint agrees' {
-        $agreeing = @($script:fixtureFacts | Where-Object { $_.Endpoint -ne 'DELETE /gadgets' })
-        @(Get-PfbContextVerbRuleDisagreement -Fact $agreeing).Count | Should -Be 0
+    It 'emits a deterministically sorted collection' {
+        @($script:findings.Endpoint) | Should -Be @($script:findings.Endpoint | Sort-Object)
     }
 }
 
-Describe 'Get-PfbContextAllowErrorsAnomaly' {
-    BeforeAll {
-        $script:fixtureAnomalies = Get-PfbContextAllowErrorsAnomaly -Fact $script:fixtureFacts
+Describe 'Get-PfbContextSizeOneWithAllowErrors' {
+    It 'returns the mirror case only' {
+        @(Get-PfbContextSizeOneWithAllowErrors -Fact $script:facts).Endpoint | Should -Be @('PATCH /mirror')
     }
 
-    It 'reports agreed multi-value endpoints that do not declare allow_errors' {
-        @($script:fixtureAnomalies.MultiValueWithoutAllowErrors).Endpoint | Should -Be @('GET /sprockets')
-    }
-
-    It 'reports the mirror image: agreed size-1 endpoints that do declare allow_errors' {
-        @($script:fixtureAnomalies.SingleValueWithAllowErrors).Endpoint | Should -Be @('PATCH /cogs')
-    }
-
-    It 'never double-counts a cardinality disagreement as an allow_errors anomaly' {
-        # DELETE /gadgets is spec-multi-value AND lacks allow_errors, so a naive
-        # spec-only filter would list it here too -- inflating one defect into two
-        # findings. It belongs to the disagreement category alone.
-        @($script:fixtureAnomalies.MultiValueWithoutAllowErrors).Endpoint | Should -Not -Contain 'DELETE /gadgets'
-    }
-
-    It 'emits deterministically sorted collections' {
-        $multi = @($script:fixtureAnomalies.MultiValueWithoutAllowErrors.Endpoint)
-        $multi | Should -Be @($multi | Sort-Object)
+    It 'is a strict subset of the signal disagreements, never an extra finding' {
+        $mirror = @(Get-PfbContextSizeOneWithAllowErrors -Fact $script:facts).Endpoint
+        $all = @(Get-PfbContextSignalDisagreement -Fact $script:facts).Endpoint
+        foreach ($m in $mirror) { $all | Should -Contain $m }
     }
 }
 
 Describe 'Get-PfbContextUnresolvedComponent' {
     It 'surfaces endpoints whose context_names has no resolvable component' {
-        @(Get-PfbContextUnresolvedComponent -Fact $script:fixtureFacts).Endpoint |
-            Should -Be @('GET /inline-context')
+        @(Get-PfbContextUnresolvedComponent -Fact $script:facts).Endpoint | Should -Be @('GET /inline-context')
     }
 }
 
-Describe 'Non-vacuity against real specs' {
+Describe 'Get-PfbContextHttp207Endpoint' {
+    It 'finds a declared 207 and normalizes the endpoint key' {
+        $spec = [PSCustomObject]@{
+            paths = [PSCustomObject]@{
+                '/api/2.26/widgets' = [PSCustomObject]@{
+                    get    = [PSCustomObject]@{ responses = [PSCustomObject]@{ '200' = @{}; '207' = @{} } }
+                    delete = [PSCustomObject]@{ responses = [PSCustomObject]@{ '200' = @{} } }
+                }
+            }
+        }
+        @(Get-PfbContextHttp207Endpoint -Spec $spec) | Should -Be @('GET /widgets')
+    }
+
+    It 'returns an empty collection for a spec with no paths' {
+        @(Get-PfbContextHttp207Endpoint -Spec ([PSCustomObject]@{})).Count | Should -Be 0
+    }
+}
+
+Describe 'Empty-collection contracts' {
+    # PowerShell collapses a bare empty array returned from a function to $null, so these
+    # functions follow the repo-wide tools/lib convention: they `return @(...)` and CALL
+    # SITES wrap in @(). These tests pin the caller-side contract -- an empty result must
+    # be a zero-length collection once wrapped, never a one-element collection containing
+    # something. (An earlier attempt to make the functions themselves never return $null,
+    # via `return ,$array`, is exactly what breaks that: @() does not flatten a nested
+    # array, so every wrapped call site would have silently seen Count 1.)
     BeforeAll {
-        # tools/specs/ is gitignored, so these are skipped wherever the cache is absent
-        # (a fresh clone, or CI without the spec-fetch step) rather than failing.
+        $script:emptyMap = [PSCustomObject]@{
+            parameterComponentDefaults = [PSCustomObject]@{ context_names = 'Context_names' }
+            endpoints                  = [PSCustomObject]@{
+                'GET /nothing' = [PSCustomObject]@{ parameters = [PSCustomObject]@{ ids = '2.0' } }
+            }
+        }
+        $script:noFacts = Get-PfbContextParameterFact -CapabilityMap $script:emptyMap
+        $script:agreeingFacts = Get-PfbContextParameterFact -CapabilityMap ([PSCustomObject]@{
+                parameterComponentDefaults = [PSCustomObject]@{ context_names = 'Context_names' }
+                endpoints                  = [PSCustomObject]@{
+                    'DELETE /q' = [PSCustomObject]@{ parameters = [PSCustomObject]@{ context_names = '2.26' } }
+                }
+            })
+    }
+
+    It 'Get-PfbContextParameterFact yields zero facts when nothing matches' {
+        @($script:noFacts).Count | Should -Be 0
+    }
+
+    It 'Get-PfbContextParameterFact yields zero facts for a map with no endpoints' {
+        @(Get-PfbContextParameterFact -CapabilityMap ([PSCustomObject]@{ endpoints = $null })).Count |
+            Should -Be 0
+    }
+
+    It 'Get-PfbContextHttp207Endpoint yields zero endpoints for a spec with no paths' {
+        @(Get-PfbContextHttp207Endpoint -Spec ([PSCustomObject]@{})).Count | Should -Be 0
+    }
+
+    It '<Function> yields zero findings when there is nothing to report' -ForEach @(
+        @{ Function = 'Get-PfbContextSignalDisagreement' }
+        @{ Function = 'Get-PfbContextSizeOneWithAllowErrors' }
+        @{ Function = 'Get-PfbContextUnresolvedComponent' }
+    ) {
+        # Count 1 here would mean a nested array leaked through the @() wrap.
+        @(& $Function -Fact $script:agreeingFacts).Count | Should -Be 0
+    }
+
+    It 'treats an EMPTY 207 set as "checked, none declare it" rather than "unknown"' {
+        # The distinction is load-bearing: scoring "none" as "unknown" would silently drop
+        # the 207 signal from comparison for a spec that legitimately declares no 207.
+        $withEmpty = Get-PfbContextParameterFact -CapabilityMap ([PSCustomObject]@{
+                parameterComponentDefaults = [PSCustomObject]@{ context_names = 'Context_names' }
+                endpoints                  = [PSCustomObject]@{
+                    'GET /w' = [PSCustomObject]@{ parameters = [PSCustomObject]@{ context_names = '2.26' } }
+                }
+            }) -Http207Endpoint ([string[]]@())
+        # Asserted as an explicit null check, not -BeNullOrEmpty: $false IS "empty" to that
+        # operator, so it could not tell the two states apart here.
+        ($null -eq $withEmpty[0].DeclaresHttp207) | Should -BeFalse -Because 'the spec was checked, so this is false rather than unknown'
+        $withEmpty[0].DeclaresHttp207 | Should -BeFalse
+    }
+
+    It 'keeps the 207 lookup case-insensitive (the HashSet comparer must survive assignment)' {
+        $f = Get-PfbContextParameterFact -CapabilityMap ([PSCustomObject]@{
+                parameterComponentDefaults = [PSCustomObject]@{ context_names = 'Context_names' }
+                endpoints                  = [PSCustomObject]@{
+                    'GET /w' = [PSCustomObject]@{ parameters = [PSCustomObject]@{ context_names = '2.26' } }
+                }
+            }) -Http207Endpoint @('get /W')
+        $f[0].DeclaresHttp207 | Should -BeTrue
+    }
+}
+
+Describe 'Against real specs' {
+    BeforeAll {
+        # tools/specs/ is gitignored, so these skip wherever the cache is absent (a fresh
+        # clone, or CI without the spec-fetch step) rather than failing.
         $script:spec227Path = Join-Path $script:repoRoot 'tools/specs/fb2.27.json'
         $script:spec228Path = Join-Path $script:repoRoot 'tools/specs/fb2.28.json'
-        $script:haveSpecs = (Test-Path $script:spec227Path) -and (Test-Path $script:spec228Path)
     }
 
-    It 'finds exactly one disagreement in fb2.27: DELETE /management-access-policies' -Skip:(-not (Test-Path (Join-Path (Split-Path -Parent $PSScriptRoot) 'tools/specs/fb2.27.json'))) {
-        # This is the proof the check is not vacuous. fb2.27 contains a KNOWN, confirmed
-        # upstream spec defect -- a multi-value component on a DELETE -- and the check
-        # must rediscover it mechanically, with no prior knowledge encoded anywhere.
-        $spec = Get-Content -Path $script:spec227Path -Raw | ConvertFrom-Json
-        $facts = @(Get-PfbContextParameterFact -SpecCapabilities @(Get-PfbSpecCapabilities -Spec $spec))
-        $disagreements = @(Get-PfbContextVerbRuleDisagreement -Fact $facts)
+    It 'flags all four fleet-scoped GETs at fb<Version>, where the wire says size-1' -ForEach @(
+        @{ Version = '2.27' }
+        @{ Version = '2.28' }
+    ) -Skip:(-not (Test-Path (Join-Path (Split-Path -Parent $PSScriptRoot) 'tools/specs/fb2.28.json'))) {
+        # The acceptance criterion for the restructure. Under the withdrawn verb rule these
+        # four were invisible: rule said multi-value (GET), component said multi-value, so
+        # the old check reported nothing while all four reject a two-name context with
+        # 400 code 15. They must appear at BOTH versions -- the upstream fix is still only
+        # in review, so a sudden disappearance here means the fix landed, not that the
+        # check improved.
+        $specPath = Join-Path $script:repoRoot "tools/specs/fb$Version.json"
+        $spec = Get-Content -Path $specPath -Raw | ConvertFrom-Json
+        $facts = @(Get-PfbContextParameterFact `
+                -SpecCapabilities @(Get-PfbSpecCapabilities -Spec $spec) `
+                -Http207Endpoint @(Get-PfbContextHttp207Endpoint -Spec $spec))
+        $findings = @(Get-PfbContextSignalDisagreement -Fact $facts)
 
-        $disagreements.Count | Should -Be 1
-        $disagreements[0].Endpoint | Should -Be 'DELETE /management-access-policies'
-        $disagreements[0].ContextComponent | Should -Be 'Context_names_get'
-        $disagreements[0].DeclaresAllowErrors | Should -BeFalse
+        foreach ($endpoint in $script:defectiveFleetScopedGets) {
+            $f = $findings | Where-Object Endpoint -EQ $endpoint
+            $f | Should -Not -BeNullOrEmpty -Because "$endpoint is a known size-1 fleet-scoped endpoint referencing the multi-value component"
+            $f.Shape | Should -Be 'component-says-multi-value-but-no-allow-errors'
+        }
     }
 
-    It 'finds no disagreement in fb2.28, where the defect was fixed upstream' -Skip:(-not (Test-Path (Join-Path (Split-Path -Parent $PSScriptRoot) 'tools/specs/fb2.28.json'))) {
-        # Pins the observed upstream fix: the same endpoint's reference changed to
-        # Context_names. Together with the fb2.27 case above, this proves the check
-        # tracks the spec rather than reporting a constant.
-        $spec = Get-Content -Path $script:spec228Path -Raw | ConvertFrom-Json
+    It 'holds the module rule to size-1 for all four fleet-scoped GETs at fb<Version>' -ForEach @(
+        @{ Version = '2.27' }
+        @{ Version = '2.28' }
+    ) -Skip:(-not (Test-Path (Join-Path (Split-Path -Parent $PSScriptRoot) 'tools/specs/fb2.28.json'))) {
+        $specPath = Join-Path $script:repoRoot "tools/specs/fb$Version.json"
+        $spec = Get-Content -Path $specPath -Raw | ConvertFrom-Json
         $facts = @(Get-PfbContextParameterFact -SpecCapabilities @(Get-PfbSpecCapabilities -Spec $spec))
 
-        @(Get-PfbContextVerbRuleDisagreement -Fact $facts).Count | Should -Be 0
-        ($facts | Where-Object Endpoint -EQ 'DELETE /management-access-policies').ContextComponent |
-            Should -Be 'Context_names'
+        foreach ($endpoint in $script:defectiveFleetScopedGets) {
+            ($facts | Where-Object Endpoint -EQ $endpoint).RuleSaysMultiValue |
+                Should -BeFalse -Because "$endpoint rejects a two-name context on the wire (400 code 15)"
+        }
     }
 
-    It 'keeps the four multi-value GETs without allow_errors separate in fb2.27' -Skip:(-not (Test-Path (Join-Path (Split-Path -Parent $PSScriptRoot) 'tools/specs/fb2.27.json'))) {
-        $spec = Get-Content -Path $script:spec227Path -Raw | ConvertFrom-Json
-        $facts = @(Get-PfbContextParameterFact -SpecCapabilities @(Get-PfbSpecCapabilities -Spec $spec))
-        $anomalies = Get-PfbContextAllowErrorsAnomaly -Fact $facts
+    It 'tracks the 2.28 correction of DELETE /management-access-policies' -Skip:(-not (Test-Path (Join-Path (Split-Path -Parent $PSScriptRoot) 'tools/specs/fb2.28.json'))) {
+        # Pins a real upstream change: the component flipped to size-1 in 2.28, so the
+        # endpoint stops being a component-vs-allow_errors disagreement. Together with the
+        # fleet-scoped assertions above this shows the check tracks the spec rather than
+        # reporting a constant.
+        foreach ($case in @(
+                @{ Path = $script:spec227Path; Expected = 'Context_names_get'; ShouldDisagree = $true }
+                @{ Path = $script:spec228Path; Expected = 'Context_names'; ShouldDisagree = $false }
+            )) {
+            if (-not (Test-Path $case.Path)) { continue }
+            $spec = Get-Content -Path $case.Path -Raw | ConvertFrom-Json
+            $facts = @(Get-PfbContextParameterFact `
+                    -SpecCapabilities @(Get-PfbSpecCapabilities -Spec $spec) `
+                    -Http207Endpoint @(Get-PfbContextHttp207Endpoint -Spec $spec))
+            $target = $facts | Where-Object Endpoint -EQ 'DELETE /management-access-policies'
+            $target.ContextComponent | Should -Be $case.Expected
+            $target.RuleSaysMultiValue | Should -BeFalse
 
-        @($anomalies.MultiValueWithoutAllowErrors).Endpoint | Should -Be @(
-            'GET /presets/workload'
-            'GET /topology-groups'
-            'GET /topology-groups/arrays'
-            'GET /topology-groups/members'
-        )
-        # The fb2.27 spec defect is a cardinality disagreement, not an allow_errors
-        # anomaly, even though it also lacks allow_errors.
-        @($anomalies.MultiValueWithoutAllowErrors).Endpoint |
-            Should -Not -Contain 'DELETE /management-access-policies'
-        @($anomalies.SingleValueWithAllowErrors).Endpoint | Should -Be @('PATCH /directory-services/test')
+            $findings = @(Get-PfbContextSignalDisagreement -Fact $facts)
+            $hit = @($findings | Where-Object Endpoint -EQ 'DELETE /management-access-policies').Count -gt 0
+            $hit | Should -Be $case.ShouldDisagree
+        }
+    }
+
+    It 'finds no unresolved context_names components in any spec on disk' -Skip:(-not (Test-Path (Join-Path (Split-Path -Parent $PSScriptRoot) 'tools/specs/fb2.28.json'))) {
+        # context_names does not exist before 2.17, so versions without it contribute zero
+        # facts rather than zero-of-many -- both are fine here.
+        foreach ($specFile in (Get-ChildItem -Path (Join-Path $script:repoRoot 'tools/specs') -Filter 'fb*.json')) {
+            $spec = Get-Content -Path $specFile.FullName -Raw | ConvertFrom-Json
+            $facts = @(Get-PfbContextParameterFact -SpecCapabilities @(Get-PfbSpecCapabilities -Spec $spec))
+            @(Get-PfbContextUnresolvedComponent -Fact $facts).Count |
+                Should -Be 0 -Because "$($specFile.BaseName) should declare no inline context_names"
+        }
     }
 }
 
 Describe 'Committed capability map' {
-    It 'resolves every context_names component (none unresolved)' {
-        $mapPath = Join-Path $script:repoRoot 'Data/PfbCapabilityMap.json'
-        $map = Get-Content -Path $mapPath -Raw | ConvertFrom-Json
-        $facts = @(Get-PfbContextParameterFact -CapabilityMap $map)
+    BeforeAll {
+        $script:mapFacts = @(Get-PfbContextParameterFact -CapabilityMap (
+                Get-Content -Path (Join-Path $script:repoRoot 'Data/PfbCapabilityMap.json') -Raw | ConvertFrom-Json))
+    }
 
-        $facts.Count | Should -BeGreaterThan 0
-        @(Get-PfbContextUnresolvedComponent -Fact $facts).Count | Should -Be 0
+    It 'resolves every context_names component (none unresolved)' {
+        $script:mapFacts.Count | Should -BeGreaterThan 0
+        @(Get-PfbContextUnresolvedComponent -Fact $script:mapFacts).Count | Should -Be 0
+    }
+
+    It 'holds the four fleet-scoped GETs to size-1' {
+        # Asserted against the map rather than a spec because this is the source the
+        # runtime injection path will read. No totals asserted -- the map is regenerated
+        # whenever specs are refreshed.
+        foreach ($endpoint in $script:defectiveFleetScopedGets) {
+            $f = $script:mapFacts | Where-Object Endpoint -EQ $endpoint
+            $f | Should -Not -BeNullOrEmpty -Because "$endpoint should be present in the capability map"
+            $f.ComponentSaysMultiValue | Should -BeTrue -Because 'the spec defect is still open upstream'
+            $f.DeclaresAllowErrors | Should -BeFalse
+            $f.RuleSaysMultiValue | Should -BeFalse
+        }
     }
 }

--- a/tools/Build-PfbApiDriftReport.ps1
+++ b/tools/Build-PfbApiDriftReport.ps1
@@ -539,39 +539,55 @@ $validateSetDrift = @(Get-PfbValidateSetDrift -CmdletInventory $inventory -Histo
 $newValidateSetCandidates = @($fieldCmdletMap.entries | Where-Object { $_.status -eq 'matched' } |
     ForEach-Object { [ordered]@{ cmdlet = $_.cmdlet; parameter = $_.parameter; wireName = $_.wireName; specValues = $_.specValues; recommendation = $_.recommendation } })
 
-# --- Category 5: spec-vs-module assumption (Fusion context_names verb rule) ---
+# --- Category 5: spec-vs-module assumption (Fusion context_names cardinality rule) ---
 # Categorically different from categories 1-4. Those ask "does the module cover what the
 # API offers?"; this one asks "is an assumption baked into the module still true?". The
 # module's cardinality rule is EXECUTED from its single declared home
 # (Private/Test-PfbContextMultiValueCapable.ps1, dot-sourced by PfbContextRuleTools.ps1),
 # never re-derived here -- a check that re-implements its own rule verifies nothing.
 #
-# Sourced from the capability map, whose component data is last-seen-wins across
-# analysedVersions, i.e. it describes $newestAnalysedVersion's wire shape. Stated
-# explicitly in the Markdown section below, because this category's headline number
-# genuinely changes between REST versions (the one historical disagreement,
-# DELETE /management-access-policies, was present in fb2.26/fb2.27 and fixed upstream in
-# fb2.28) and an unlabelled count would be actively misleading.
-$contextFacts = @(Get-PfbContextParameterFact -CapabilityMap $capabilityMap)
-$contextRuleDisagreements = @(Get-PfbContextVerbRuleDisagreement -Fact $contextFacts |
+# The parameter signals come from the capability map, whose component data is
+# last-seen-wins across analysedVersions, i.e. it describes $newestAnalysedVersion's wire
+# shape. The HTTP 207 signal CANNOT come from the map -- it records the request surface
+# only, with no response data at all -- so it is read from that same version's spec, keeping
+# both halves on one version. When no spec is available the 207 signal is omitted entirely
+# rather than defaulted: Get-PfbContextParameterFact carries an unknown 207 as $null and
+# excludes it from comparison, so a missing spec narrows what this category can see but
+# never makes it report something false.
+# Plain if-statements with direct assignment, NOT `$x = if (...) { @() }`: an empty array
+# emitted as the value of a scriptblock collapses to $null, which here would silently
+# convert "checked the spec, no endpoint declares 207" into "207 was never checked", and
+# would hand a null $contextFacts to functions that require a collection.
+$context207Endpoints = $null
+if ($newestSpec) {
+    $context207Endpoints = [string[]]@(Get-PfbContextHttp207Endpoint -Spec $newestSpec)
+}
+$contextFacts = @()
+if ($null -ne $context207Endpoints) {
+    $contextFacts = @(Get-PfbContextParameterFact -CapabilityMap $capabilityMap -Http207Endpoint $context207Endpoints)
+}
+else {
+    $contextFacts = @(Get-PfbContextParameterFact -CapabilityMap $capabilityMap)
+}
+$contextSignalDisagreements = @(Get-PfbContextSignalDisagreement -Fact $contextFacts |
     ForEach-Object {
         [ordered]@{
-            endpoint            = $_.Endpoint
-            method              = $_.Method
-            contextComponent    = $_.ContextComponent
-            ruleSaysMultiValue  = $_.RuleSaysMultiValue
-            specSaysMultiValue  = $_.SpecSaysMultiValue
-            declaresAllowErrors = $_.DeclaresAllowErrors
-            summary             = $_.Summary
+            endpoint                = $_.Endpoint
+            method                  = $_.Method
+            contextComponent        = $_.ContextComponent
+            shape                   = $_.Shape
+            ruleSaysMultiValue      = $_.RuleSaysMultiValue
+            componentSaysMultiValue = $_.ComponentSaysMultiValue
+            declaresAllowErrors     = $_.DeclaresAllowErrors
+            declaresHttp207         = $_.DeclaresHttp207
+            multiValueSignals       = @($_.MultiValueSignals)
+            sizeOneSignals          = @($_.SizeOneSignals)
+            summary                 = $_.Summary
         }
     })
-$contextAllowErrorsAnomalyResult = Get-PfbContextAllowErrorsAnomaly -Fact $contextFacts
-$contextAllowErrorsAnomalies = [ordered]@{
-    multiValueWithoutAllowErrors = @($contextAllowErrorsAnomalyResult.MultiValueWithoutAllowErrors |
-        ForEach-Object { [ordered]@{ endpoint = $_.Endpoint; method = $_.Method; contextComponent = $_.ContextComponent } })
-    singleValueWithAllowErrors   = @($contextAllowErrorsAnomalyResult.SingleValueWithAllowErrors |
-        ForEach-Object { [ordered]@{ endpoint = $_.Endpoint; method = $_.Method; contextComponent = $_.ContextComponent } })
-}
+# A NAMED SUBSET of the above, never an additional category -- see the function's help.
+$contextSizeOneWithAllowErrors = @(Get-PfbContextSizeOneWithAllowErrors -Fact $contextFacts |
+    ForEach-Object { [ordered]@{ endpoint = $_.Endpoint; method = $_.Method; contextComponent = $_.ContextComponent } })
 $contextUnresolvedComponents = @(Get-PfbContextUnresolvedComponent -Fact $contextFacts |
     ForEach-Object { [ordered]@{ endpoint = $_.Endpoint; method = $_.Method } })
 
@@ -591,14 +607,19 @@ $manifest = [ordered]@{
     conventionStrength        = $conventionStrength
     validateSetDrift          = $validateSetDrift
     newValidateSetCandidates  = $newValidateSetCandidates
-    contextVerbRule           = [ordered]@{
+    contextCardinality        = [ordered]@{
         # The version this category's numbers describe -- never omit it, see the block
         # where these are computed.
-        componentSourceVersion       = $newestAnalysedVersion
-        endpointsWithContextNames    = $contextFacts.Count
-        disagreements                = $contextRuleDisagreements
-        allowErrorsAnomalies         = $contextAllowErrorsAnomalies
-        unresolvedComponents         = $contextUnresolvedComponents
+        componentSourceVersion    = $newestAnalysedVersion
+        # $null (not $false) when no spec was available to read responses from, so a
+        # consumer can tell "no endpoint declares 207" from "207 was never checked".
+        http207SignalAvailable    = ($null -ne $context207Endpoints)
+        endpointsWithContextNames = $contextFacts.Count
+        multiContextCapable       = @($contextFacts | Where-Object { $_.RuleSaysMultiValue }).Count
+        signalDisagreements       = $contextSignalDisagreements
+        # Named subset of signalDisagreements, NOT an additional finding.
+        sizeOneWithAllowErrors    = $contextSizeOneWithAllowErrors
+        unresolvedComponents      = $contextUnresolvedComponents
     }
 }
 
@@ -654,7 +675,7 @@ $mdLines.Add("- Partial-confidence endpoints (see ``How to read this report`` ab
 $mdLines.Add("- Systemic gaps (distinct field names collapsed across high-confidence endpoints, detailed below): $($systemicGaps.Count)")
 $mdLines.Add("- ValidateSet drift: $($validateSetDrift.Count)")
 $mdLines.Add("- New ValidateSet candidates: $($newValidateSetCandidates.Count)")
-$mdLines.Add("- Context verb-rule disagreements (fb$newestAnalysedVersion): $($contextRuleDisagreements.Count)")
+$mdLines.Add("- Context cardinality signal disagreements (fb$newestAnalysedVersion): $($contextSignalDisagreements.Count)")
 
 if ($systemicGaps.Count -gt 0) {
     $mdLines.Add(''); $mdLines.Add('## Systemic gaps'); $mdLines.Add('')
@@ -737,64 +758,82 @@ if ($newValidateSetCandidates.Count -gt 0) {
 }
 
 # Emitted UNCONDITIONALLY, unlike every section above -- for this category "nothing to
-# report" is itself the finding (the baked-in assumption still holds), and a section that
-# disappears when clean is indistinguishable from a section that never ran.
-$mdLines.Add(''); $mdLines.Add('## Spec-vs-module assumptions: `context_names` verb rule'); $mdLines.Add('')
+# report" is itself a finding, and a section that disappears when clean is
+# indistinguishable from a section that never ran.
+$mdLines.Add(''); $mdLines.Add('## Spec-vs-module assumptions: `context_names` cardinality'); $mdLines.Add('')
 $mdLines.Add('Every category above asks *"does the module cover what the API offers?"*. This one asks a different question: *"is an assumption baked into the module still true?"*')
 $mdLines.Add('')
-$mdLines.Add('The module hardcodes a cardinality rule -- **`GET` is multi-context-capable; `POST`/`PUT`/`PATCH`/`DELETE` are single-context-only** -- declared in exactly one place, `Private/Test-PfbContextMultiValueCapable.ps1`, which this check *executes* rather than re-derives. The spec expresses the same property only through which component `context_names` `$ref`s: `Context_names_get` (multi-value) versus `Context_names` (size-1). Those components have identical schemas and there is no `maxItems` -- the size-1 restriction lives only in free-text `description` -- so the component name is the sole mechanical signal available to check the assumption against.')
+$mdLines.Add('The module''s cardinality rule -- **an endpoint is multi-context-capable if and only if its `context_names` resolves to component `Context_names_get` AND the endpoint declares `allow_errors`** -- is declared in exactly one place, `Private/Test-PfbContextMultiValueCapable.ps1`, which this check *executes* rather than re-derives. The HTTP verb is not the rule; it survives only as a fallback for an endpoint absent from the capability map. See section 8 of `docs/design/fusion-context-injection.md`.')
 $mdLines.Add('')
-$mdLines.Add("Measured against **fb$newestAnalysedVersion** (the newest analysed version; the capability map's component data is last-seen-wins, so it describes that version's wire shape). $($contextFacts.Count) endpoints declare ``context_names``.")
+$mdLines.Add('This is a **cross-signal** check, not a rule-versus-spec one. The earlier two-signal shape was structurally unable to see the defect that actually exists: four fleet-scoped GETs reference the multi-value component *and* are size-1 on the wire, so the rule and the component agreed while both were wrong. Any endpoint whose available signals do not all agree is reported below, including the case where the component agrees with the rule but the remaining signals dissent.')
 $mdLines.Add('')
-$mdLines.Add('**A disagreement is not automatically a spec bug.** The case worth catching is a genuine multi-context mutation endpoint, where the *module* would be the wrong side. A human decides which side is wrong, each time.')
+$mdLines.Add("Measured against **fb$newestAnalysedVersion** (the newest analysed version; the capability map's component data is last-seen-wins, so it describes that version's wire shape). $($contextFacts.Count) endpoints declare ``context_names``, of which **$(@($contextFacts | Where-Object { $_.RuleSaysMultiValue }).Count)** satisfy the rule.")
 $mdLines.Add('')
-if ($contextRuleDisagreements.Count -eq 0) {
-    $mdLines.Add("**No disagreements.** The module rule and the spec's component identity agree on all $($contextFacts.Count) endpoints in fb$newestAnalysedVersion.")
-    $mdLines.Add('')
-    $mdLines.Add('For provenance: fb2.26 and fb2.27 each carried exactly one disagreement -- `DELETE /management-access-policies` referencing `Context_names_get` -- investigated and confirmed an upstream documentation defect, with no exception ever implemented in the module. REST 2.28 corrected that reference to `Context_names`. The module rule was right and was left untouched.')
+if ($null -ne $context207Endpoints) {
+    $mdLines.Add("The HTTP 207 signal is read from ``tools/specs/fb$newestAnalysedVersion.json`` -- the capability map records the request surface only and holds no response data, so 207 is a corroborating signal for this report and never a runtime gate.")
 }
 else {
-    $mdLines.Add("**$($contextRuleDisagreements.Count) disagreement(s).**")
+    $mdLines.Add('**The HTTP 207 signal was unavailable** (no spec on disk for the newest analysed version), so it was excluded from comparison rather than assumed absent. Findings below are based on the component and `allow_errors` signals only.')
+}
+$mdLines.Add('')
+$mdLines.Add('**A disagreement is not automatically a spec defect.** The case worth catching is a genuine future multi-context endpoint, where the *module* would be the wrong side. A human decides which signal is wrong, each time.')
+$mdLines.Add('')
+if ($contextSignalDisagreements.Count -eq 0) {
+    $mdLines.Add("**No signal disagreements** across all $($contextFacts.Count) endpoints in fb$newestAnalysedVersion.")
     $mdLines.Add('')
-    $mdLines.Add('| Endpoint | Method | Referenced component | Module rule | Spec | Declares `allow_errors` |'); $mdLines.Add('|---|---|---|---|---|---|')
-    foreach ($d in $contextRuleDisagreements) {
-        $ruleCell = if ($d.ruleSaysMultiValue) { 'multi-value' } else { 'size-1' }
-        $specCell = if ($d.specSaysMultiValue) { 'multi-value' } else { 'size-1' }
-        $aeCell = if ($d.declaresAllowErrors) { 'yes' } else { 'no' }
-        $mdLines.Add("| ``$($d.endpoint)`` | $($d.method) | ``$($d.contextComponent)`` | $ruleCell | $specCell | $aeCell |")
+    $mdLines.Add('Read this as *the available signals agree*, not as *the module is verified correct*. Signals agreeing is exactly the state the four fleet-scoped GETs were in under the previous two-signal check while being wrong on the wire. Only live testing settles behaviour; see Appendix A of the design doc for what has actually been probed.')
+}
+else {
+    $mdLines.Add("**$($contextSignalDisagreements.Count) endpoint(s) with disagreeing signals**, grouped by shape.")
+    $mdLines.Add('')
+    foreach ($shapeGroup in ($contextSignalDisagreements | Group-Object { $_.shape } | Sort-Object Name)) {
+        $mdLines.Add("#### ``$($shapeGroup.Name)`` ($($shapeGroup.Count))")
+        $mdLines.Add('')
+        switch ($shapeGroup.Name) {
+            'component-says-multi-value-but-no-allow-errors' {
+                $mdLines.Add('The component claims fan-out while the endpoint offers no partial-failure story. Strong evidence of a spec defect: this is the shape of the four fleet-scoped GETs confirmed size-1 on the wire, and of `DELETE /management-access-policies` before its 2.28 correction.')
+            }
+            'size-1-component-but-declares-allow-errors' {
+                $mdLines.Add('The mirror case -- a size-1 component on an endpoint that nonetheless declares `allow_errors`. Named again below.')
+            }
+            'rule-says-capable-but-declares-no-207' {
+                $mdLines.Add('Component and `allow_errors` both say fan-out, but no HTTP 207 is declared, so partial failure has no documented response shape. Status genuinely unknown -- which is precisely why 207 is a corroborating signal here and never a runtime gate: treating these as size-1 would block calls that may well work.')
+            }
+            default {
+                $mdLines.Add('An endpoint declaring a partial-failure response while no other signal says it fans out.')
+            }
+        }
+        $mdLines.Add('')
+        $mdLines.Add('| Endpoint | Method | Component | Declares `allow_errors` | Declares 207 | Module rule |'); $mdLines.Add('|---|---|---|---|---|---|')
+        foreach ($d in $shapeGroup.Group) {
+            $aeCell = if ($d.declaresAllowErrors) { 'yes' } else { 'no' }
+            $c207Cell = if ($null -eq $d.declaresHttp207) { '_unknown_' } elseif ($d.declaresHttp207) { 'yes' } else { 'no' }
+            $ruleCell = if ($d.ruleSaysMultiValue) { 'multi-value' } else { 'size-1' }
+            $mdLines.Add("| ``$($d.endpoint)`` | $($d.method) | ``$($d.contextComponent)`` | $aeCell | $c207Cell | $ruleCell |")
+        }
+        $mdLines.Add('')
     }
-    $mdLines.Add('')
-    $mdLines.Add('`allow_errors` is corroborating evidence, not a cardinality signal: a genuinely multi-value endpoint would almost certainly declare it, so a multi-value component *without* it points towards a spec defect rather than a real API change.')
 }
 
-# Deliberately a SEPARATE subsection from the disagreement table above, and scoped to
-# endpoints where rule and spec AGREE on cardinality. These are a different anomaly;
-# conflating the two muddies both, and double-counting one endpoint as both would
-# overstate the problem.
+# A NAMED SUBSET of the findings above, never an additional category -- reporting it as its
+# own finding would double-count one defect as two.
 $mdLines.Add('')
-$mdLines.Add('### `allow_errors` co-occurrence anomalies')
+$mdLines.Add('### Named case: size-1 component declaring `allow_errors`')
 $mdLines.Add('')
-$mdLines.Add('Separate from the cardinality question above, and scoped to endpoints where the rule and the spec already agree -- so nothing listed here is also listed as a disagreement.')
+$mdLines.Add('A **subset** of the findings above (shape `size-1-component-but-declares-allow-errors`), not an additional finding. Called out by name because it is a known, characterized case.')
 $mdLines.Add('')
-$multiWithoutAE = @($contextAllowErrorsAnomalies.multiValueWithoutAllowErrors)
-$singleWithAE = @($contextAllowErrorsAnomalies.singleValueWithAllowErrors)
-$mdLines.Add("**Agreed multi-value, but does not declare ``allow_errors`` ($($multiWithoutAE.Count)):**")
-$mdLines.Add('')
-if ($multiWithoutAE.Count -eq 0) { $mdLines.Add('_None._') }
-else { foreach ($m in $multiWithoutAE) { $mdLines.Add("- ``$($m.endpoint)``") } }
-$mdLines.Add('')
-$mdLines.Add("These matter for context injection: a caller with a multi-value context active would have ``allow_errors`` injected into an endpoint that does not declare it. Whether injection is *gated* on the endpoint declaring the parameter, or sent regardless, is a behavioural decision owned by the context-injection work -- this report states the affected endpoints and does not presume the answer.")
-$mdLines.Add('')
-$mdLines.Add("**Agreed size-1, but declares ``allow_errors`` ($($singleWithAE.Count)) -- the mirror image:**")
-$mdLines.Add('')
-if ($singleWithAE.Count -eq 0) { $mdLines.Add('_None._') }
-else { foreach ($s in $singleWithAE) { $mdLines.Add("- ``$($s.endpoint)``") } }
+if ($contextSizeOneWithAllowErrors.Count -eq 0) { $mdLines.Add('_None._') }
+else {
+    foreach ($s in $contextSizeOneWithAllowErrors) { $mdLines.Add("- ``$($s.endpoint)``") }
+    $mdLines.Add('')
+    $mdLines.Add('Not live-verified: these carry mutating verbs and were not probed during the 2026-08-01 testing (Appendix A, "Not verified").')
+}
 
 if ($contextUnresolvedComponents.Count -gt 0) {
     $mdLines.Add('')
     $mdLines.Add("### Unresolved `context_names` components ($($contextUnresolvedComponents.Count))")
     $mdLines.Add('')
-    $mdLines.Add('These endpoints declare `context_names` with no resolvable `$ref` component, so their cardinality cannot be checked at all. They are **not** scored as size-1 -- doing so would hide a genuine multi-value endpoint behind the module''s hardcoded throw.')
+    $mdLines.Add('These endpoints declare `context_names` with no resolvable `$ref` component, so their cardinality cannot be checked at all. They are **not** scored as size-1 -- doing so would hide a genuine multi-value endpoint behind the module''s size-1 throw.')
     $mdLines.Add('')
     foreach ($u in $contextUnresolvedComponents) { $mdLines.Add("- ``$($u.endpoint)``") }
 }

--- a/tools/Build-PfbApiDriftReport.ps1
+++ b/tools/Build-PfbApiDriftReport.ps1
@@ -120,6 +120,7 @@ $scriptDir = $PSScriptRoot
 . (Join-Path $scriptDir 'lib/PfbValueEnumTools.ps1')
 . (Join-Path $scriptDir 'lib/PfbCmdletParamTools.ps1')
 . (Join-Path $scriptDir 'lib/PfbApiDriftTools.ps1')
+. (Join-Path $scriptDir 'lib/PfbContextRuleTools.ps1')
 
 $repoRoot = Split-Path -Parent $scriptDir
 if (-not $SpecsDirectory)      { $SpecsDirectory = Join-Path $scriptDir 'specs' }
@@ -538,6 +539,42 @@ $validateSetDrift = @(Get-PfbValidateSetDrift -CmdletInventory $inventory -Histo
 $newValidateSetCandidates = @($fieldCmdletMap.entries | Where-Object { $_.status -eq 'matched' } |
     ForEach-Object { [ordered]@{ cmdlet = $_.cmdlet; parameter = $_.parameter; wireName = $_.wireName; specValues = $_.specValues; recommendation = $_.recommendation } })
 
+# --- Category 5: spec-vs-module assumption (Fusion context_names verb rule) ---
+# Categorically different from categories 1-4. Those ask "does the module cover what the
+# API offers?"; this one asks "is an assumption baked into the module still true?". The
+# module's cardinality rule is EXECUTED from its single declared home
+# (Private/Test-PfbContextMultiValueCapable.ps1, dot-sourced by PfbContextRuleTools.ps1),
+# never re-derived here -- a check that re-implements its own rule verifies nothing.
+#
+# Sourced from the capability map, whose component data is last-seen-wins across
+# analysedVersions, i.e. it describes $newestAnalysedVersion's wire shape. Stated
+# explicitly in the Markdown section below, because this category's headline number
+# genuinely changes between REST versions (the one historical disagreement,
+# DELETE /management-access-policies, was present in fb2.26/fb2.27 and fixed upstream in
+# fb2.28) and an unlabelled count would be actively misleading.
+$contextFacts = @(Get-PfbContextParameterFact -CapabilityMap $capabilityMap)
+$contextRuleDisagreements = @(Get-PfbContextVerbRuleDisagreement -Fact $contextFacts |
+    ForEach-Object {
+        [ordered]@{
+            endpoint            = $_.Endpoint
+            method              = $_.Method
+            contextComponent    = $_.ContextComponent
+            ruleSaysMultiValue  = $_.RuleSaysMultiValue
+            specSaysMultiValue  = $_.SpecSaysMultiValue
+            declaresAllowErrors = $_.DeclaresAllowErrors
+            summary             = $_.Summary
+        }
+    })
+$contextAllowErrorsAnomalyResult = Get-PfbContextAllowErrorsAnomaly -Fact $contextFacts
+$contextAllowErrorsAnomalies = [ordered]@{
+    multiValueWithoutAllowErrors = @($contextAllowErrorsAnomalyResult.MultiValueWithoutAllowErrors |
+        ForEach-Object { [ordered]@{ endpoint = $_.Endpoint; method = $_.Method; contextComponent = $_.ContextComponent } })
+    singleValueWithAllowErrors   = @($contextAllowErrorsAnomalyResult.SingleValueWithAllowErrors |
+        ForEach-Object { [ordered]@{ endpoint = $_.Endpoint; method = $_.Method; contextComponent = $_.ContextComponent } })
+}
+$contextUnresolvedComponents = @(Get-PfbContextUnresolvedComponent -Fact $contextFacts |
+    ForEach-Object { [ordered]@{ endpoint = $_.Endpoint; method = $_.Method } })
+
 $manifest = [ordered]@{
     schemaVersion             = 1
     # See the generatedFrom-split block above: two distinctly-named keys instead of one
@@ -554,6 +591,15 @@ $manifest = [ordered]@{
     conventionStrength        = $conventionStrength
     validateSetDrift          = $validateSetDrift
     newValidateSetCandidates  = $newValidateSetCandidates
+    contextVerbRule           = [ordered]@{
+        # The version this category's numbers describe -- never omit it, see the block
+        # where these are computed.
+        componentSourceVersion       = $newestAnalysedVersion
+        endpointsWithContextNames    = $contextFacts.Count
+        disagreements                = $contextRuleDisagreements
+        allowErrorsAnomalies         = $contextAllowErrorsAnomalies
+        unresolvedComponents         = $contextUnresolvedComponents
+    }
 }
 
 $outputDir = Split-Path -Parent $OutputPath
@@ -608,6 +654,7 @@ $mdLines.Add("- Partial-confidence endpoints (see ``How to read this report`` ab
 $mdLines.Add("- Systemic gaps (distinct field names collapsed across high-confidence endpoints, detailed below): $($systemicGaps.Count)")
 $mdLines.Add("- ValidateSet drift: $($validateSetDrift.Count)")
 $mdLines.Add("- New ValidateSet candidates: $($newValidateSetCandidates.Count)")
+$mdLines.Add("- Context verb-rule disagreements (fb$newestAnalysedVersion): $($contextRuleDisagreements.Count)")
 
 if ($systemicGaps.Count -gt 0) {
     $mdLines.Add(''); $mdLines.Add('## Systemic gaps'); $mdLines.Add('')
@@ -688,6 +735,70 @@ if ($newValidateSetCandidates.Count -gt 0) {
     $mdLines.Add('| Cmdlet | Parameter | Spec values |'); $mdLines.Add('|---|---|---|')
     foreach ($c in $newValidateSetCandidates) { $mdLines.Add("| ``$($c.cmdlet)`` | ``-$($c.parameter)`` | $($c.specValues -join ', ') |") }
 }
+
+# Emitted UNCONDITIONALLY, unlike every section above -- for this category "nothing to
+# report" is itself the finding (the baked-in assumption still holds), and a section that
+# disappears when clean is indistinguishable from a section that never ran.
+$mdLines.Add(''); $mdLines.Add('## Spec-vs-module assumptions: `context_names` verb rule'); $mdLines.Add('')
+$mdLines.Add('Every category above asks *"does the module cover what the API offers?"*. This one asks a different question: *"is an assumption baked into the module still true?"*')
+$mdLines.Add('')
+$mdLines.Add('The module hardcodes a cardinality rule -- **`GET` is multi-context-capable; `POST`/`PUT`/`PATCH`/`DELETE` are single-context-only** -- declared in exactly one place, `Private/Test-PfbContextMultiValueCapable.ps1`, which this check *executes* rather than re-derives. The spec expresses the same property only through which component `context_names` `$ref`s: `Context_names_get` (multi-value) versus `Context_names` (size-1). Those components have identical schemas and there is no `maxItems` -- the size-1 restriction lives only in free-text `description` -- so the component name is the sole mechanical signal available to check the assumption against.')
+$mdLines.Add('')
+$mdLines.Add("Measured against **fb$newestAnalysedVersion** (the newest analysed version; the capability map's component data is last-seen-wins, so it describes that version's wire shape). $($contextFacts.Count) endpoints declare ``context_names``.")
+$mdLines.Add('')
+$mdLines.Add('**A disagreement is not automatically a spec bug.** The case worth catching is a genuine multi-context mutation endpoint, where the *module* would be the wrong side. A human decides which side is wrong, each time.')
+$mdLines.Add('')
+if ($contextRuleDisagreements.Count -eq 0) {
+    $mdLines.Add("**No disagreements.** The module rule and the spec's component identity agree on all $($contextFacts.Count) endpoints in fb$newestAnalysedVersion.")
+    $mdLines.Add('')
+    $mdLines.Add('For provenance: fb2.26 and fb2.27 each carried exactly one disagreement -- `DELETE /management-access-policies` referencing `Context_names_get` -- investigated and confirmed an upstream documentation defect, with no exception ever implemented in the module. REST 2.28 corrected that reference to `Context_names`. The module rule was right and was left untouched.')
+}
+else {
+    $mdLines.Add("**$($contextRuleDisagreements.Count) disagreement(s).**")
+    $mdLines.Add('')
+    $mdLines.Add('| Endpoint | Method | Referenced component | Module rule | Spec | Declares `allow_errors` |'); $mdLines.Add('|---|---|---|---|---|---|')
+    foreach ($d in $contextRuleDisagreements) {
+        $ruleCell = if ($d.ruleSaysMultiValue) { 'multi-value' } else { 'size-1' }
+        $specCell = if ($d.specSaysMultiValue) { 'multi-value' } else { 'size-1' }
+        $aeCell = if ($d.declaresAllowErrors) { 'yes' } else { 'no' }
+        $mdLines.Add("| ``$($d.endpoint)`` | $($d.method) | ``$($d.contextComponent)`` | $ruleCell | $specCell | $aeCell |")
+    }
+    $mdLines.Add('')
+    $mdLines.Add('`allow_errors` is corroborating evidence, not a cardinality signal: a genuinely multi-value endpoint would almost certainly declare it, so a multi-value component *without* it points towards a spec defect rather than a real API change.')
+}
+
+# Deliberately a SEPARATE subsection from the disagreement table above, and scoped to
+# endpoints where rule and spec AGREE on cardinality. These are a different anomaly;
+# conflating the two muddies both, and double-counting one endpoint as both would
+# overstate the problem.
+$mdLines.Add('')
+$mdLines.Add('### `allow_errors` co-occurrence anomalies')
+$mdLines.Add('')
+$mdLines.Add('Separate from the cardinality question above, and scoped to endpoints where the rule and the spec already agree -- so nothing listed here is also listed as a disagreement.')
+$mdLines.Add('')
+$multiWithoutAE = @($contextAllowErrorsAnomalies.multiValueWithoutAllowErrors)
+$singleWithAE = @($contextAllowErrorsAnomalies.singleValueWithAllowErrors)
+$mdLines.Add("**Agreed multi-value, but does not declare ``allow_errors`` ($($multiWithoutAE.Count)):**")
+$mdLines.Add('')
+if ($multiWithoutAE.Count -eq 0) { $mdLines.Add('_None._') }
+else { foreach ($m in $multiWithoutAE) { $mdLines.Add("- ``$($m.endpoint)``") } }
+$mdLines.Add('')
+$mdLines.Add("These matter for context injection: a caller with a multi-value context active would have ``allow_errors`` injected into an endpoint that does not declare it. Whether injection is *gated* on the endpoint declaring the parameter, or sent regardless, is a behavioural decision owned by the context-injection work -- this report states the affected endpoints and does not presume the answer.")
+$mdLines.Add('')
+$mdLines.Add("**Agreed size-1, but declares ``allow_errors`` ($($singleWithAE.Count)) -- the mirror image:**")
+$mdLines.Add('')
+if ($singleWithAE.Count -eq 0) { $mdLines.Add('_None._') }
+else { foreach ($s in $singleWithAE) { $mdLines.Add("- ``$($s.endpoint)``") } }
+
+if ($contextUnresolvedComponents.Count -gt 0) {
+    $mdLines.Add('')
+    $mdLines.Add("### Unresolved `context_names` components ($($contextUnresolvedComponents.Count))")
+    $mdLines.Add('')
+    $mdLines.Add('These endpoints declare `context_names` with no resolvable `$ref` component, so their cardinality cannot be checked at all. They are **not** scored as size-1 -- doing so would hide a genuine multi-value endpoint behind the module''s hardcoded throw.')
+    $mdLines.Add('')
+    foreach ($u in $contextUnresolvedComponents) { $mdLines.Add("- ``$($u.endpoint)``") }
+}
+
 $mdLines.Add('')
 
 Set-Content -Path $ReportPath -Value ($mdLines -join "`n") -Encoding UTF8

--- a/tools/lib/PfbContextRuleTools.ps1
+++ b/tools/lib/PfbContextRuleTools.ps1
@@ -1,0 +1,320 @@
+#Requires -Version 5.1
+
+<#
+    PfbContextRuleTools -- the spec-vs-module-assumption check for the Fusion
+    `context_names` verb rule.
+
+    Every other drift category asks "does the module cover what the API offers?". This one
+    asks a different question: "is an assumption we baked into the code still true?" The
+    module hardcodes a cardinality rule (GET fans out; POST/PATCH/PUT/DELETE are size-1)
+    that the OpenAPI spec expresses only through which component a parameter `$ref`s --
+    `Context_names_get` (multi-value) versus `Context_names` (size-1). Those two components
+    have identical schemas and there is no `maxItems`, so the component NAME is the only
+    mechanical signal that the assumption could ever be checked against.
+
+    THE LOAD-BEARING DESIGN POINT: the rule is read from ONE declared place --
+    Private/Test-PfbContextMultiValueCapable.ps1, dot-sourced below and actually EXECUTED.
+    It is never re-derived here. A check that re-implements the rule it is checking
+    verifies nothing; it would agree with itself forever while the module drifted.
+
+    The rule is ground truth (live-tested plus upstream confirmation) and the spec is the
+    side that has been observed wrong. This file therefore REPORTS disagreement and
+    deliberately does not prejudge which side is at fault -- a future disagreement may well
+    be a real API change (a genuine multi-context mutation endpoint) rather than another
+    spec defect. A human decides, each time.
+#>
+
+$script:PfbContextParameterName = 'context_names'
+$script:PfbContextMultiValueComponent = 'Context_names_get'
+$script:PfbAllowErrorsParameterName = 'allow_errors'
+
+# Execute the module's own rule rather than copying it. Failing loudly here is correct:
+# silently falling back to a local copy of the rule is the one outcome that would make
+# this whole check meaningless.
+$script:PfbContextRuleRepoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$script:PfbContextRulePredicatePath = Join-Path $script:PfbContextRuleRepoRoot 'Private/Test-PfbContextMultiValueCapable.ps1'
+if (-not (Test-Path $script:PfbContextRulePredicatePath)) {
+    throw ("PfbContextRuleTools: cannot locate the module's declared context-cardinality " +
+        "rule at '$script:PfbContextRulePredicatePath'. This check must execute the " +
+        'module rule, never re-implement it -- refusing to load rather than silently ' +
+        'verifying a private copy of the rule against itself.')
+}
+. $script:PfbContextRulePredicatePath
+
+function Get-PfbContextParameterFact {
+    <#
+    .SYNOPSIS
+        Normalizes every endpoint carrying a `context_names` parameter into one comparable
+        record, from either the committed capability map or a single spec version's
+        Get-PfbSpecCapabilities output.
+    .DESCRIPTION
+        Two sources, deliberately both supported, because they answer different questions
+        and can legitimately disagree:
+
+          -CapabilityMap      Data/PfbCapabilityMap.json (parsed). Its component data is
+                              LAST-SEEN-WINS across the versions it was generated from --
+                              i.e. it describes the NEWEST version's wire shape, not a
+                              union. See Build-PfbCapabilityMap.ps1's
+                              parameterComponentDefaults/parameterComponentOverrides
+                              resolution contract.
+          -SpecCapabilities   Get-PfbSpecCapabilities output for ONE fb<version>.json.
+                              Use this to ask the question of a specific REST version.
+
+        These two inputs drift when specs are refreshed without rebuilding the map, so
+        every figure derived from them should be stated together with which input and
+        which version it came from.
+
+        Component resolution for -CapabilityMap follows the documented three-step
+        contract: (1) the endpoint's parameterComponentOverrides value for the parameter
+        if the KEY is present -- which may be JSON null, meaning "this endpoint's
+        parameter has no component"; otherwise (2) the top-level
+        parameterComponentDefaults value; otherwise (3) no known component. Key-present-
+        but-null and key-absent are distinguished, never conflated.
+    .OUTPUTS
+        [PSCustomObject][] sorted by Endpoint, one per endpoint declaring `context_names`:
+            Endpoint            "<METHOD> /<path>"
+            Method              HTTP method, upper-case
+            Path                normalized path
+            ContextComponent    resolved component name, or $null when the endpoint
+                                declares the parameter inline with no "$ref"
+            SpecSaysMultiValue  [bool] or $null when ContextComponent is $null
+            RuleSaysMultiValue  [bool] -- the MODULE's verdict, from
+                                Test-PfbContextMultiValueCapable
+            DeclaresAllowErrors [bool]
+    #>
+    [CmdletBinding(DefaultParameterSetName = 'CapabilityMap')]
+    [OutputType([PSCustomObject[]])]
+    param(
+        [Parameter(Mandatory, ParameterSetName = 'CapabilityMap')]
+        $CapabilityMap,
+
+        [Parameter(Mandatory, ParameterSetName = 'SpecCapabilities')]
+        [AllowEmptyCollection()]
+        [object[]]$SpecCapabilities
+    )
+
+    $facts = [System.Collections.Generic.List[object]]::new()
+
+    if ($PSCmdlet.ParameterSetName -eq 'CapabilityMap') {
+        if (-not $CapabilityMap -or -not $CapabilityMap.endpoints) { return @() }
+        $defaults = $CapabilityMap.parameterComponentDefaults
+
+        foreach ($endpointKey in $CapabilityMap.endpoints.PSObject.Properties.Name) {
+            $entry = $CapabilityMap.endpoints.$endpointKey
+            if (-not $entry.parameters) { continue }
+            $paramNames = $entry.parameters.PSObject.Properties.Name
+            if ($paramNames -notcontains $script:PfbContextParameterName) { continue }
+
+            $component = $null
+            $overrides = $entry.parameterComponentOverrides
+            if ($overrides -and ($overrides.PSObject.Properties.Name -contains $script:PfbContextParameterName)) {
+                # Key present -- authoritative, even when its value is null.
+                $component = $overrides.$($script:PfbContextParameterName)
+            }
+            elseif ($defaults -and ($defaults.PSObject.Properties.Name -contains $script:PfbContextParameterName)) {
+                $component = $defaults.$($script:PfbContextParameterName)
+            }
+
+            # Endpoint keys are "<METHOD> /<path>"; split once on the first space only, so
+            # a path can never be truncated.
+            $splitIndex = $endpointKey.IndexOf(' ')
+            if ($splitIndex -lt 1) { continue }
+            $method = $endpointKey.Substring(0, $splitIndex)
+            $path = $endpointKey.Substring($splitIndex + 1)
+
+            $facts.Add((New-PfbContextParameterFactRecord -Method $method -Path $path `
+                        -Component $component `
+                        -DeclaresAllowErrors ($paramNames -contains $script:PfbAllowErrorsParameterName)))
+        }
+    }
+    else {
+        foreach ($capability in $SpecCapabilities) {
+            if (-not $capability) { continue }
+            $components = $capability.ParameterComponents
+            $parameters = @($capability.Parameters)
+            if ($parameters -notcontains $script:PfbContextParameterName) { continue }
+
+            $component = $null
+            if ($components -and $components.ContainsKey($script:PfbContextParameterName)) {
+                $component = $components[$script:PfbContextParameterName]
+            }
+
+            $facts.Add((New-PfbContextParameterFactRecord -Method $capability.Method -Path $capability.Path `
+                        -Component $component `
+                        -DeclaresAllowErrors ($parameters -contains $script:PfbAllowErrorsParameterName)))
+        }
+    }
+
+    # Hashtable/PSObject property order is not guaranteed and this feeds a tracked report.
+    return @($facts | Sort-Object -Property Endpoint)
+}
+
+function New-PfbContextParameterFactRecord {
+    <#
+    .SYNOPSIS
+        Internal helper for Get-PfbContextParameterFact: builds one fact record and, in
+        doing so, is the single point at which the MODULE's rule is executed.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string]$Method,
+        [Parameter(Mandatory)] [string]$Path,
+        [AllowNull()] [string]$Component,
+        [Parameter(Mandatory)] [bool]$DeclaresAllowErrors
+    )
+
+    $upperMethod = $Method.ToUpperInvariant()
+
+    # An empty-string component is treated as absent: the generator documents that a
+    # parameter with no "$ref" contributes NO key rather than an empty value, so an empty
+    # string here means malformed input, not "a component named ''".
+    $hasComponent = -not [string]::IsNullOrWhiteSpace($Component)
+
+    return [PSCustomObject]@{
+        Endpoint            = "$upperMethod $Path"
+        Method              = $upperMethod
+        Path                = $Path
+        ContextComponent    = if ($hasComponent) { $Component } else { $null }
+        SpecSaysMultiValue  = if ($hasComponent) { $Component -eq $script:PfbContextMultiValueComponent } else { $null }
+        RuleSaysMultiValue  = [bool](Test-PfbContextMultiValueCapable -Method $upperMethod)
+        DeclaresAllowErrors = $DeclaresAllowErrors
+    }
+}
+
+function Get-PfbContextVerbRuleDisagreement {
+    <#
+    .SYNOPSIS
+        The check: every endpoint where the MODULE's cardinality rule and the SPEC's
+        component identity disagree.
+    .DESCRIPTION
+        Deliberately reports rather than adjudicates. A disagreement is NOT automatically a
+        spec bug -- the case this check exists to catch is a genuine future multi-context
+        mutation endpoint, where the module would be the wrong side. The wording of the
+        emitted records is neutral for that reason.
+
+        Endpoints whose `context_names` has no resolvable component are NOT comparable and
+        are excluded here rather than being silently scored as size-1; retrieve them from
+        Get-PfbContextUnresolvedComponent so they stay visible.
+    .PARAMETER Fact
+        Get-PfbContextParameterFact output.
+    .OUTPUTS
+        [PSCustomObject][] sorted by Endpoint:
+            Endpoint, Method, ContextComponent, RuleSaysMultiValue, SpecSaysMultiValue,
+            DeclaresAllowErrors, Summary
+    #>
+    [CmdletBinding()]
+    [OutputType([PSCustomObject[]])]
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyCollection()]
+        [object[]]$Fact
+    )
+
+    $disagreements = foreach ($f in $Fact) {
+        if ($null -eq $f.SpecSaysMultiValue) { continue }
+        if ($f.SpecSaysMultiValue -eq $f.RuleSaysMultiValue) { continue }
+
+        $ruleWord = if ($f.RuleSaysMultiValue) { 'multi-value' } else { 'size-1' }
+        $specWord = if ($f.SpecSaysMultiValue) { 'multi-value' } else { 'size-1' }
+
+        [PSCustomObject]@{
+            Endpoint            = $f.Endpoint
+            Method              = $f.Method
+            ContextComponent    = $f.ContextComponent
+            RuleSaysMultiValue  = $f.RuleSaysMultiValue
+            SpecSaysMultiValue  = $f.SpecSaysMultiValue
+            DeclaresAllowErrors = $f.DeclaresAllowErrors
+            Summary             = ("module rule says $ruleWord for $($f.Method); spec " +
+                "references '$($f.ContextComponent)' ($specWord)")
+        }
+    }
+
+    return @($disagreements | Sort-Object -Property Endpoint)
+}
+
+function Get-PfbContextAllowErrorsAnomaly {
+    <#
+    .SYNOPSIS
+        A SEPARATE anomaly from the cardinality disagreement: endpoints whose
+        `allow_errors` declaration does not line up with their context cardinality.
+    .DESCRIPTION
+        Kept apart from Get-PfbContextVerbRuleDisagreement on purpose -- they are different
+        anomalies and conflating them muddies both. `allow_errors` is corroborating
+        evidence about cardinality, not a cardinality signal in its own right.
+
+        MultiValueWithoutAllowErrors is scoped to endpoints where the rule and the spec
+        AGREE the endpoint is multi-value. That scoping is the whole point of the
+        separation: an endpoint that is already reported as a cardinality disagreement must
+        not also appear here, or the same defect would be double-counted as two anomalies.
+        (Against fb2.27 this is exactly what keeps DELETE /management-access-policies in
+        the disagreement list only, leaving the four genuine GET anomalies here.)
+
+        SingleValueWithAllowErrors is the mirror image -- agreed size-1 endpoints that
+        nonetheless declare `allow_errors`. Named rather than left to be discovered later.
+    .PARAMETER Fact
+        Get-PfbContextParameterFact output.
+    .OUTPUTS
+        [PSCustomObject] with two sorted [PSCustomObject[]] properties:
+        MultiValueWithoutAllowErrors, SingleValueWithAllowErrors.
+    #>
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyCollection()]
+        [object[]]$Fact
+    )
+
+    $agreed = @($Fact | Where-Object { $null -ne $_.SpecSaysMultiValue -and $_.SpecSaysMultiValue -eq $_.RuleSaysMultiValue })
+
+    $project = {
+        param($record)
+        [PSCustomObject]@{
+            Endpoint            = $record.Endpoint
+            Method              = $record.Method
+            ContextComponent    = $record.ContextComponent
+            DeclaresAllowErrors = $record.DeclaresAllowErrors
+        }
+    }
+
+    $multiWithout = @($agreed | Where-Object { $_.SpecSaysMultiValue -and -not $_.DeclaresAllowErrors } |
+            ForEach-Object { & $project $_ } | Sort-Object -Property Endpoint)
+    $singleWith = @($agreed | Where-Object { -not $_.SpecSaysMultiValue -and $_.DeclaresAllowErrors } |
+            ForEach-Object { & $project $_ } | Sort-Object -Property Endpoint)
+
+    return [PSCustomObject]@{
+        MultiValueWithoutAllowErrors = $multiWithout
+        SingleValueWithAllowErrors   = $singleWith
+    }
+}
+
+function Get-PfbContextUnresolvedComponent {
+    <#
+    .SYNOPSIS
+        Endpoints declaring `context_names` with no resolvable component -- neither
+        checkable nor safe to score as size-1.
+    .DESCRIPTION
+        Expected to be empty (0 occurrences across fb2.0-fb2.28). Surfaced anyway because
+        the failure mode it guards against is silent: were a future spec to declare
+        `context_names` inline with no "$ref", treating it as size-1 by default would hide
+        a genuine multi-value endpoint behind a hardcoded throw.
+    .PARAMETER Fact
+        Get-PfbContextParameterFact output.
+    #>
+    [CmdletBinding()]
+    [OutputType([PSCustomObject[]])]
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyCollection()]
+        [object[]]$Fact
+    )
+
+    return @($Fact | Where-Object { $null -eq $_.SpecSaysMultiValue } |
+            ForEach-Object {
+                [PSCustomObject]@{
+                    Endpoint            = $_.Endpoint
+                    Method              = $_.Method
+                    DeclaresAllowErrors = $_.DeclaresAllowErrors
+                }
+            } | Sort-Object -Property Endpoint)
+}

--- a/tools/lib/PfbContextRuleTools.ps1
+++ b/tools/lib/PfbContextRuleTools.ps1
@@ -2,26 +2,50 @@
 
 <#
     PfbContextRuleTools -- the spec-vs-module-assumption check for the Fusion
-    `context_names` verb rule.
+    `context_names` cardinality rule.
 
     Every other drift category asks "does the module cover what the API offers?". This one
-    asks a different question: "is an assumption we baked into the code still true?" The
-    module hardcodes a cardinality rule (GET fans out; POST/PATCH/PUT/DELETE are size-1)
-    that the OpenAPI spec expresses only through which component a parameter `$ref`s --
-    `Context_names_get` (multi-value) versus `Context_names` (size-1). Those two components
-    have identical schemas and there is no `maxItems`, so the component NAME is the only
-    mechanical signal that the assumption could ever be checked against.
+    asks a different question: "is an assumption baked into the module still true?"
 
     THE LOAD-BEARING DESIGN POINT: the rule is read from ONE declared place --
     Private/Test-PfbContextMultiValueCapable.ps1, dot-sourced below and actually EXECUTED.
     It is never re-derived here. A check that re-implements the rule it is checking
     verifies nothing; it would agree with itself forever while the module drifted.
 
-    The rule is ground truth (live-tested plus upstream confirmation) and the spec is the
-    side that has been observed wrong. This file therefore REPORTS disagreement and
-    deliberately does not prejudge which side is at fault -- a future disagreement may well
-    be a real API change (a genuine multi-context mutation endpoint) rather than another
-    spec defect. A human decides, each time.
+    WHY THIS IS A CROSS-SIGNAL CHECK RATHER THAN RULE-VS-COMPONENT. The first version of
+    this file compared the module's rule against one spec signal, the component name. That
+    shape is structurally blind to the failure that actually exists: four fleet-scoped GETs
+    reference the multi-value component AND are size-1 on the wire, so rule and component
+    AGREE and both are wrong in the same direction. Two-signal comparison cannot see that.
+    This file therefore compares every available signal and reports any endpoint whose
+    signals do not all agree -- including the case where the rule and the component agree
+    but the remaining signals dissent.
+
+    The signals, and what each is worth (measured against fb2.27; see section 8 of
+    docs/design/fusion-context-injection.md):
+
+      component `Context_names_get`  139 endpoints  wrong for 5
+      declares `allow_errors`        135 endpoints  correct on every case with evidence
+      declares an HTTP 207 response  124 endpoints  correct but stricter; excludes 11
+                                                    endpoints of unknown status
+      carries an `errors` envelope   139 endpoints  UNRELIABLE -- applied by an
+                                                    allOf-composed `_errorContextResponse`
+                                                    authoring convention to 15 endpoints
+                                                    that declare no 207, including all four
+                                                    defective ones. Deliberately NOT
+                                                    implemented here, and must never be
+                                                    used as a signal.
+
+    HTTP 207 is available from the specs under tools/ but NOT from the capability map,
+    which records the request surface only. It is therefore a corroborating signal for this
+    maintainer check and never a runtime gate -- which is why it is optional throughout: an
+    unknown 207 is carried as $null and excluded from comparison, never silently scored as
+    "does not declare".
+
+    This file REPORTS and deliberately does not adjudicate. A disagreement is not
+    automatically a spec defect -- the case worth catching is a genuine future
+    multi-context endpoint, where the module would be the wrong side. A human decides which
+    signal is wrong, each time.
 #>
 
 $script:PfbContextParameterName = 'context_names'
@@ -41,11 +65,54 @@ if (-not (Test-Path $script:PfbContextRulePredicatePath)) {
 }
 . $script:PfbContextRulePredicatePath
 
+function Get-PfbContextHttp207Endpoint {
+    <#
+    .SYNOPSIS
+        Endpoint keys ("<METHOD> /<path>") in one spec document that declare an HTTP 207
+        (Multi-Status) response.
+    .DESCRIPTION
+        The 207 signal is the reason this lives here rather than in the capability map: the
+        map holds no response data at all. Feed the result to Get-PfbContextParameterFact's
+        -Http207Endpoint so map-sourced facts can still carry the signal.
+
+        Only the PRESENCE of the '207' key on the operation's `responses` object matters, so
+        no $ref resolution is needed or attempted -- a 207 whose value is a $ref to a
+        response component is still a declared 207. Path normalization goes through the
+        shared ConvertTo-PfbNormalizedPath so keys match Get-PfbSpecCapabilities exactly.
+    .OUTPUTS
+        [string[]] sorted endpoint keys. Empty array when the spec declares none.
+    #>
+    [CmdletBinding()]
+    [OutputType([string[]])]
+    param(
+        [Parameter(Mandatory)]
+        $Spec
+    )
+
+    if (-not $Spec.paths) { return @() }
+
+    $found = [System.Collections.Generic.List[string]]::new()
+    foreach ($rawPath in $Spec.paths.PSObject.Properties.Name) {
+        $pathItem = $Spec.paths.$rawPath
+        $normalizedPath = ConvertTo-PfbNormalizedPath -Path $rawPath
+        foreach ($methodName in $pathItem.PSObject.Properties.Name) {
+            if ($script:PfbHttpMethods -notcontains $methodName) { continue }
+            $op = $pathItem.$methodName
+            if (-not $op.responses) { continue }
+            if ($op.responses.PSObject.Properties.Name -contains '207') {
+                $found.Add("$($methodName.ToUpper()) $normalizedPath")
+            }
+        }
+    }
+
+    return @($found | Sort-Object -Unique)
+}
+
 function Get-PfbContextParameterFact {
     <#
     .SYNOPSIS
         Normalizes every endpoint carrying a `context_names` parameter into one comparable
-        record, from either the committed capability map or a single spec version's
+        signal record, from either the committed capability map or a single spec version's
         Get-PfbSpecCapabilities output.
     .DESCRIPTION
         Two sources, deliberately both supported, because they answer different questions
@@ -53,34 +120,43 @@ function Get-PfbContextParameterFact {
 
           -CapabilityMap      Data/PfbCapabilityMap.json (parsed). Its component data is
                               LAST-SEEN-WINS across the versions it was generated from --
-                              i.e. it describes the NEWEST version's wire shape, not a
-                              union. See Build-PfbCapabilityMap.ps1's
+                              it describes the NEWEST version's wire shape, not a union.
+                              See Build-PfbCapabilityMap.ps1's
                               parameterComponentDefaults/parameterComponentOverrides
                               resolution contract.
           -SpecCapabilities   Get-PfbSpecCapabilities output for ONE fb<version>.json.
                               Use this to ask the question of a specific REST version.
 
-        These two inputs drift when specs are refreshed without rebuilding the map, so
-        every figure derived from them should be stated together with which input and
-        which version it came from.
+        Dual input matters more since rev 3: the four defective endpoints' signals will all
+        change when the upstream fix lands, and being able to ask a specific version is how
+        that gets confirmed rather than assumed. These two inputs also drift when specs are
+        refreshed without rebuilding the map, so every figure derived from them should be
+        stated together with which input and which version it came from.
 
-        Component resolution for -CapabilityMap follows the documented three-step
-        contract: (1) the endpoint's parameterComponentOverrides value for the parameter
-        if the KEY is present -- which may be JSON null, meaning "this endpoint's
-        parameter has no component"; otherwise (2) the top-level
-        parameterComponentDefaults value; otherwise (3) no known component. Key-present-
-        but-null and key-absent are distinguished, never conflated.
+        Component resolution for -CapabilityMap follows the documented three-step contract:
+        (1) the endpoint's parameterComponentOverrides value for the parameter if the KEY is
+        present -- which may be JSON null, meaning "this endpoint's parameter has no
+        component"; otherwise (2) the top-level parameterComponentDefaults value; otherwise
+        (3) no known component. Key-present-but-null and key-absent are distinguished, never
+        conflated.
+    .PARAMETER Http207Endpoint
+        Optional endpoint keys declaring an HTTP 207, from Get-PfbContextHttp207Endpoint.
+        When omitted, DeclaresHttp207 is $null on every record -- meaning UNKNOWN, not
+        "does not declare". Downstream comparison excludes unknown signals rather than
+        scoring them, so omitting this narrows what the check can see without ever making
+        it report something false.
     .OUTPUTS
         [PSCustomObject][] sorted by Endpoint, one per endpoint declaring `context_names`:
-            Endpoint            "<METHOD> /<path>"
-            Method              HTTP method, upper-case
-            Path                normalized path
-            ContextComponent    resolved component name, or $null when the endpoint
-                                declares the parameter inline with no "$ref"
-            SpecSaysMultiValue  [bool] or $null when ContextComponent is $null
-            RuleSaysMultiValue  [bool] -- the MODULE's verdict, from
-                                Test-PfbContextMultiValueCapable
-            DeclaresAllowErrors [bool]
+            Endpoint                "<METHOD> /<path>"
+            Method                  HTTP method, upper-case
+            Path                    normalized path
+            ContextComponent        resolved component name, or $null when the endpoint
+                                    declares the parameter inline with no "$ref"
+            ComponentSaysMultiValue [bool], or $null when ContextComponent is $null
+            DeclaresAllowErrors     [bool]
+            DeclaresHttp207         [bool], or $null when not supplied (UNKNOWN)
+            RuleSaysMultiValue      [bool] -- the MODULE's verdict, from
+                                    Test-PfbContextMultiValueCapable
     #>
     [CmdletBinding(DefaultParameterSetName = 'CapabilityMap')]
     [OutputType([PSCustomObject[]])]
@@ -90,8 +166,24 @@ function Get-PfbContextParameterFact {
 
         [Parameter(Mandatory, ParameterSetName = 'SpecCapabilities')]
         [AllowEmptyCollection()]
-        [object[]]$SpecCapabilities
+        [object[]]$SpecCapabilities,
+
+        [AllowNull()]
+        [string[]]$Http207Endpoint
     )
+
+    # $null (parameter omitted) must stay distinguishable from an empty set (a spec that
+    # genuinely declares no 207 anywhere) -- the first means "unknown", the second "none".
+    #
+    # Assigned by a plain if-statement, NOT `$set207 = if (...) { $hashSet }`: a HashSet
+    # emitted as the value of a scriptblock gets ENUMERATED, which turns an empty set into
+    # $null (silently reclassifying "none" as "unknown") and a populated one into a plain
+    # array that has lost the OrdinalIgnoreCase comparer.
+    $has207Data = $PSBoundParameters.ContainsKey('Http207Endpoint') -and $null -ne $Http207Endpoint
+    $set207 = $null
+    if ($has207Data) {
+        $set207 = [System.Collections.Generic.HashSet[string]]::new([string[]]@($Http207Endpoint), [System.StringComparer]::OrdinalIgnoreCase)
+    }
 
     $facts = [System.Collections.Generic.List[object]]::new()
 
@@ -124,7 +216,8 @@ function Get-PfbContextParameterFact {
 
             $facts.Add((New-PfbContextParameterFactRecord -Method $method -Path $path `
                         -Component $component `
-                        -DeclaresAllowErrors ($paramNames -contains $script:PfbAllowErrorsParameterName)))
+                        -DeclaresAllowErrors ($paramNames -contains $script:PfbAllowErrorsParameterName) `
+                        -Set207 $set207))
         }
     }
     else {
@@ -141,7 +234,8 @@ function Get-PfbContextParameterFact {
 
             $facts.Add((New-PfbContextParameterFactRecord -Method $capability.Method -Path $capability.Path `
                         -Component $component `
-                        -DeclaresAllowErrors ($parameters -contains $script:PfbAllowErrorsParameterName)))
+                        -DeclaresAllowErrors ($parameters -contains $script:PfbAllowErrorsParameterName) `
+                        -Set207 $set207))
         }
     }
 
@@ -152,7 +246,7 @@ function Get-PfbContextParameterFact {
 function New-PfbContextParameterFactRecord {
     <#
     .SYNOPSIS
-        Internal helper for Get-PfbContextParameterFact: builds one fact record and, in
+        Internal helper for Get-PfbContextParameterFact: builds one signal record and, in
         doing so, is the single point at which the MODULE's rule is executed.
     #>
     [CmdletBinding()]
@@ -160,10 +254,12 @@ function New-PfbContextParameterFactRecord {
         [Parameter(Mandatory)] [string]$Method,
         [Parameter(Mandatory)] [string]$Path,
         [AllowNull()] [string]$Component,
-        [Parameter(Mandatory)] [bool]$DeclaresAllowErrors
+        [Parameter(Mandatory)] [bool]$DeclaresAllowErrors,
+        [AllowNull()] $Set207
     )
 
     $upperMethod = $Method.ToUpperInvariant()
+    $endpoint = "$upperMethod $Path"
 
     # An empty-string component is treated as absent: the generator documents that a
     # parameter with no "$ref" contributes NO key rather than an empty value, so an empty
@@ -171,36 +267,64 @@ function New-PfbContextParameterFactRecord {
     $hasComponent = -not [string]::IsNullOrWhiteSpace($Component)
 
     return [PSCustomObject]@{
-        Endpoint            = "$upperMethod $Path"
-        Method              = $upperMethod
-        Path                = $Path
-        ContextComponent    = if ($hasComponent) { $Component } else { $null }
-        SpecSaysMultiValue  = if ($hasComponent) { $Component -eq $script:PfbContextMultiValueComponent } else { $null }
-        RuleSaysMultiValue  = [bool](Test-PfbContextMultiValueCapable -Method $upperMethod)
-        DeclaresAllowErrors = $DeclaresAllowErrors
+        Endpoint                = $endpoint
+        Method                  = $upperMethod
+        Path                    = $Path
+        ContextComponent        = if ($hasComponent) { $Component } else { $null }
+        ComponentSaysMultiValue = if ($hasComponent) { $Component -eq $script:PfbContextMultiValueComponent } else { $null }
+        DeclaresAllowErrors     = $DeclaresAllowErrors
+        DeclaresHttp207         = if ($null -ne $Set207) { $Set207.Contains($endpoint) } else { $null }
+        RuleSaysMultiValue      = [bool](Test-PfbContextMultiValueCapable -Method $upperMethod `
+                -ContextComponent $Component -DeclaresAllowErrors $DeclaresAllowErrors)
     }
 }
 
-function Get-PfbContextVerbRuleDisagreement {
+function Get-PfbContextSignalDisagreement {
     <#
     .SYNOPSIS
-        The check: every endpoint where the MODULE's cardinality rule and the SPEC's
-        component identity disagree.
+        The check: every endpoint whose cardinality signals do not all agree.
     .DESCRIPTION
-        Deliberately reports rather than adjudicates. A disagreement is NOT automatically a
-        spec bug -- the case this check exists to catch is a genuine future multi-context
-        mutation endpoint, where the module would be the wrong side. The wording of the
-        emitted records is neutral for that reason.
+        Replaces the earlier rule-vs-component comparison, which was structurally unable to
+        see the defect that actually exists (rule and component agreeing while the wire
+        disagrees with both).
 
-        Endpoints whose `context_names` has no resolvable component are NOT comparable and
-        are excluded here rather than being silently scored as size-1; retrieve them from
+        Compared signals, per endpoint: the component identity, whether `allow_errors` is
+        declared, and -- when known -- whether an HTTP 207 is declared. Unanimity means no
+        finding. An UNKNOWN 207 is excluded from the comparison rather than scored as
+        "does not declare", so supplying less data can narrow what the check sees but can
+        never make it report something false.
+
+        The module's own verdict (RuleSaysMultiValue) is carried on every finding for
+        transparency, but is not itself a compared signal: it is derived from two of them,
+        so including it would double-weight the component and `allow_errors` rather than
+        adding independent evidence.
+
+        Endpoints whose `context_names` has no resolvable component are not comparable and
+        are excluded here rather than silently scored as size-1; retrieve them from
         Get-PfbContextUnresolvedComponent so they stay visible.
+
+        Findings are classified by Shape so the report can group them. The shapes are
+        exhaustive over the non-unanimous combinations:
+
+          component-says-multi-value-but-no-allow-errors
+              The four fleet-scoped GETs today, and DELETE /management-access-policies in
+              2.26/2.27. Strong evidence of a spec defect: the component claims fan-out
+              while the endpoint offers no partial-failure story.
+          size-1-component-but-declares-allow-errors
+              The named mirror case, PATCH /directory-services/test.
+          rule-says-capable-but-declares-no-207
+              Rule and component and `allow_errors` all agree the endpoint fans out, but it
+              declares no 207. 11 endpoints at fb2.27 -- status genuinely unknown, which is
+              precisely why 207 is not used as a runtime gate.
+          size-1-but-declares-207
+              Declares a partial-failure response while nothing else says it fans out.
     .PARAMETER Fact
         Get-PfbContextParameterFact output.
     .OUTPUTS
         [PSCustomObject][] sorted by Endpoint:
-            Endpoint, Method, ContextComponent, RuleSaysMultiValue, SpecSaysMultiValue,
-            DeclaresAllowErrors, Summary
+            Endpoint, Method, ContextComponent, Shape, RuleSaysMultiValue,
+            ComponentSaysMultiValue, DeclaresAllowErrors, DeclaresHttp207,
+            MultiValueSignals, SizeOneSignals, Summary
     #>
     [CmdletBinding()]
     [OutputType([PSCustomObject[]])]
@@ -210,82 +334,84 @@ function Get-PfbContextVerbRuleDisagreement {
         [object[]]$Fact
     )
 
-    $disagreements = foreach ($f in $Fact) {
-        if ($null -eq $f.SpecSaysMultiValue) { continue }
-        if ($f.SpecSaysMultiValue -eq $f.RuleSaysMultiValue) { continue }
+    $findings = foreach ($f in $Fact) {
+        if ($null -eq $f.ComponentSaysMultiValue) { continue }
 
-        $ruleWord = if ($f.RuleSaysMultiValue) { 'multi-value' } else { 'size-1' }
-        $specWord = if ($f.SpecSaysMultiValue) { 'multi-value' } else { 'size-1' }
+        $signals = [ordered]@{
+            component    = [bool]$f.ComponentSaysMultiValue
+            allow_errors = [bool]$f.DeclaresAllowErrors
+        }
+        if ($null -ne $f.DeclaresHttp207) { $signals['http207'] = [bool]$f.DeclaresHttp207 }
+
+        $multiSignals = @($signals.Keys | Where-Object { $signals[$_] } | Sort-Object)
+        $sizeOneSignals = @($signals.Keys | Where-Object { -not $signals[$_] } | Sort-Object)
+        if ($multiSignals.Count -eq 0 -or $sizeOneSignals.Count -eq 0) { continue }  # unanimous
+
+        $component = $signals['component']
+        $allowErrors = $signals['allow_errors']
+        $shape = if ($component -and -not $allowErrors) { 'component-says-multi-value-but-no-allow-errors' }
+        elseif (-not $component -and $allowErrors) { 'size-1-component-but-declares-allow-errors' }
+        elseif ($component -and $allowErrors) { 'rule-says-capable-but-declares-no-207' }
+        else { 'size-1-but-declares-207' }
 
         [PSCustomObject]@{
-            Endpoint            = $f.Endpoint
-            Method              = $f.Method
-            ContextComponent    = $f.ContextComponent
-            RuleSaysMultiValue  = $f.RuleSaysMultiValue
-            SpecSaysMultiValue  = $f.SpecSaysMultiValue
-            DeclaresAllowErrors = $f.DeclaresAllowErrors
-            Summary             = ("module rule says $ruleWord for $($f.Method); spec " +
-                "references '$($f.ContextComponent)' ($specWord)")
+            Endpoint                = $f.Endpoint
+            Method                  = $f.Method
+            ContextComponent        = $f.ContextComponent
+            Shape                   = $shape
+            RuleSaysMultiValue      = $f.RuleSaysMultiValue
+            ComponentSaysMultiValue = $f.ComponentSaysMultiValue
+            DeclaresAllowErrors     = $f.DeclaresAllowErrors
+            DeclaresHttp207         = $f.DeclaresHttp207
+            MultiValueSignals       = $multiSignals
+            SizeOneSignals          = $sizeOneSignals
+            Summary                 = ("signals split -- multi-value: $($multiSignals -join ', '); " +
+                "size-1: $($sizeOneSignals -join ', '); module rule says " +
+                $(if ($f.RuleSaysMultiValue) { 'multi-value' } else { 'size-1' }))
         }
     }
 
-    return @($disagreements | Sort-Object -Property Endpoint)
+    return @($findings | Sort-Object -Property Endpoint)
 }
 
-function Get-PfbContextAllowErrorsAnomaly {
+function Get-PfbContextSizeOneWithAllowErrors {
     <#
     .SYNOPSIS
-        A SEPARATE anomaly from the cardinality disagreement: endpoints whose
-        `allow_errors` declaration does not line up with their context cardinality.
+        The named mirror case: endpoints whose component says size-1 yet which declare
+        `allow_errors`.
     .DESCRIPTION
-        Kept apart from Get-PfbContextVerbRuleDisagreement on purpose -- they are different
-        anomalies and conflating them muddies both. `allow_errors` is corroborating
-        evidence about cardinality, not a cardinality signal in its own right.
+        A NAMED SUBSET of Get-PfbContextSignalDisagreement's findings (Shape
+        'size-1-component-but-declares-allow-errors'), never an additional category --
+        reporting it separately as well would double-count one defect as two findings.
+        Surfaced under its own name only because it is a known, characterized case worth
+        pointing at directly: `PATCH /directory-services/test`, the one size-1 endpoint
+        declaring `allow_errors`, which rev 3's Appendix A records as NOT live-verified
+        (it is a mutating verb and was not probed).
 
-        MultiValueWithoutAllowErrors is scoped to endpoints where the rule and the spec
-        AGREE the endpoint is multi-value. That scoping is the whole point of the
-        separation: an endpoint that is already reported as a cardinality disagreement must
-        not also appear here, or the same defect would be double-counted as two anomalies.
-        (Against fb2.27 this is exactly what keeps DELETE /management-access-policies in
-        the disagreement list only, leaving the four genuine GET anomalies here.)
-
-        SingleValueWithAllowErrors is the mirror image -- agreed size-1 endpoints that
-        nonetheless declare `allow_errors`. Named rather than left to be discovered later.
+        Its counterpart -- agreed multi-value endpoints lacking `allow_errors` -- is
+        deliberately NOT surfaced here any more. Under rev 3's rule that is a cardinality
+        finding, not a co-occurrence curiosity, and it belongs in the disagreement list.
     .PARAMETER Fact
         Get-PfbContextParameterFact output.
-    .OUTPUTS
-        [PSCustomObject] with two sorted [PSCustomObject[]] properties:
-        MultiValueWithoutAllowErrors, SingleValueWithAllowErrors.
     #>
     [CmdletBinding()]
-    [OutputType([PSCustomObject])]
+    [OutputType([PSCustomObject[]])]
     param(
         [Parameter(Mandatory)]
         [AllowEmptyCollection()]
         [object[]]$Fact
     )
 
-    $agreed = @($Fact | Where-Object { $null -ne $_.SpecSaysMultiValue -and $_.SpecSaysMultiValue -eq $_.RuleSaysMultiValue })
-
-    $project = {
-        param($record)
-        [PSCustomObject]@{
-            Endpoint            = $record.Endpoint
-            Method              = $record.Method
-            ContextComponent    = $record.ContextComponent
-            DeclaresAllowErrors = $record.DeclaresAllowErrors
-        }
-    }
-
-    $multiWithout = @($agreed | Where-Object { $_.SpecSaysMultiValue -and -not $_.DeclaresAllowErrors } |
-            ForEach-Object { & $project $_ } | Sort-Object -Property Endpoint)
-    $singleWith = @($agreed | Where-Object { -not $_.SpecSaysMultiValue -and $_.DeclaresAllowErrors } |
-            ForEach-Object { & $project $_ } | Sort-Object -Property Endpoint)
-
-    return [PSCustomObject]@{
-        MultiValueWithoutAllowErrors = $multiWithout
-        SingleValueWithAllowErrors   = $singleWith
-    }
+    return @($Fact |
+            Where-Object { $false -eq $_.ComponentSaysMultiValue -and $_.DeclaresAllowErrors } |
+            ForEach-Object {
+                [PSCustomObject]@{
+                    Endpoint         = $_.Endpoint
+                    Method           = $_.Method
+                    ContextComponent = $_.ContextComponent
+                    DeclaresHttp207  = $_.DeclaresHttp207
+                }
+            } | Sort-Object -Property Endpoint)
 }
 
 function Get-PfbContextUnresolvedComponent {
@@ -294,10 +420,14 @@ function Get-PfbContextUnresolvedComponent {
         Endpoints declaring `context_names` with no resolvable component -- neither
         checkable nor safe to score as size-1.
     .DESCRIPTION
-        Expected to be empty (0 occurrences across fb2.0-fb2.28). Surfaced anyway because
-        the failure mode it guards against is silent: were a future spec to declare
-        `context_names` inline with no "$ref", treating it as size-1 by default would hide
-        a genuine multi-value endpoint behind a hardcoded throw.
+        Expected to be empty: verified 0 occurrences across every spec where the parameter
+        exists at all, which is fb2.17-fb2.28 (`context_names` does not exist before 2.17,
+        so the wider fb2.0-2.28 range this comment previously claimed was not wrong so much
+        as vacuous over its first seventeen versions).
+
+        Surfaced anyway because the failure mode it guards against is silent: were a future
+        spec to declare `context_names` inline with no "$ref", treating it as size-1 by
+        default would hide a genuine multi-value endpoint behind a hardcoded throw.
     .PARAMETER Fact
         Get-PfbContextParameterFact output.
     #>
@@ -309,7 +439,7 @@ function Get-PfbContextUnresolvedComponent {
         [object[]]$Fact
     )
 
-    return @($Fact | Where-Object { $null -eq $_.SpecSaysMultiValue } |
+    return @($Fact | Where-Object { $null -eq $_.ComponentSaysMultiValue } |
             ForEach-Object {
                 [PSCustomObject]@{
                     Endpoint            = $_.Endpoint


### PR DESCRIPTION
## What this does

Adds a maintainer drift-report check for the Fusion `context_names` **cardinality** assumption — can an endpoint carry many context names, or exactly one? — and establishes the single declared home of that rule.

Every existing drift category asks *"does the module cover what the API offers?"*. This one asks a different question: *"is an assumption baked into the module still true?"*

## The rule

Ratified in section 8 of `docs/design/fusion-context-injection.md` (rev 3):

> An endpoint is multi-context-capable **iff** its `context_names` parameter resolves to component `Context_names_get` **and** the endpoint also declares `allow_errors`.

It lives in exactly one place — `Private/Test-PfbContextMultiValueCapable.ps1`, a pure predicate — and the drift check **executes** it rather than re-deriving it. A check that re-implements the rule it is checking verifies nothing.

An earlier revision proposed a clean HTTP-verb split (GET fans out, mutations are size-1). **That was falsified by live testing** and is not the rule here. Four fleet-scoped GETs reject any two-name context with `400 code 15 "Multiple location contexts are not allowed"` while referencing the multi-value component in the spec — an upstream defect, in review, still present at 2.28. The verb survives only as a fallback for an endpoint absent from the capability map.

## Why cross-signal rather than rule-vs-spec

The check compares component identity, `allow_errors`, and HTTP 207 (from `tools/specs`, since the capability map holds no response data), and reports any endpoint whose signals are not unanimous.

This matters: a two-signal rule-vs-spec design is structurally blind to *both sides being wrong in the same direction*. That is exactly the live defect — the rule and the component agreed while both were wrong. Against fb2.28 the two-signal shape reported **zero**; this reports **nine**.

| Shape | fb2.27 | fb2.28 |
|---|---|---|
| `component-says-multi-value-but-no-allow-errors` | 5 | 4 |
| `rule-says-capable-but-declares-no-207` | 11 | 4 |
| `size-1-component-but-declares-allow-errors` | 1 | 1 |
| `size-1-but-declares-207` | 0 | 0 |

A disagreement is **not** automatically a spec defect — the case worth catching is a genuine future multi-context endpoint, where the module would be the wrong side. A human decides which signal is wrong, each time.

An *unknown* 207 is carried as `$null` and excluded from comparison rather than scored as absent, so a missing spec narrows what the check sees but never makes it report something false.

## Live verification

FB-A (Purity//FB 4.8.2, REST 2.26), fleet `cc-test-fleet`, probed via remote member FB-C to avoid the local-context short-circuit. Read-only; no lab state changed.

| Rule verdict | Endpoints | `context_names=FB-A,FB-C` | `context_names=FB-C` |
|---|---|---|---|
| size-1 | the 4 fleet-scoped GETs | **400 code 15** | 400 code 13 |
| capable | `/file-systems`, `/admins`, `/arrays`, `/buckets`, `/policies` | **400 code 20** | 400 code 20 |

**9 of 9 match the predicate.** The single-context control is load-bearing: code 15 appears only on the multi-value probe, so it is cardinality and not context rejection.

## Runtime impact

**None.** `Test-PfbContextMultiValueCapable` has no callers yet — it is the interface the Fusion context-injection PR will consume, published ahead of it so both sides execute one rule instead of two copies. No cmdlet behavior changes.

## Files

- `Private/Test-PfbContextMultiValueCapable.ps1` — the rule (new, no callers yet)
- `tools/lib/PfbContextRuleTools.ps1` — fact gathering, signal comparison, 207 extraction
- `tools/Build-PfbApiDriftReport.ps1` — new report category
- `Reports/PfbApiDriftReport.{json,md}` — regenerated with the `contextCardinality` section
- `Tests/PfbContextRuleTools.Tests.ps1` — 54 tests

## Notes for review

- Tests assert **specific endpoints and structure, never population totals**. Two deliberately pin real upstream state and are *designed* to fail loudly if it changes: the four fleet-scoped endpoints must disagree at both 2.27 and 2.28, and `DELETE /management-access-policies` must stop disagreeing at 2.28 (2.28 shipped that fix upstream). If the fleet-scoped defect is fixed upstream, those failures are the signal, not a regression.
- No version bump, no CHANGELOG entry — maintainer's call.
- Follow-up, not in scope here: the three-step component resolution lives in `tools/lib/`, which is not shipped. The Fusion runtime path will need it in `Private/` or it will re-implement it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
