### PR TITLE
feat(tools): add response-shape drift axis to the maintainer toolchain

### DIFF
--- a/.github/workflows/update-api-capability-map.yml
+++ b/.github/workflows/update-api-capability-map.yml
@@ -81,6 +81,15 @@ jobs:
         shell: pwsh
         run: ./tools/Build-PfbFieldCmdletMap.ps1
 
+      # Position is load-bearing, do not reorder: this must run AFTER "Fetch all published
+      # REST API spec versions" (the generator walks tools/specs/ and never fetches) and
+      # BEFORE "Build API drift report" (the report reads Data/PfbResponseShapeMap.json).
+      # Placed after the report, CI would build the report from the stale committed map and
+      # then overwrite it -- a report and map that disagree, with no error raised.
+      - name: Build response shape map
+        shell: pwsh
+        run: ./tools/Build-PfbResponseShapeMap.ps1
+
       - name: Build API drift report
         shell: pwsh
         run: ./tools/Build-PfbApiDriftReport.ps1
@@ -133,7 +142,13 @@ jobs:
           $queryFieldCount = (@($drift.parameterGaps.missingQueryParameters) | Measure-Object).Count
           $bodyFieldCount = (@($drift.parameterGaps.missingBodyProperties) | Measure-Object).Count
           $readOnlyFieldCount = (@($drift.parameterGaps.readOnlyFields) | Measure-Object).Count
-          $driftSummary = "$($drift.uncoveredEndpoints.Count) uncovered endpoints, $($drift.parameterGaps.Count) endpoints with parameter gaps ($queryFieldCount missing query fields, $bodyFieldCount missing body fields, $readOnlyFieldCount read-only fields), $($drift.systemicGaps.Count) systemic gaps, $($drift.validateSetDrift.Count) ValidateSet drift findings, $($drift.newValidateSetCandidates.Count) new ValidateSet candidates"
+          # Same @() guard as above, for the same reason: ConvertFrom-Json yields a bare
+          # object for a single-element array and $null for a missing key, so a direct
+          # .Count is unreliable for both.
+          $responseRemovalCount = (@($drift.responseFieldRemovals) | Measure-Object).Count
+          $responseRenameCount = (@($drift.responseFieldRenameCandidates) | Measure-Object).Count
+          $unhandledEnvelopeCount = (@($drift.unhandledResponseEnvelopeFields) | Measure-Object).Count
+          $driftSummary = "$($drift.uncoveredEndpoints.Count) uncovered endpoints, $($drift.parameterGaps.Count) endpoints with parameter gaps ($queryFieldCount missing query fields, $bodyFieldCount missing body fields, $readOnlyFieldCount read-only fields), $($drift.systemicGaps.Count) systemic gaps, $($drift.validateSetDrift.Count) ValidateSet drift findings, $($drift.newValidateSetCandidates.Count) new ValidateSet candidates, $responseRemovalCount response field removals (one per endpoint+field pair), $responseRenameCount response field rename candidates, $unhandledEnvelopeCount unhandled response envelope fields"
           "drift_summary=$driftSummary" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
       - name: Open pull request
@@ -154,6 +169,8 @@ jobs:
               `Data/PfbCapabilityMap.json` from the full history.
             - Updated `Data/PfbVersionMap.json` if an `SSOT_API_KEY` secret is
               configured; otherwise left untouched (see `tools/Update-PfbVersionMap.ps1`).
+            - Rebuilt `Data/PfbResponseShapeMap.json`, the response-side counterpart to the
+              capability map, which feeds the drift report's response-shape findings.
             - Rebuilt `Reports/PfbValueEnumMap.json`, `Reports/PfbFieldCmdletMap.json`, and
               `Reports/PfbApiDriftReport.json` (+ their Markdown companions) -- see
               `Reports/README.md` for what each answers.

--- a/Data/PfbResponseShapeMap.json
+++ b/Data/PfbResponseShapeMap.json
@@ -1,0 +1,8932 @@
+{
+  "schemaVersion": 1,
+  "generatedFrom": [
+    "2.0",
+    "2.1",
+    "2.2",
+    "2.3",
+    "2.4",
+    "2.5",
+    "2.6",
+    "2.7",
+    "2.8",
+    "2.9",
+    "2.10",
+    "2.11",
+    "2.12",
+    "2.13",
+    "2.14",
+    "2.15",
+    "2.16",
+    "2.17",
+    "2.18",
+    "2.19",
+    "2.20",
+    "2.21",
+    "2.22",
+    "2.23",
+    "2.24",
+    "2.25",
+    "2.26",
+    "2.27",
+    "2.28"
+  ],
+  "endpoints": {
+    "GET /active-directory": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "ca_certificate": "2.27",
+        "ca_certificate_group": "2.27",
+        "computer_name": "2.0",
+        "directory_servers": "2.0",
+        "domain": "2.0",
+        "encryption_types": "2.0",
+        "global_catalog_servers": "2.12",
+        "id": "2.0",
+        "join_ou": "2.0",
+        "kerberos_servers": "2.0",
+        "name": "2.0",
+        "realms": "2.19",
+        "server": "2.16",
+        "service_principal_names": "2.0"
+      }
+    },
+    "GET /active-directory/test": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.23",
+        "errors": "2.23",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "component_address": "2.0",
+        "component_name": "2.0",
+        "context": "2.23",
+        "description": "2.0",
+        "destination": "2.0",
+        "enabled": "2.0",
+        "resource": "2.0",
+        "result_details": "2.0",
+        "success": "2.0",
+        "test_type": "2.0"
+      }
+    },
+    "GET /admins": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "errors": "2.22",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "admin_type": "2.24",
+        "api_token": "2.0",
+        "authorization_model": "2.24",
+        "context": "2.22",
+        "id": "2.0",
+        "is_local": "2.0",
+        "locked": "2.3",
+        "lockout_remaining": "2.3",
+        "management_access_policies": "2.19",
+        "name": "2.0",
+        "public_key": "2.0",
+        "role": "2.0"
+      }
+    },
+    "GET /admins/api-tokens": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "errors": "2.24",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "admin": "2.0",
+        "api_token": "2.0",
+        "context": "2.24"
+      }
+    },
+    "GET /admins/cache": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "errors": "2.24",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "authorization_model": "2.24",
+        "context": "2.24",
+        "id": "2.0",
+        "management_access_policies": "2.19",
+        "name": "2.0",
+        "role": "2.0",
+        "time": "2.0"
+      }
+    },
+    "GET /admins/management-access-policies": {
+      "minVersion": "2.19",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.19",
+        "errors": "2.24",
+        "items": "2.19",
+        "total_item_count": "2.19"
+      },
+      "responseItemProperties": {
+        "context": "2.24",
+        "member": "2.19",
+        "policy": "2.19"
+      }
+    },
+    "GET /admins/management-authentication-policies": {
+      "minVersion": "2.22",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.22",
+        "errors": "2.22",
+        "items": "2.22",
+        "total_item_count": "2.22"
+      },
+      "responseItemProperties": {
+        "context": "2.22",
+        "member": "2.22",
+        "policy": "2.22"
+      }
+    },
+    "GET /admins/settings": {
+      "minVersion": "2.3",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.3",
+        "items": "2.3",
+        "total_item_count": "2.3"
+      },
+      "responseItemProperties": {
+        "lockout_duration": "2.3",
+        "max_login_attempts": "2.3",
+        "min_password_length": "2.3"
+      }
+    },
+    "GET /admins/ssh-certificate-authority-policies": {
+      "minVersion": "2.14",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.14",
+        "errors": "2.24",
+        "items": "2.14",
+        "total_item_count": "2.14"
+      },
+      "responseItemProperties": {
+        "context": "2.24",
+        "member": "2.14",
+        "policy": "2.14"
+      }
+    },
+    "GET /alert-watchers": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "enabled": "2.0",
+        "id": "2.0",
+        "minimum_notification_severity": "2.0",
+        "name": "2.0"
+      }
+    },
+    "GET /alert-watchers/test": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "component_address": "2.0",
+        "component_name": "2.0",
+        "description": "2.0",
+        "destination": "2.0",
+        "enabled": "2.0",
+        "resource": "2.0",
+        "result_details": "2.0",
+        "success": "2.0",
+        "test_type": "2.0"
+      }
+    },
+    "GET /alerts": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "action": "2.0",
+        "code": "2.0",
+        "component_name": "2.0",
+        "component_type": "2.0",
+        "created": "2.0",
+        "description": "2.0",
+        "duration": "2.20",
+        "flagged": "2.0",
+        "id": "2.0",
+        "index": "2.0",
+        "knowledge_base_url": "2.0",
+        "name": "2.0",
+        "notified": "2.0",
+        "severity": "2.0",
+        "state": "2.0",
+        "summary": "2.0",
+        "updated": "2.0",
+        "variables": "2.0"
+      }
+    },
+    "GET /api-clients": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "access_policies": "2.19",
+        "access_token_ttl_in_ms": "2.0",
+        "enabled": "2.0",
+        "id": "2.0",
+        "issuer": "2.0",
+        "key_id": "2.0",
+        "max_role": "2.0",
+        "name": "2.0",
+        "public_key": "2.0"
+      }
+    },
+    "GET /api/api_version": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "versions": "2.0"
+      },
+      "responseItemProperties": {}
+    },
+    "GET /api/login-banner": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "login_banner": "2.0"
+      },
+      "responseItemProperties": {}
+    },
+    "GET /array-connections": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "errors": "2.17",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "ca_certificate_group": "2.0",
+        "context": "2.17",
+        "encrypted": "2.0",
+        "id": "2.0",
+        "management_address": "2.0",
+        "os": "2.17",
+        "remote": "2.0",
+        "replication_addresses": "2.0",
+        "status": "2.0",
+        "throttle": "2.3",
+        "type": "2.17",
+        "version": "2.0"
+      }
+    },
+    "GET /array-connections/connection-key": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "connection_key": "2.0",
+        "created": "2.0",
+        "expires": "2.0"
+      }
+    },
+    "GET /array-connections/path": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "errors": "2.17",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "destination": "2.0",
+        "id": "2.0",
+        "remote": "2.0",
+        "source": "2.0",
+        "status": "2.0",
+        "status_details": "2.0",
+        "type": "2.17"
+      }
+    },
+    "GET /array-connections/performance/replication": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "items": "2.0",
+        "total": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "aggregate": "2.1",
+        "continuous": "2.1",
+        "id": "2.0",
+        "periodic": "2.0",
+        "remote": "2.0",
+        "time": "2.0"
+      }
+    },
+    "GET /arrays": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "errors": "2.22",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "_as_of": "2.0",
+        "banner": "2.0",
+        "context": "2.22",
+        "default_inbound_tls_policy": "2.17",
+        "encryption": "2.8",
+        "eradication_config": "2.5",
+        "id": "2.0",
+        "idle_timeout": "2.0",
+        "name": "2.0",
+        "network_access_policy": "2.13",
+        "ntp_servers": "2.0",
+        "os": "2.0",
+        "product_type": "2.6",
+        "revision": "2.0",
+        "security_update": "2.7",
+        "smb_mode": "2.2",
+        "time_zone": "2.0",
+        "version": "2.0"
+      }
+    },
+    "GET /arrays/clients/performance": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "errors": "2.17",
+        "items": "2.0",
+        "total": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "bytes_per_op": "2.0",
+        "bytes_per_read": "2.0",
+        "bytes_per_write": "2.0",
+        "name": "2.0",
+        "others_per_sec": "2.0",
+        "read_bytes_per_sec": "2.0",
+        "reads_per_sec": "2.0",
+        "time": "2.0",
+        "usec_per_other_op": "2.0",
+        "usec_per_read_op": "2.0",
+        "usec_per_write_op": "2.0",
+        "write_bytes_per_sec": "2.0",
+        "writes_per_sec": "2.0"
+      }
+    },
+    "GET /arrays/clients/s3-specific-performance": {
+      "minVersion": "2.18",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.18",
+        "items": "2.18",
+        "total": "2.18",
+        "total_item_count": "2.18"
+      },
+      "responseItemProperties": {
+        "name": "2.18",
+        "others_per_sec": "2.18",
+        "read_buckets_per_sec": "2.18",
+        "read_objects_per_sec": "2.18",
+        "time": "2.18",
+        "usec_per_other_op": "2.18",
+        "usec_per_read_bucket_op": "2.18",
+        "usec_per_read_object_op": "2.18",
+        "usec_per_write_bucket_op": "2.18",
+        "usec_per_write_object_op": "2.18",
+        "write_buckets_per_sec": "2.18",
+        "write_objects_per_sec": "2.18"
+      }
+    },
+    "GET /arrays/erasures": {
+      "minVersion": "2.18",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.18",
+        "items": "2.18",
+        "total_item_count": "2.18"
+      },
+      "responseItemProperties": {
+        "details": "2.18",
+        "name": "2.18",
+        "sanitization_certificate": "2.18",
+        "status": "2.18"
+      }
+    },
+    "GET /arrays/eula": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "agreement": "2.0",
+        "signature": "2.0"
+      }
+    },
+    "GET /arrays/factory-reset-token": {
+      "minVersion": "2.1",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.1",
+        "items": "2.1",
+        "total_item_count": "2.1"
+      },
+      "responseItemProperties": {
+        "name": "2.1",
+        "token": "2.1"
+      }
+    },
+    "GET /arrays/http-specific-performance": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "errors": "2.17",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "id": "2.0",
+        "name": "2.0",
+        "others_per_sec": "2.0",
+        "read_dirs_per_sec": "2.0",
+        "read_files_per_sec": "2.0",
+        "time": "2.0",
+        "usec_per_other_op": "2.0",
+        "usec_per_read_dir_op": "2.0",
+        "usec_per_read_file_op": "2.0",
+        "usec_per_write_dir_op": "2.0",
+        "usec_per_write_file_op": "2.0",
+        "write_dirs_per_sec": "2.0",
+        "write_files_per_sec": "2.0"
+      }
+    },
+    "GET /arrays/management-authentication-policies": {
+      "minVersion": "2.22",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.22",
+        "errors": "2.22",
+        "items": "2.22",
+        "total_item_count": "2.22"
+      },
+      "responseItemProperties": {
+        "context": "2.22",
+        "member": "2.22",
+        "policy": "2.22"
+      }
+    },
+    "GET /arrays/nfs-specific-performance": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "errors": "2.17",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "accesses_per_sec": "2.0",
+        "aggregate_file_metadata_creates_per_sec": "2.0",
+        "aggregate_file_metadata_modifies_per_sec": "2.0",
+        "aggregate_file_metadata_reads_per_sec": "2.0",
+        "aggregate_other_per_sec": "2.0",
+        "aggregate_share_metadata_reads_per_sec": "2.0",
+        "aggregate_usec_per_file_metadata_create_op": "2.0",
+        "aggregate_usec_per_file_metadata_modify_op": "2.0",
+        "aggregate_usec_per_file_metadata_read_op": "2.0",
+        "aggregate_usec_per_other_op": "2.0",
+        "aggregate_usec_per_share_metadata_read_op": "2.0",
+        "context": "2.17",
+        "creates_per_sec": "2.0",
+        "fsinfos_per_sec": "2.0",
+        "fsstats_per_sec": "2.0",
+        "getattrs_per_sec": "2.0",
+        "id": "2.0",
+        "links_per_sec": "2.0",
+        "lookups_per_sec": "2.0",
+        "mkdirs_per_sec": "2.0",
+        "name": "2.0",
+        "pathconfs_per_sec": "2.0",
+        "readdirpluses_per_sec": "2.0",
+        "readdirs_per_sec": "2.0",
+        "readlinks_per_sec": "2.0",
+        "reads_per_sec": "2.0",
+        "removes_per_sec": "2.0",
+        "renames_per_sec": "2.0",
+        "rmdirs_per_sec": "2.0",
+        "setattrs_per_sec": "2.0",
+        "symlinks_per_sec": "2.0",
+        "time": "2.0",
+        "usec_per_access_op": "2.0",
+        "usec_per_create_op": "2.0",
+        "usec_per_fsinfo_op": "2.0",
+        "usec_per_fsstat_op": "2.0",
+        "usec_per_getattr_op": "2.0",
+        "usec_per_link_op": "2.0",
+        "usec_per_lookup_op": "2.0",
+        "usec_per_mkdir_op": "2.0",
+        "usec_per_pathconf_op": "2.0",
+        "usec_per_read_op": "2.0",
+        "usec_per_readdir_op": "2.0",
+        "usec_per_readdirplus_op": "2.0",
+        "usec_per_readlink_op": "2.0",
+        "usec_per_remove_op": "2.0",
+        "usec_per_rename_op": "2.0",
+        "usec_per_rmdir_op": "2.0",
+        "usec_per_setattr_op": "2.0",
+        "usec_per_symlink_op": "2.0",
+        "usec_per_write_op": "2.0",
+        "writes_per_sec": "2.0"
+      }
+    },
+    "GET /arrays/performance": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "errors": "2.17",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "bytes_per_op": "2.0",
+        "bytes_per_read": "2.0",
+        "bytes_per_write": "2.0",
+        "context": "2.17",
+        "id": "2.0",
+        "name": "2.0",
+        "others_per_sec": "2.0",
+        "read_bytes_per_sec": "2.0",
+        "reads_per_sec": "2.0",
+        "time": "2.0",
+        "usec_per_other_op": "2.0",
+        "usec_per_read_op": "2.0",
+        "usec_per_write_op": "2.0",
+        "write_bytes_per_sec": "2.0",
+        "writes_per_sec": "2.0"
+      }
+    },
+    "GET /arrays/performance/replication": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "errors": "2.17",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "aggregate": "2.1",
+        "context": "2.17",
+        "continuous": "2.1",
+        "id": "2.0",
+        "periodic": "2.0",
+        "time": "2.0"
+      },
+      "removedResponseFields": [
+        {
+          "field": "remote",
+          "location": "items",
+          "introducedVersion": "2.0",
+          "lastSeenVersion": "2.10"
+        }
+      ]
+    },
+    "GET /arrays/s3-specific-performance": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "errors": "2.17",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "id": "2.0",
+        "name": "2.0",
+        "others_per_sec": "2.0",
+        "read_buckets_per_sec": "2.0",
+        "read_objects_per_sec": "2.0",
+        "time": "2.0",
+        "usec_per_other_op": "2.0",
+        "usec_per_read_bucket_op": "2.0",
+        "usec_per_read_object_op": "2.0",
+        "usec_per_write_bucket_op": "2.0",
+        "usec_per_write_object_op": "2.0",
+        "write_buckets_per_sec": "2.0",
+        "write_objects_per_sec": "2.0"
+      }
+    },
+    "GET /arrays/space": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "errors": "2.17",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "capacity": "2.0",
+        "context": "2.17",
+        "id": "2.0",
+        "name": "2.0",
+        "parity": "2.0",
+        "space": "2.0",
+        "time": "2.0"
+      }
+    },
+    "GET /arrays/space/storage-classes": {
+      "minVersion": "2.16",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.16",
+        "items": "2.16",
+        "total": "2.16",
+        "total_item_count": "2.16"
+      },
+      "responseItemProperties": {
+        "capacity": "2.16",
+        "name": "2.16",
+        "space": "2.16",
+        "time": "2.16"
+      }
+    },
+    "GET /arrays/ssh-certificate-authority-policies": {
+      "minVersion": "2.14",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.14",
+        "errors": "2.24",
+        "items": "2.14",
+        "total_item_count": "2.14"
+      },
+      "responseItemProperties": {
+        "context": "2.24",
+        "member": "2.14",
+        "policy": "2.14"
+      }
+    },
+    "GET /arrays/supported-time-zones": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "name": "2.0"
+      }
+    },
+    "GET /audit-file-systems-policies": {
+      "minVersion": "2.14",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.14",
+        "errors": "2.17",
+        "items": "2.14",
+        "total_item_count": "2.14"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "control_type": "2.18",
+        "enabled": "2.14",
+        "id": "2.14",
+        "is_local": "2.14",
+        "location": "2.14",
+        "log_targets": "2.14",
+        "name": "2.14",
+        "policy_type": "2.14",
+        "realms": "2.19",
+        "rules": "2.18"
+      }
+    },
+    "GET /audit-file-systems-policies/members": {
+      "minVersion": "2.14",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.14",
+        "errors": "2.17",
+        "items": "2.14",
+        "total_item_count": "2.14"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "member": "2.14",
+        "policy": "2.14"
+      }
+    },
+    "GET /audit-file-systems-policy-operations": {
+      "minVersion": "2.18",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.18",
+        "items": "2.18",
+        "total_item_count": "2.18"
+      },
+      "responseItemProperties": {
+        "description": "2.18",
+        "name": "2.18"
+      }
+    },
+    "GET /audit-object-store-policies": {
+      "minVersion": "2.20",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.20",
+        "errors": "2.20",
+        "items": "2.20",
+        "total_item_count": "2.20"
+      },
+      "responseItemProperties": {
+        "context": "2.20",
+        "enabled": "2.20",
+        "id": "2.20",
+        "is_local": "2.20",
+        "location": "2.20",
+        "log_targets": "2.20",
+        "name": "2.20",
+        "policy_type": "2.20",
+        "realms": "2.20"
+      }
+    },
+    "GET /audit-object-store-policies/members": {
+      "minVersion": "2.20",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.20",
+        "errors": "2.20",
+        "items": "2.20",
+        "total_item_count": "2.20"
+      },
+      "responseItemProperties": {
+        "context": "2.20",
+        "member": "2.20",
+        "policy": "2.20"
+      }
+    },
+    "GET /audits": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "errors": "2.28",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "arguments": "2.0",
+        "command": "2.0",
+        "context": "2.28",
+        "correlation_id": "2.28",
+        "id": "2.0",
+        "ip_address": "2.0",
+        "name": "2.0",
+        "origin": "2.17",
+        "scopes": "2.20",
+        "subcommand": "2.0",
+        "system_event": "2.28",
+        "time": "2.0",
+        "user": "2.0",
+        "user_agent": "2.0",
+        "user_interface": "2.0"
+      }
+    },
+    "GET /blades": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "items": "2.0",
+        "total": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "details": "2.0",
+        "id": "2.0",
+        "name": "2.0",
+        "progress": "2.0",
+        "raw_capacity": "2.0",
+        "status": "2.0",
+        "target": "2.0"
+      }
+    },
+    "GET /bucket-audit-filter-actions": {
+      "minVersion": "2.20",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.20",
+        "errors": "2.20",
+        "items": "2.20",
+        "total_item_count": "2.20"
+      },
+      "responseItemProperties": {
+        "context": "2.20",
+        "description": "2.20",
+        "name": "2.20"
+      }
+    },
+    "GET /bucket-replica-links": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "errors": "2.17",
+        "items": "2.0",
+        "total": "2.2",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "cascading_enabled": "2.2",
+        "context": "2.17",
+        "direction": "2.0",
+        "id": "2.0",
+        "lag": "2.0",
+        "local_bucket": "2.0",
+        "object_backlog": "2.2",
+        "paused": "2.0",
+        "recovery_point": "2.0",
+        "remote": "2.0",
+        "remote_bucket": "2.0",
+        "remote_credentials": "2.0",
+        "status": "2.0",
+        "status_details": "2.0"
+      }
+    },
+    "GET /buckets": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "errors": "2.17",
+        "items": "2.0",
+        "total": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "account": "2.0",
+        "bucket_type": "2.4",
+        "context": "2.17",
+        "created": "2.0",
+        "destroyed": "2.0",
+        "eradication_config": "2.8",
+        "hard_limit_enabled": "2.8",
+        "id": "2.0",
+        "name": "2.0",
+        "object_count": "2.0",
+        "object_lock_config": "2.8",
+        "public_access_config": "2.12",
+        "public_status": "2.12",
+        "qos_policy": "2.20",
+        "quota_limit": "2.8",
+        "retention_lock": "2.8",
+        "space": "2.0",
+        "storage_class": "2.19",
+        "time_remaining": "2.0",
+        "time_remaining_status": "2.14",
+        "versioning": "2.0"
+      }
+    },
+    "GET /buckets/audit-filters": {
+      "minVersion": "2.20",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.20",
+        "errors": "2.20",
+        "items": "2.20",
+        "total_item_count": "2.20"
+      },
+      "responseItemProperties": {
+        "actions": "2.20",
+        "bucket": "2.20",
+        "context": "2.20",
+        "name": "2.20",
+        "s3_prefixes": "2.20"
+      }
+    },
+    "GET /buckets/bucket-access-policies": {
+      "minVersion": "2.12",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.12",
+        "errors": "2.17",
+        "items": "2.12",
+        "total_item_count": "2.12"
+      },
+      "responseItemProperties": {
+        "bucket": "2.12",
+        "context": "2.17",
+        "enabled": "2.12",
+        "id": "2.12",
+        "is_local": "2.12",
+        "location": "2.12",
+        "name": "2.12",
+        "policy_type": "2.12",
+        "realms": "2.19",
+        "rules": "2.12"
+      }
+    },
+    "GET /buckets/bucket-access-policies/rules": {
+      "minVersion": "2.12",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.12",
+        "errors": "2.17",
+        "items": "2.12",
+        "total_item_count": "2.12"
+      },
+      "responseItemProperties": {
+        "actions": "2.12",
+        "context": "2.17",
+        "effect": "2.12",
+        "name": "2.12",
+        "policy": "2.12",
+        "principals": "2.12",
+        "resources": "2.12"
+      }
+    },
+    "GET /buckets/cross-origin-resource-sharing-policies": {
+      "minVersion": "2.12",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.12",
+        "errors": "2.17",
+        "items": "2.12",
+        "total_item_count": "2.12"
+      },
+      "responseItemProperties": {
+        "bucket": "2.12",
+        "context": "2.17",
+        "enabled": "2.12",
+        "id": "2.12",
+        "is_local": "2.12",
+        "location": "2.12",
+        "name": "2.12",
+        "policy_type": "2.12",
+        "realms": "2.19",
+        "rules": "2.12"
+      }
+    },
+    "GET /buckets/cross-origin-resource-sharing-policies/rules": {
+      "minVersion": "2.12",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.12",
+        "errors": "2.17",
+        "items": "2.12",
+        "total_item_count": "2.12"
+      },
+      "responseItemProperties": {
+        "allowed_headers": "2.12",
+        "allowed_methods": "2.12",
+        "allowed_origins": "2.12",
+        "context": "2.17",
+        "name": "2.12",
+        "policy": "2.12"
+      }
+    },
+    "GET /buckets/performance": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "items": "2.0",
+        "total": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "bytes_per_op": "2.0",
+        "bytes_per_read": "2.0",
+        "bytes_per_write": "2.0",
+        "id": "2.0",
+        "max_total_bytes_per_sec": "2.19",
+        "max_total_ops_per_sec": "2.19",
+        "name": "2.0",
+        "others_per_sec": "2.0",
+        "read_bytes_per_sec": "2.0",
+        "reads_per_sec": "2.0",
+        "time": "2.0",
+        "usec_per_other_op": "2.0",
+        "usec_per_read_op": "2.0",
+        "usec_per_write_op": "2.0",
+        "write_bytes_per_sec": "2.0",
+        "writes_per_sec": "2.0"
+      }
+    },
+    "GET /buckets/s3-specific-performance": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "items": "2.0",
+        "total": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "id": "2.0",
+        "name": "2.0",
+        "others_per_sec": "2.0",
+        "read_buckets_per_sec": "2.0",
+        "read_objects_per_sec": "2.0",
+        "time": "2.0",
+        "usec_per_other_op": "2.0",
+        "usec_per_read_bucket_op": "2.0",
+        "usec_per_read_object_op": "2.0",
+        "usec_per_write_bucket_op": "2.0",
+        "usec_per_write_object_op": "2.0",
+        "write_buckets_per_sec": "2.0",
+        "write_objects_per_sec": "2.0"
+      }
+    },
+    "GET /certificate-groups": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "id": "2.0",
+        "name": "2.0",
+        "realms": "2.19"
+      }
+    },
+    "GET /certificate-groups/certificates": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "group": "2.0",
+        "member": "2.0"
+      }
+    },
+    "GET /certificate-groups/uses": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "id": "2.0",
+        "name": "2.0",
+        "use": "2.0"
+      }
+    },
+    "GET /certificates": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "certificate": "2.0",
+        "certificate_type": "2.0",
+        "common_name": "2.0",
+        "country": "2.0",
+        "email": "2.0",
+        "id": "2.0",
+        "intermediate_certificate": "2.0",
+        "issued_by": "2.0",
+        "issued_to": "2.0",
+        "key_algorithm": "2.20",
+        "key_size": "2.0",
+        "locality": "2.0",
+        "name": "2.0",
+        "organization": "2.0",
+        "organizational_unit": "2.0",
+        "realms": "2.19",
+        "state": "2.0",
+        "status": "2.0",
+        "subject_alternative_names": "2.0",
+        "valid_from": "2.0",
+        "valid_to": "2.0"
+      }
+    },
+    "GET /certificates/certificate-groups": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "group": "2.0",
+        "member": "2.0"
+      }
+    },
+    "GET /certificates/uses": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "group": "2.0",
+        "id": "2.0",
+        "name": "2.0",
+        "use": "2.0"
+      }
+    },
+    "GET /data-eviction-policies": {
+      "minVersion": "2.21",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.21",
+        "errors": "2.21",
+        "items": "2.21",
+        "total_item_count": "2.21"
+      },
+      "responseItemProperties": {
+        "context": "2.21",
+        "enabled": "2.21",
+        "id": "2.21",
+        "is_local": "2.21",
+        "keep_size": "2.21",
+        "location": "2.21",
+        "name": "2.21",
+        "policy_type": "2.21",
+        "realms": "2.21"
+      }
+    },
+    "GET /data-eviction-policies/file-systems": {
+      "minVersion": "2.21",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.21",
+        "errors": "2.21",
+        "items": "2.21",
+        "total_item_count": "2.21"
+      },
+      "responseItemProperties": {
+        "context": "2.21",
+        "member": "2.21",
+        "policy": "2.21"
+      }
+    },
+    "GET /data-eviction-policies/members": {
+      "minVersion": "2.21",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.21",
+        "errors": "2.21",
+        "items": "2.21",
+        "total_item_count": "2.21"
+      },
+      "responseItemProperties": {
+        "context": "2.21",
+        "member": "2.21",
+        "policy": "2.21"
+      }
+    },
+    "GET /directory-services": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "base_dn": "2.0",
+        "bind_password": "2.0",
+        "bind_user": "2.0",
+        "ca_certificate": "2.0",
+        "ca_certificate_group": "2.0",
+        "enabled": "2.0",
+        "id": "2.0",
+        "management": "2.0",
+        "name": "2.0",
+        "nfs": "2.0",
+        "services": "2.0",
+        "smb": "2.0",
+        "uris": "2.0"
+      }
+    },
+    "GET /directory-services/local/directory-services": {
+      "minVersion": "2.24",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.24",
+        "errors": "2.24",
+        "items": "2.24",
+        "total_item_count": "2.24"
+      },
+      "responseItemProperties": {
+        "context": "2.24",
+        "destroyed": "2.24",
+        "domain": "2.24",
+        "id": "2.24",
+        "name": "2.24",
+        "realms": "2.24",
+        "server": "2.24",
+        "time_remaining": "2.24"
+      }
+    },
+    "GET /directory-services/local/groups": {
+      "minVersion": "2.24",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.24",
+        "errors": "2.24",
+        "items": "2.24",
+        "total_item_count": "2.24"
+      },
+      "responseItemProperties": {
+        "built_in": "2.24",
+        "context": "2.24",
+        "email": "2.24",
+        "gid": "2.24",
+        "local_directory_service": "2.24",
+        "name": "2.24",
+        "realms": "2.24",
+        "server": "2.24",
+        "sid": "2.24"
+      }
+    },
+    "GET /directory-services/local/groups/members": {
+      "minVersion": "2.24",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.24",
+        "errors": "2.24",
+        "items": "2.24",
+        "total_item_count": "2.24"
+      },
+      "responseItemProperties": {
+        "context": "2.24",
+        "group": "2.24",
+        "group_gid": "2.24",
+        "is_primary_group": "2.24",
+        "local_directory_service": "2.24",
+        "member": "2.24",
+        "member_id": "2.24",
+        "realms": "2.24",
+        "server": "2.24"
+      }
+    },
+    "GET /directory-services/local/users": {
+      "minVersion": "2.24",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.24",
+        "errors": "2.24",
+        "items": "2.24",
+        "total_item_count": "2.24"
+      },
+      "responseItemProperties": {
+        "built_in": "2.24",
+        "context": "2.24",
+        "email": "2.24",
+        "enabled": "2.24",
+        "local_directory_service": "2.24",
+        "name": "2.24",
+        "primary_group": "2.24",
+        "realms": "2.24",
+        "server": "2.24",
+        "sid": "2.24",
+        "uid": "2.24"
+      }
+    },
+    "GET /directory-services/local/users/members": {
+      "minVersion": "2.24",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.24",
+        "errors": "2.24",
+        "items": "2.24",
+        "total_item_count": "2.24"
+      },
+      "responseItemProperties": {
+        "context": "2.24",
+        "group": "2.24",
+        "group_gid": "2.24",
+        "is_primary_group": "2.24",
+        "local_directory_service": "2.24",
+        "member": "2.24",
+        "member_id": "2.24",
+        "realms": "2.24",
+        "server": "2.24"
+      }
+    },
+    "GET /directory-services/roles": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "group": "2.0",
+        "group_base": "2.0",
+        "id": "2.0",
+        "management_access_policies": "2.19",
+        "name": "2.14",
+        "role": "2.0"
+      }
+    },
+    "GET /directory-services/roles/management-access-policies": {
+      "minVersion": "2.19",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.19",
+        "items": "2.19",
+        "total_item_count": "2.19"
+      },
+      "responseItemProperties": {
+        "member": "2.19",
+        "policy": "2.19"
+      }
+    },
+    "GET /directory-services/test": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.23",
+        "errors": "2.23",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "component_address": "2.0",
+        "component_name": "2.0",
+        "context": "2.23",
+        "description": "2.0",
+        "destination": "2.0",
+        "enabled": "2.0",
+        "resource": "2.0",
+        "result_details": "2.0",
+        "success": "2.0",
+        "test_type": "2.0"
+      }
+    },
+    "GET /dns": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "errors": "2.25",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "ca_certificate": "2.25",
+        "ca_certificate_group": "2.25",
+        "context": "2.25",
+        "domain": "2.0",
+        "id": "2.0",
+        "name": "2.0",
+        "nameservers": "2.0",
+        "realms": "2.19",
+        "services": "2.16",
+        "sources": "2.16"
+      }
+    },
+    "GET /drives": {
+      "minVersion": "2.4",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.4",
+        "items": "2.4",
+        "total": "2.4",
+        "total_item_count": "2.4"
+      },
+      "responseItemProperties": {
+        "details": "2.4",
+        "id": "2.4",
+        "name": "2.4",
+        "progress": "2.4",
+        "raw_capacity": "2.4",
+        "status": "2.4",
+        "type": "2.9"
+      }
+    },
+    "GET /file-system-exports": {
+      "minVersion": "2.16",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.16",
+        "errors": "2.17",
+        "items": "2.16",
+        "total_item_count": "2.16"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "enabled": "2.16",
+        "export_name": "2.16",
+        "id": "2.16",
+        "member": "2.16",
+        "name": "2.16",
+        "policy": "2.16",
+        "policy_type": "2.16",
+        "server": "2.16",
+        "share_policy": "2.16",
+        "status": "2.16",
+        "workload": "2.23"
+      }
+    },
+    "GET /file-system-group-quotas": {
+      "minVersion": "2.25",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.25",
+        "errors": "2.25",
+        "items": "2.25",
+        "total_item_count": "2.25"
+      },
+      "responseItemProperties": {
+        "context": "2.25",
+        "file_system": "2.25",
+        "group": "2.25",
+        "percentage_used": "2.25",
+        "policy_rule": "2.25",
+        "usage": "2.25"
+      }
+    },
+    "GET /file-system-junctions": {
+      "minVersion": "2.25",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.25",
+        "errors": "2.25",
+        "items": "2.25",
+        "total_item_count": "2.25"
+      },
+      "responseItemProperties": {
+        "context": "2.25",
+        "destination_file_system": "2.25",
+        "id": "2.25",
+        "junction_origin_path": "2.25",
+        "name": "2.25",
+        "origin_file_system": "2.25",
+        "status": "2.25"
+      }
+    },
+    "GET /file-system-replica-links": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "errors": "2.17",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "direction": "2.0",
+        "id": "2.0",
+        "lag": "2.0",
+        "link_type": "2.17",
+        "local_file_system": "2.0",
+        "policies": "2.0",
+        "recovery_point": "2.0",
+        "remote": "2.0",
+        "remote_file_system": "2.0",
+        "status": "2.0",
+        "status_details": "2.0"
+      }
+    },
+    "GET /file-system-replica-links/policies": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "context": "2.22",
+        "continuation_token": "2.0",
+        "errors": "2.17",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "link": "2.0",
+        "member": "2.0",
+        "policy": "2.0"
+      }
+    },
+    "GET /file-system-replica-links/transfer": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "errors": "2.17",
+        "items": "2.0",
+        "total": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "completed": "2.0",
+        "context": "2.17",
+        "data_transferred": "2.0",
+        "direction": "2.0",
+        "id": "2.0",
+        "local_snapshot": "2.10",
+        "name": "2.0",
+        "progress": "2.0",
+        "remote": "2.0",
+        "remote_snapshot": "2.0",
+        "started": "2.0",
+        "status": "2.0"
+      }
+    },
+    "GET /file-system-snapshots": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "errors": "2.17",
+        "items": "2.0",
+        "total": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "created": "2.0",
+        "destroyed": "2.0",
+        "id": "2.0",
+        "name": "2.0",
+        "owner": "2.0",
+        "owner_destroyed": "2.0",
+        "policies": "2.12",
+        "policy": "2.0",
+        "source": "2.0",
+        "suffix": "2.0",
+        "time_remaining": "2.0"
+      },
+      "removedResponseFields": [
+        {
+          "field": "copyable",
+          "location": "items",
+          "introducedVersion": "2.0",
+          "lastSeenVersion": "2.10"
+        }
+      ]
+    },
+    "GET /file-system-snapshots/policies": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "errors": "2.17",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "member": "2.0",
+        "policy": "2.0"
+      }
+    },
+    "GET /file-system-snapshots/transfer": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "errors": "2.17",
+        "items": "2.0",
+        "total": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "completed": "2.0",
+        "context": "2.17",
+        "data_transferred": "2.0",
+        "direction": "2.0",
+        "id": "2.0",
+        "local_snapshot": "2.10",
+        "name": "2.0",
+        "progress": "2.0",
+        "remote": "2.0",
+        "remote_snapshot": "2.0",
+        "started": "2.0",
+        "status": "2.0"
+      }
+    },
+    "GET /file-system-user-quotas": {
+      "minVersion": "2.25",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.25",
+        "errors": "2.25",
+        "items": "2.25",
+        "total_item_count": "2.25"
+      },
+      "responseItemProperties": {
+        "context": "2.25",
+        "file_system": "2.25",
+        "percentage_used": "2.25",
+        "policy_rule": "2.25",
+        "usage": "2.25",
+        "user": "2.25"
+      }
+    },
+    "GET /file-systems": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "errors": "2.17",
+        "items": "2.0",
+        "total": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "created": "2.0",
+        "default_group_quota": "2.0",
+        "default_user_quota": "2.0",
+        "destroyed": "2.0",
+        "eradication_config": "2.15",
+        "fast_remove_directory_enabled": "2.0",
+        "group_ownership": "2.13",
+        "hard_limit_enabled": "2.0",
+        "http": "2.0",
+        "id": "2.0",
+        "multi_protocol": "2.0",
+        "name": "2.0",
+        "nfs": "2.0",
+        "node_group": "2.18",
+        "promotion_status": "2.0",
+        "provisioned": "2.0",
+        "qos_policy": "2.17",
+        "realms": "2.19",
+        "requested_promotion_state": "2.0",
+        "smb": "2.0",
+        "snapshot_directory_enabled": "2.0",
+        "source": "2.0",
+        "space": "2.0",
+        "storage_class": "2.16",
+        "time_remaining": "2.0",
+        "workload": "2.23",
+        "writable": "2.0"
+      }
+    },
+    "GET /file-systems/audit-policies": {
+      "minVersion": "2.14",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.14",
+        "errors": "2.17",
+        "items": "2.14",
+        "total_item_count": "2.14"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "member": "2.14",
+        "policy": "2.14"
+      }
+    },
+    "GET /file-systems/data-eviction-policies": {
+      "minVersion": "2.21",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.21",
+        "errors": "2.21",
+        "items": "2.21",
+        "total_item_count": "2.21"
+      },
+      "responseItemProperties": {
+        "context": "2.21",
+        "member": "2.21",
+        "policy": "2.21"
+      }
+    },
+    "GET /file-systems/groups": {
+      "minVersion": "2.25",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.25",
+        "errors": "2.25",
+        "items": "2.25",
+        "total_item_count": "2.25"
+      },
+      "responseItemProperties": {
+        "context": "2.25",
+        "file_system": "2.25",
+        "group": "2.25",
+        "limited_by": "2.25",
+        "percentage_used": "2.25",
+        "quota_limit": "2.25",
+        "usage": "2.25"
+      }
+    },
+    "GET /file-systems/groups/performance": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0",
+        "total": "2.0"
+      },
+      "responseItemProperties": {
+        "bytes_per_op": "2.0",
+        "bytes_per_read": "2.0",
+        "bytes_per_write": "2.0",
+        "file_system": "2.0",
+        "group": "2.0",
+        "name": "2.0",
+        "others_per_sec": "2.0",
+        "read_bytes_per_sec": "2.0",
+        "reads_per_sec": "2.0",
+        "time": "2.0",
+        "usec_per_other_op": "2.0",
+        "usec_per_read_op": "2.0",
+        "usec_per_write_op": "2.0",
+        "write_bytes_per_sec": "2.0",
+        "writes_per_sec": "2.0"
+      }
+    },
+    "GET /file-systems/locks": {
+      "minVersion": "2.8",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.8",
+        "errors": "2.22",
+        "items": "2.8",
+        "total_item_count": "2.8"
+      },
+      "responseItemProperties": {
+        "access_type": "2.8",
+        "client": "2.8",
+        "context": "2.22",
+        "created_at": "2.8",
+        "inode": "2.8",
+        "name": "2.8",
+        "path": "2.8",
+        "protocol": "2.8",
+        "range": "2.8",
+        "source": "2.8"
+      }
+    },
+    "GET /file-systems/locks/clients": {
+      "minVersion": "2.8",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.8",
+        "errors": "2.22",
+        "items": "2.8",
+        "total_item_count": "2.8"
+      },
+      "responseItemProperties": {
+        "context": "2.22",
+        "name": "2.8"
+      }
+    },
+    "GET /file-systems/open-files": {
+      "minVersion": "2.17",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.17",
+        "items": "2.17",
+        "total_item_count": "2.17"
+      },
+      "responseItemProperties": {
+        "client": "2.17",
+        "id": "2.17",
+        "lock_count": "2.17",
+        "mode": "2.17",
+        "path": "2.17",
+        "session": "2.17",
+        "source": "2.17",
+        "user": "2.17"
+      }
+    },
+    "GET /file-systems/performance": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "items": "2.0",
+        "total": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "bytes_per_op": "2.0",
+        "bytes_per_read": "2.0",
+        "bytes_per_write": "2.0",
+        "id": "2.0",
+        "name": "2.0",
+        "others_per_sec": "2.0",
+        "read_bytes_per_sec": "2.0",
+        "reads_per_sec": "2.0",
+        "time": "2.0",
+        "usec_per_other_op": "2.0",
+        "usec_per_read_op": "2.0",
+        "usec_per_write_op": "2.0",
+        "write_bytes_per_sec": "2.0",
+        "writes_per_sec": "2.0"
+      }
+    },
+    "GET /file-systems/policies": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "errors": "2.17",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "member": "2.0",
+        "policy": "2.0"
+      }
+    },
+    "GET /file-systems/policies-all": {
+      "minVersion": "2.3",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.3",
+        "errors": "2.17",
+        "items": "2.3",
+        "total_item_count": "2.3"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "member": "2.3",
+        "policy": "2.3"
+      }
+    },
+    "GET /file-systems/sessions": {
+      "minVersion": "2.10",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.10",
+        "errors": "2.22",
+        "items": "2.10",
+        "total_item_count": "2.10"
+      },
+      "responseItemProperties": {
+        "authentication": "2.10",
+        "client": "2.10",
+        "connection_time": "2.10",
+        "context": "2.22",
+        "idle_time": "2.10",
+        "name": "2.10",
+        "opens": "2.10",
+        "port": "2.10",
+        "protocol": "2.10",
+        "time": "2.10",
+        "user": "2.10"
+      }
+    },
+    "GET /file-systems/space/storage-classes": {
+      "minVersion": "2.18",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.18",
+        "items": "2.18",
+        "total": "2.18",
+        "total_item_count": "2.18"
+      },
+      "responseItemProperties": {
+        "id": "2.18",
+        "name": "2.18",
+        "space": "2.18",
+        "storage_class": "2.18",
+        "time": "2.18"
+      }
+    },
+    "GET /file-systems/user-group-quota-policies": {
+      "minVersion": "2.25",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.25",
+        "errors": "2.25",
+        "items": "2.25",
+        "total_item_count": "2.25"
+      },
+      "responseItemProperties": {
+        "context": "2.25",
+        "member": "2.25",
+        "policy": "2.25"
+      }
+    },
+    "GET /file-systems/users": {
+      "minVersion": "2.25",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.25",
+        "errors": "2.25",
+        "items": "2.25",
+        "total_item_count": "2.25"
+      },
+      "responseItemProperties": {
+        "context": "2.25",
+        "file_system": "2.25",
+        "limited_by": "2.25",
+        "percentage_used": "2.25",
+        "quota_limit": "2.25",
+        "usage": "2.25",
+        "user": "2.25"
+      }
+    },
+    "GET /file-systems/users/performance": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0",
+        "total": "2.0"
+      },
+      "responseItemProperties": {
+        "bytes_per_op": "2.0",
+        "bytes_per_read": "2.0",
+        "bytes_per_write": "2.0",
+        "file_system": "2.0",
+        "name": "2.0",
+        "others_per_sec": "2.0",
+        "read_bytes_per_sec": "2.0",
+        "reads_per_sec": "2.0",
+        "time": "2.0",
+        "usec_per_other_op": "2.0",
+        "usec_per_read_op": "2.0",
+        "usec_per_write_op": "2.0",
+        "user": "2.0",
+        "write_bytes_per_sec": "2.0",
+        "writes_per_sec": "2.0"
+      }
+    },
+    "GET /file-systems/worm-data-policies": {
+      "minVersion": "2.15",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.15",
+        "errors": "2.17",
+        "items": "2.15",
+        "total_item_count": "2.15"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "member": "2.15",
+        "policy": "2.15"
+      }
+    },
+    "GET /fleets": {
+      "minVersion": "2.17",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.17",
+        "items": "2.17",
+        "total_item_count": "2.17"
+      },
+      "responseItemProperties": {
+        "id": "2.17",
+        "is_local": "2.17",
+        "name": "2.17"
+      }
+    },
+    "GET /fleets/fleet-key": {
+      "minVersion": "2.17",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.17",
+        "items": "2.17",
+        "total_item_count": "2.17"
+      },
+      "responseItemProperties": {
+        "created": "2.17",
+        "expires": "2.17",
+        "fleet_key": "2.17"
+      }
+    },
+    "GET /fleets/members": {
+      "minVersion": "2.17",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.17",
+        "items": "2.17",
+        "total_item_count": "2.17"
+      },
+      "responseItemProperties": {
+        "coordinator_of": "2.20",
+        "fleet": "2.17",
+        "member": "2.17",
+        "status": "2.17",
+        "status_details": "2.17"
+      }
+    },
+    "GET /hardware": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "data_mac": "2.16",
+        "details": "2.0",
+        "id": "2.0",
+        "identify_enabled": "2.0",
+        "index": "2.0",
+        "management_mac": "2.16",
+        "model": "2.0",
+        "name": "2.0",
+        "part_number": "2.8",
+        "sensor_readings": "2.18",
+        "serial": "2.0",
+        "slot": "2.0",
+        "speed": "2.0",
+        "status": "2.0",
+        "temperature": "2.0",
+        "type": "2.0"
+      }
+    },
+    "GET /hardware-connectors": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "connector_type": "2.0",
+        "id": "2.0",
+        "lane_speed": "2.0",
+        "lanes_per_port": "2.20",
+        "name": "2.0",
+        "port_count": "2.0",
+        "port_speed": "2.15",
+        "transceiver_type": "2.0"
+      }
+    },
+    "GET /hardware-connectors/performance": {
+      "minVersion": "2.3",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.3",
+        "items": "2.3",
+        "total": "2.3",
+        "total_item_count": "2.3"
+      },
+      "responseItemProperties": {
+        "id": "2.3",
+        "link_aggregation_group": "2.3",
+        "name": "2.3",
+        "other_errors_per_sec": "2.3",
+        "received_bytes_per_sec": "2.3",
+        "received_crc_errors_per_sec": "2.3",
+        "received_frame_errors_per_sec": "2.3",
+        "received_packets_per_sec": "2.3",
+        "time": "2.3",
+        "total_errors_per_sec": "2.3",
+        "transmitted_bytes_per_sec": "2.3",
+        "transmitted_carrier_errors_per_sec": "2.3",
+        "transmitted_dropped_errors_per_sec": "2.3",
+        "transmitted_packets_per_sec": "2.3"
+      }
+    },
+    "GET /keytabs": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "encryption_type": "2.0",
+        "fqdn": "2.0",
+        "id": "2.0",
+        "kvno": "2.0",
+        "name": "2.0",
+        "prefix": "2.0",
+        "principal": "2.0",
+        "realm": "2.0",
+        "server": "2.16",
+        "source": "2.0",
+        "suffix": "2.0"
+      }
+    },
+    "GET /keytabs/download": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {},
+      "responseItemProperties": {}
+    },
+    "GET /kmip": {
+      "minVersion": "2.1",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.1"
+      },
+      "responseItemProperties": {
+        "ca_certificate": "2.1",
+        "ca_certificate_group": "2.1",
+        "id": "2.1",
+        "name": "2.1",
+        "uris": "2.1"
+      }
+    },
+    "GET /kmip/test": {
+      "minVersion": "2.1",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.1"
+      },
+      "responseItemProperties": {
+        "component_address": "2.1",
+        "component_name": "2.1",
+        "description": "2.1",
+        "destination": "2.1",
+        "enabled": "2.1",
+        "resource": "2.1",
+        "result_details": "2.1",
+        "success": "2.1",
+        "test_type": "2.1"
+      }
+    },
+    "GET /legal-holds": {
+      "minVersion": "2.17",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.17",
+        "items": "2.17",
+        "total_item_count": "2.17"
+      },
+      "responseItemProperties": {
+        "description": "2.17",
+        "id": "2.17",
+        "name": "2.17",
+        "realms": "2.19"
+      }
+    },
+    "GET /legal-holds/held-entities": {
+      "minVersion": "2.17",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.17",
+        "items": "2.17",
+        "total_item_count": "2.17"
+      },
+      "responseItemProperties": {
+        "file_system": "2.17",
+        "legal_hold": "2.17",
+        "path": "2.17",
+        "status": "2.17"
+      }
+    },
+    "GET /lifecycle-rules": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "errors": "2.17",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "abort_incomplete_multipart_uploads_after": "2.1",
+        "bucket": "2.0",
+        "cleanup_expired_object_delete_marker": "2.1",
+        "context": "2.17",
+        "enabled": "2.0",
+        "id": "2.0",
+        "keep_current_version_for": "2.1",
+        "keep_current_version_until": "2.1",
+        "keep_previous_version_for": "2.0",
+        "name": "2.0",
+        "prefix": "2.0",
+        "rule_id": "2.0"
+      }
+    },
+    "GET /link-aggregation-groups": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "id": "2.0",
+        "lag_speed": "2.0",
+        "mac_address": "2.0",
+        "name": "2.0",
+        "port_speed": "2.0",
+        "ports": "2.0",
+        "status": "2.0"
+      }
+    },
+    "GET /log-targets/file-systems": {
+      "minVersion": "2.20",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.20",
+        "items": "2.20",
+        "total_item_count": "2.20"
+      },
+      "responseItemProperties": {
+        "file_system": "2.20",
+        "id": "2.20",
+        "keep_for": "2.20",
+        "keep_size": "2.20",
+        "name": "2.20"
+      }
+    },
+    "GET /log-targets/object-store": {
+      "minVersion": "2.20",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.20",
+        "errors": "2.20",
+        "items": "2.20",
+        "total_item_count": "2.20"
+      },
+      "responseItemProperties": {
+        "bucket": "2.20",
+        "context": "2.20",
+        "id": "2.20",
+        "log_name_prefix": "2.20",
+        "log_rotate": "2.20",
+        "name": "2.20"
+      }
+    },
+    "GET /logs": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {},
+      "responseItemProperties": {}
+    },
+    "GET /logs-async": {
+      "minVersion": "2.4",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.4",
+        "items": "2.4",
+        "total_item_count": "2.4"
+      },
+      "responseItemProperties": {
+        "available_files": "2.4",
+        "end_time": "2.4",
+        "hardware_components": "2.4",
+        "id": "2.4",
+        "last_request_time": "2.4",
+        "name": "2.4",
+        "processing": "2.4",
+        "progress": "2.4",
+        "start_time": "2.4"
+      }
+    },
+    "GET /logs-async/download": {
+      "minVersion": "2.4",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {},
+      "responseItemProperties": {}
+    },
+    "GET /maintenance-windows": {
+      "minVersion": "2.16",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.16",
+        "items": "2.16",
+        "total_item_count": "2.16"
+      },
+      "responseItemProperties": {
+        "created": "2.16",
+        "expires": "2.16",
+        "id": "2.16",
+        "name": "2.16"
+      }
+    },
+    "GET /management-access-policies": {
+      "minVersion": "2.19",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.19",
+        "errors": "2.24",
+        "items": "2.19",
+        "total_item_count": "2.19"
+      },
+      "responseItemProperties": {
+        "aggregation_strategy": "2.19",
+        "context": "2.24",
+        "enabled": "2.19",
+        "id": "2.19",
+        "is_local": "2.19",
+        "location": "2.19",
+        "name": "2.19",
+        "policy_type": "2.19",
+        "realms": "2.19",
+        "rules": "2.19",
+        "version": "2.19"
+      }
+    },
+    "GET /management-access-policies/admins": {
+      "minVersion": "2.19",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.19",
+        "errors": "2.24",
+        "items": "2.19",
+        "total_item_count": "2.19"
+      },
+      "responseItemProperties": {
+        "context": "2.24",
+        "member": "2.19",
+        "policy": "2.19"
+      }
+    },
+    "GET /management-access-policies/directory-services/roles": {
+      "minVersion": "2.19",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.19",
+        "items": "2.19",
+        "total_item_count": "2.19"
+      },
+      "responseItemProperties": {
+        "member": "2.19",
+        "policy": "2.19"
+      }
+    },
+    "GET /management-access-policies/members": {
+      "minVersion": "2.19",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.19",
+        "errors": "2.24",
+        "items": "2.19",
+        "total_item_count": "2.19"
+      },
+      "responseItemProperties": {
+        "context": "2.24",
+        "member": "2.19",
+        "policy": "2.19"
+      }
+    },
+    "GET /management-access-policies/roles": {
+      "minVersion": "2.26",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.26",
+        "errors": "2.26",
+        "items": "2.26",
+        "total_item_count": "2.26"
+      },
+      "responseItemProperties": {
+        "context": "2.26",
+        "description": "2.26",
+        "id": "2.26",
+        "name": "2.26",
+        "pure_defined": "2.26"
+      }
+    },
+    "GET /management-access-policies/roles/permissions": {
+      "minVersion": "2.26",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.26",
+        "errors": "2.26",
+        "items": "2.26",
+        "total_item_count": "2.26"
+      },
+      "responseItemProperties": {
+        "actions": "2.26",
+        "context": "2.26",
+        "id": "2.26",
+        "name": "2.26",
+        "resource": "2.26",
+        "role": "2.26"
+      }
+    },
+    "GET /management-access-policies/roles/permissions/supported-resources": {
+      "minVersion": "2.26",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.26",
+        "errors": "2.26",
+        "items": "2.26",
+        "total_item_count": "2.26"
+      },
+      "responseItemProperties": {
+        "context": "2.26",
+        "description": "2.26",
+        "name": "2.26",
+        "supported_actions": "2.26"
+      }
+    },
+    "GET /management-access-policies/rules": {
+      "minVersion": "2.26",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.26",
+        "errors": "2.26",
+        "items": "2.26",
+        "total_item_count": "2.26"
+      },
+      "responseItemProperties": {
+        "context": "2.26",
+        "id": "2.26",
+        "index": "2.26",
+        "name": "2.26",
+        "policy": "2.26",
+        "policy_version": "2.26",
+        "role": "2.26",
+        "scope": "2.26"
+      }
+    },
+    "GET /management-authentication-policies": {
+      "minVersion": "2.22",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.22",
+        "errors": "2.22",
+        "items": "2.22",
+        "total_item_count": "2.22"
+      },
+      "responseItemProperties": {
+        "context": "2.22",
+        "enabled": "2.22",
+        "id": "2.22",
+        "is_local": "2.22",
+        "location": "2.22",
+        "name": "2.22",
+        "policy_type": "2.22",
+        "realms": "2.22",
+        "ssh": "2.22"
+      }
+    },
+    "GET /management-authentication-policies/members": {
+      "minVersion": "2.22",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.22",
+        "errors": "2.22",
+        "items": "2.22",
+        "total_item_count": "2.22"
+      },
+      "responseItemProperties": {
+        "context": "2.22",
+        "member": "2.22",
+        "policy": "2.22"
+      }
+    },
+    "GET /network-access-policies": {
+      "minVersion": "2.13",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.13",
+        "items": "2.13",
+        "total_item_count": "2.13"
+      },
+      "responseItemProperties": {
+        "enabled": "2.13",
+        "id": "2.13",
+        "is_local": "2.13",
+        "location": "2.13",
+        "name": "2.13",
+        "policy_type": "2.13",
+        "realms": "2.19",
+        "rules": "2.13",
+        "version": "2.13"
+      }
+    },
+    "GET /network-access-policies/members": {
+      "minVersion": "2.13",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.13",
+        "items": "2.13",
+        "total_item_count": "2.13"
+      },
+      "responseItemProperties": {
+        "member": "2.13",
+        "policy": "2.13"
+      }
+    },
+    "GET /network-access-policies/rules": {
+      "minVersion": "2.13",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.13",
+        "items": "2.13",
+        "total_item_count": "2.13"
+      },
+      "responseItemProperties": {
+        "client": "2.13",
+        "effect": "2.13",
+        "id": "2.13",
+        "index": "2.13",
+        "interfaces": "2.13",
+        "name": "2.13",
+        "policy": "2.13",
+        "policy_version": "2.13"
+      }
+    },
+    "GET /network-interfaces": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "address": "2.0",
+        "attached_servers": "2.20",
+        "enabled": "2.0",
+        "gateway": "2.0",
+        "id": "2.0",
+        "mtu": "2.0",
+        "name": "2.0",
+        "netmask": "2.0",
+        "rdma_enabled": "2.28",
+        "realms": "2.19",
+        "services": "2.0",
+        "subnet": "2.0",
+        "type": "2.0",
+        "vlan": "2.0"
+      },
+      "removedResponseFields": [
+        {
+          "field": "server",
+          "location": "items",
+          "introducedVersion": "2.16",
+          "lastSeenVersion": "2.19"
+        }
+      ]
+    },
+    "GET /network-interfaces/connectors": {
+      "minVersion": "2.17",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.17",
+        "items": "2.17",
+        "total_item_count": "2.17"
+      },
+      "responseItemProperties": {
+        "connector_type": "2.17",
+        "id": "2.17",
+        "lane_speed": "2.17",
+        "lanes_per_port": "2.20",
+        "name": "2.17",
+        "port_count": "2.17",
+        "port_speed": "2.17",
+        "transceiver_type": "2.17"
+      }
+    },
+    "GET /network-interfaces/connectors/performance": {
+      "minVersion": "2.17",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.17",
+        "items": "2.17",
+        "total": "2.17",
+        "total_item_count": "2.17"
+      },
+      "responseItemProperties": {
+        "flow_control_received_congestion_packets_per_sec": "2.17",
+        "flow_control_received_discarded_packets_per_sec": "2.17",
+        "flow_control_received_lossless_bytes_per_sec": "2.17",
+        "flow_control_received_pause_frames_per_sec": "2.17",
+        "flow_control_transmitted_congestion_packets_per_sec": "2.17",
+        "flow_control_transmitted_discarded_packets_per_sec": "2.17",
+        "flow_control_transmitted_lossless_bytes_per_sec": "2.17",
+        "flow_control_transmitted_pause_frames_per_sec": "2.17",
+        "id": "2.17",
+        "link_aggregation_group": "2.17",
+        "name": "2.17",
+        "other_errors_per_sec": "2.17",
+        "rdma_received_req_cqe_errors_per_sec": "2.17",
+        "rdma_received_sequence_errors_per_sec": "2.17",
+        "rdma_transmitted_local_ack_timeout_errors_per_sec": "2.17",
+        "received_bytes_per_sec": "2.17",
+        "received_crc_errors_per_sec": "2.17",
+        "received_frame_errors_per_sec": "2.17",
+        "received_packets_per_sec": "2.17",
+        "time": "2.17",
+        "total_errors_per_sec": "2.17",
+        "transmitted_bytes_per_sec": "2.17",
+        "transmitted_carrier_errors_per_sec": "2.17",
+        "transmitted_dropped_errors_per_sec": "2.17",
+        "transmitted_packets_per_sec": "2.17"
+      }
+    },
+    "GET /network-interfaces/connectors/settings": {
+      "minVersion": "2.17",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.17",
+        "items": "2.17",
+        "total_item_count": "2.17"
+      },
+      "responseItemProperties": {
+        "id": "2.17",
+        "name": "2.17",
+        "roce": "2.17"
+      }
+    },
+    "GET /network-interfaces/neighbors": {
+      "minVersion": "2.20",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.20",
+        "items": "2.20",
+        "total_item_count": "2.20"
+      },
+      "responseItemProperties": {
+        "initial_ttl_in_sec": "2.20",
+        "local_port": "2.20",
+        "neighbor_chassis": "2.20",
+        "neighbor_port": "2.20"
+      }
+    },
+    "GET /network-interfaces/network-connection-statistics": {
+      "minVersion": "2.18",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.18"
+      },
+      "responseItemProperties": {
+        "current_state": "2.18",
+        "local": "2.18",
+        "remote": "2.18",
+        "time": "2.18"
+      }
+    },
+    "GET /network-interfaces/ping": {
+      "minVersion": "2.6",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.6",
+        "items": "2.6",
+        "total_item_count": "2.6"
+      },
+      "responseItemProperties": {
+        "component_name": "2.6",
+        "destination": "2.6",
+        "details": "2.6",
+        "source": "2.6"
+      }
+    },
+    "GET /network-interfaces/tls-policies": {
+      "minVersion": "2.17",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.17",
+        "items": "2.17",
+        "total_item_count": "2.17"
+      },
+      "responseItemProperties": {
+        "member": "2.17",
+        "policy": "2.17"
+      }
+    },
+    "GET /network-interfaces/trace": {
+      "minVersion": "2.6",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.6",
+        "items": "2.6",
+        "total_item_count": "2.6"
+      },
+      "responseItemProperties": {
+        "component_name": "2.6",
+        "destination": "2.6",
+        "details": "2.6",
+        "source": "2.6"
+      }
+    },
+    "GET /nfs-export-policies": {
+      "minVersion": "2.3",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.3",
+        "errors": "2.17",
+        "items": "2.3",
+        "total_item_count": "2.3"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "enabled": "2.3",
+        "id": "2.3",
+        "is_local": "2.3",
+        "location": "2.3",
+        "name": "2.3",
+        "policy_type": "2.3",
+        "realms": "2.19",
+        "rules": "2.3",
+        "version": "2.3",
+        "workload": "2.23"
+      }
+    },
+    "GET /nfs-export-policies/rules": {
+      "minVersion": "2.3",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.3",
+        "errors": "2.17",
+        "items": "2.3",
+        "total_item_count": "2.3"
+      },
+      "responseItemProperties": {
+        "access": "2.3",
+        "anongid": "2.3",
+        "anonuid": "2.3",
+        "atime": "2.3",
+        "client": "2.3",
+        "context": "2.17",
+        "fileid_32bit": "2.3",
+        "id": "2.3",
+        "index": "2.3",
+        "name": "2.3",
+        "permission": "2.3",
+        "policy": "2.3",
+        "policy_version": "2.3",
+        "required_transport_security": "2.18",
+        "secure": "2.3",
+        "security": "2.3"
+      }
+    },
+    "GET /node-groups": {
+      "minVersion": "2.18",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.18",
+        "items": "2.18",
+        "total_item_count": "2.18"
+      },
+      "responseItemProperties": {
+        "id": "2.18",
+        "name": "2.18"
+      }
+    },
+    "GET /node-groups/nodes": {
+      "minVersion": "2.18",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.18",
+        "items": "2.18",
+        "total_item_count": "2.18"
+      },
+      "responseItemProperties": {
+        "group": "2.18",
+        "member": "2.18"
+      }
+    },
+    "GET /node-groups/uses": {
+      "minVersion": "2.18",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.18",
+        "items": "2.18",
+        "total_item_count": "2.18"
+      },
+      "responseItemProperties": {
+        "id": "2.18",
+        "name": "2.18",
+        "use": "2.18"
+      }
+    },
+    "GET /nodes": {
+      "minVersion": "2.18",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.18",
+        "items": "2.18",
+        "total": "2.18",
+        "total_item_count": "2.18"
+      },
+      "responseItemProperties": {
+        "capacity": "2.18",
+        "chassis_serial_number": "2.23",
+        "data_addresses": "2.18",
+        "details": "2.18",
+        "id": "2.18",
+        "management_address": "2.18",
+        "name": "2.18",
+        "raw_capacity": "2.18",
+        "serial_number": "2.18",
+        "status": "2.18",
+        "unique": "2.18"
+      }
+    },
+    "GET /object-store-access-keys": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "errors": "2.17",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "access_key_id": "2.20",
+        "context": "2.17",
+        "created": "2.0",
+        "enabled": "2.0",
+        "name": "2.0",
+        "secret_access_key": "2.0",
+        "user": "2.0"
+      }
+    },
+    "GET /object-store-access-policies": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "errors": "2.17",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "account": "2.2",
+        "arn": "2.2",
+        "context": "2.17",
+        "created": "2.2",
+        "description": "2.2",
+        "enabled": "2.2",
+        "id": "2.0",
+        "is_local": "2.2",
+        "location": "2.2",
+        "name": "2.0",
+        "policy_type": "2.2",
+        "realms": "2.19",
+        "rules": "2.2",
+        "updated": "2.2"
+      }
+    },
+    "GET /object-store-access-policies/object-store-roles": {
+      "minVersion": "2.17",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.17",
+        "errors": "2.17",
+        "items": "2.17",
+        "total_item_count": "2.17"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "member": "2.17",
+        "policy": "2.17"
+      }
+    },
+    "GET /object-store-access-policies/object-store-users": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "errors": "2.17",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "member": "2.0",
+        "policy": "2.0"
+      }
+    },
+    "GET /object-store-access-policies/rules": {
+      "minVersion": "2.2",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.2",
+        "errors": "2.17",
+        "items": "2.2",
+        "total_item_count": "2.2"
+      },
+      "responseItemProperties": {
+        "actions": "2.2",
+        "conditions": "2.2",
+        "context": "2.17",
+        "effect": "2.2",
+        "name": "2.2",
+        "policy": "2.2",
+        "resources": "2.2"
+      }
+    },
+    "GET /object-store-access-policy-actions": {
+      "minVersion": "2.2",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.2",
+        "errors": "2.17",
+        "items": "2.2",
+        "total_item_count": "2.2"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "description": "2.2",
+        "name": "2.2"
+      }
+    },
+    "GET /object-store-account-exports": {
+      "minVersion": "2.20",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.20",
+        "errors": "2.20",
+        "items": "2.20",
+        "total_item_count": "2.20"
+      },
+      "responseItemProperties": {
+        "context": "2.20",
+        "enabled": "2.20",
+        "id": "2.20",
+        "member": "2.20",
+        "name": "2.20",
+        "policy": "2.20",
+        "realms": "2.20",
+        "server": "2.20"
+      }
+    },
+    "GET /object-store-accounts": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "errors": "2.17",
+        "items": "2.0",
+        "total": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "bucket_defaults": "2.8",
+        "context": "2.17",
+        "created": "2.0",
+        "hard_limit_enabled": "2.8",
+        "id": "2.0",
+        "name": "2.0",
+        "object_count": "2.0",
+        "public_access_config": "2.12",
+        "quota_limit": "2.8",
+        "realms": "2.20",
+        "space": "2.0"
+      }
+    },
+    "GET /object-store-remote-credentials": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "errors": "2.17",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "access_key_id": "2.0",
+        "context": "2.17",
+        "id": "2.0",
+        "name": "2.0",
+        "realms": "2.20",
+        "remote": "2.0",
+        "secret_access_key": "2.0"
+      }
+    },
+    "GET /object-store-roles": {
+      "minVersion": "2.17",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.17",
+        "errors": "2.17",
+        "items": "2.17",
+        "total_item_count": "2.17"
+      },
+      "responseItemProperties": {
+        "account": "2.17",
+        "context": "2.17",
+        "created": "2.17",
+        "id": "2.17",
+        "max_session_duration": "2.17",
+        "name": "2.17",
+        "prn": "2.17",
+        "trusted_entities": "2.17"
+      }
+    },
+    "GET /object-store-roles/object-store-access-policies": {
+      "minVersion": "2.17",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.17",
+        "errors": "2.17",
+        "items": "2.17",
+        "total_item_count": "2.17"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "member": "2.17",
+        "policy": "2.17"
+      }
+    },
+    "GET /object-store-roles/object-store-trust-policies": {
+      "minVersion": "2.17",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.17",
+        "errors": "2.17",
+        "items": "2.17",
+        "total_item_count": "2.17"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "enabled": "2.17",
+        "id": "2.17",
+        "is_local": "2.17",
+        "location": "2.17",
+        "name": "2.17",
+        "policy_type": "2.17",
+        "realms": "2.19",
+        "role": "2.17",
+        "rules": "2.17"
+      }
+    },
+    "GET /object-store-roles/object-store-trust-policies/download": {
+      "minVersion": "2.17",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {},
+      "responseItemProperties": {}
+    },
+    "GET /object-store-roles/object-store-trust-policies/rules": {
+      "minVersion": "2.17",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.17",
+        "errors": "2.17",
+        "items": "2.17",
+        "total_item_count": "2.17"
+      },
+      "responseItemProperties": {
+        "actions": "2.17",
+        "conditions": "2.17",
+        "context": "2.17",
+        "effect": "2.17",
+        "index": "2.17",
+        "name": "2.17",
+        "policy": "2.17",
+        "principals": "2.17"
+      }
+    },
+    "GET /object-store-users": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "errors": "2.17",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "access_keys": "2.0",
+        "account": "2.0",
+        "context": "2.17",
+        "created": "2.0",
+        "id": "2.0",
+        "name": "2.0"
+      }
+    },
+    "GET /object-store-users/object-store-access-policies": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "errors": "2.17",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "member": "2.0",
+        "policy": "2.0"
+      }
+    },
+    "GET /object-store-virtual-hosts": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "errors": "2.17",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "attached_servers": "2.20",
+        "context": "2.17",
+        "hostname": "2.20",
+        "id": "2.0",
+        "name": "2.0",
+        "realms": "2.20"
+      }
+    },
+    "GET /password-policies": {
+      "minVersion": "2.16",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.16",
+        "items": "2.16",
+        "total_item_count": "2.16"
+      },
+      "responseItemProperties": {
+        "enabled": "2.16",
+        "enforce_dictionary_check": "2.16",
+        "enforce_username_check": "2.16",
+        "id": "2.16",
+        "is_local": "2.16",
+        "location": "2.16",
+        "lockout_duration": "2.16",
+        "max_login_attempts": "2.16",
+        "max_password_age": "2.18",
+        "min_character_groups": "2.16",
+        "min_characters_per_group": "2.16",
+        "min_password_age": "2.16",
+        "min_password_length": "2.16",
+        "name": "2.16",
+        "password_history": "2.16",
+        "policy_type": "2.16",
+        "realms": "2.19"
+      }
+    },
+    "GET /policies": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "errors": "2.17",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "enabled": "2.0",
+        "id": "2.0",
+        "is_local": "2.0",
+        "location": "2.0",
+        "name": "2.0",
+        "policy_type": "2.2",
+        "realms": "2.19",
+        "retention_lock": "2.5",
+        "rules": "2.0",
+        "workload": "2.23"
+      }
+    },
+    "GET /policies-all": {
+      "minVersion": "2.2",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.2",
+        "errors": "2.17",
+        "items": "2.2",
+        "total_item_count": "2.2"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "enabled": "2.2",
+        "id": "2.2",
+        "is_local": "2.2",
+        "location": "2.2",
+        "name": "2.2",
+        "policy_type": "2.2",
+        "realms": "2.19"
+      }
+    },
+    "GET /policies-all/members": {
+      "minVersion": "2.2",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "context": "2.22",
+        "continuation_token": "2.2",
+        "errors": "2.17",
+        "items": "2.2",
+        "total_item_count": "2.2"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "link": "2.2",
+        "member": "2.2",
+        "policy": "2.2"
+      }
+    },
+    "GET /policies/file-system-replica-links": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "context": "2.22",
+        "continuation_token": "2.0",
+        "errors": "2.17",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "link": "2.0",
+        "member": "2.0",
+        "policy": "2.0"
+      }
+    },
+    "GET /policies/file-system-snapshots": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "errors": "2.17",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "member": "2.0",
+        "policy": "2.0"
+      }
+    },
+    "GET /policies/file-systems": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "errors": "2.17",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "member": "2.0",
+        "policy": "2.0"
+      }
+    },
+    "GET /policies/members": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "context": "2.22",
+        "continuation_token": "2.0",
+        "errors": "2.17",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "link": "2.0",
+        "member": "2.0",
+        "policy": "2.0"
+      }
+    },
+    "GET /presets/workload": {
+      "minVersion": "2.23",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.23",
+        "errors": "2.23",
+        "items": "2.23",
+        "total_item_count": "2.23"
+      },
+      "responseItemProperties": {
+        "context": "2.23",
+        "description": "2.23",
+        "directory_configurations": "2.23",
+        "export_configurations": "2.23",
+        "id": "2.23",
+        "name": "2.23",
+        "parameters": "2.23",
+        "periodic_replication_configurations": "2.23",
+        "placement_configurations": "2.23",
+        "platform_features": "2.23",
+        "qos_configurations": "2.23",
+        "quota_configurations": "2.23",
+        "revision": "2.23",
+        "snapshot_configurations": "2.23",
+        "volume_configurations": "2.23",
+        "workload_tags": "2.23",
+        "workload_type": "2.23"
+      }
+    },
+    "GET /public-keys": {
+      "minVersion": "2.14",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.14",
+        "items": "2.14",
+        "total_item_count": "2.14"
+      },
+      "responseItemProperties": {
+        "algorithm": "2.14",
+        "id": "2.14",
+        "key_size": "2.14",
+        "name": "2.14",
+        "public_key": "2.14"
+      }
+    },
+    "GET /public-keys/uses": {
+      "minVersion": "2.14",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.14",
+        "items": "2.14",
+        "total_item_count": "2.14"
+      },
+      "responseItemProperties": {
+        "id": "2.14",
+        "name": "2.14",
+        "use": "2.14"
+      }
+    },
+    "GET /qos-policies": {
+      "minVersion": "2.17",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.17",
+        "errors": "2.23",
+        "items": "2.17",
+        "total_item_count": "2.17"
+      },
+      "responseItemProperties": {
+        "context": "2.23",
+        "enabled": "2.17",
+        "id": "2.17",
+        "is_local": "2.17",
+        "location": "2.17",
+        "max_total_bytes_per_sec": "2.17",
+        "max_total_ops_per_sec": "2.17",
+        "name": "2.17",
+        "policy_type": "2.17",
+        "realms": "2.19"
+      }
+    },
+    "GET /qos-policies/buckets": {
+      "minVersion": "2.19",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.19",
+        "errors": "2.23",
+        "items": "2.19",
+        "total_item_count": "2.19"
+      },
+      "responseItemProperties": {
+        "context": "2.23",
+        "member": "2.19",
+        "policy": "2.19"
+      }
+    },
+    "GET /qos-policies/file-systems": {
+      "minVersion": "2.17",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.17",
+        "errors": "2.23",
+        "items": "2.17",
+        "total_item_count": "2.17"
+      },
+      "responseItemProperties": {
+        "context": "2.23",
+        "member": "2.17",
+        "policy": "2.17"
+      }
+    },
+    "GET /qos-policies/members": {
+      "minVersion": "2.17",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.17",
+        "errors": "2.23",
+        "items": "2.17",
+        "total_item_count": "2.17"
+      },
+      "responseItemProperties": {
+        "context": "2.23",
+        "member": "2.17",
+        "policy": "2.17"
+      }
+    },
+    "GET /quotas/groups": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "errors": "2.17",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "file_system": "2.0",
+        "file_system_default_quota": "2.0",
+        "group": "2.0",
+        "name": "2.0",
+        "quota": "2.0",
+        "usage": "2.0"
+      }
+    },
+    "GET /quotas/settings": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "contact": "2.0",
+        "direct_notifications_enabled": "2.0",
+        "id": "2.0",
+        "name": "2.0"
+      }
+    },
+    "GET /quotas/users": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "errors": "2.17",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "file_system": "2.0",
+        "file_system_default_quota": "2.0",
+        "name": "2.0",
+        "quota": "2.0",
+        "usage": "2.0",
+        "user": "2.0"
+      }
+    },
+    "GET /rapid-data-locking": {
+      "minVersion": "2.1",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.1"
+      },
+      "responseItemProperties": {
+        "enabled": "2.1",
+        "kmip_server": "2.1"
+      }
+    },
+    "GET /rapid-data-locking/test": {
+      "minVersion": "2.1",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.1"
+      },
+      "responseItemProperties": {
+        "component_address": "2.1",
+        "component_name": "2.1",
+        "description": "2.1",
+        "destination": "2.1",
+        "enabled": "2.1",
+        "resource": "2.1",
+        "result_details": "2.1",
+        "success": "2.1",
+        "test_type": "2.1"
+      }
+    },
+    "GET /realm-connections": {
+      "minVersion": "2.25",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.25",
+        "items": "2.25",
+        "total_item_count": "2.25"
+      },
+      "responseItemProperties": {
+        "id": "2.25",
+        "local_realm": "2.25",
+        "remote_realm": "2.25",
+        "status": "2.25"
+      }
+    },
+    "GET /realm-connections/connection-key": {
+      "minVersion": "2.25",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.25",
+        "items": "2.25",
+        "total_item_count": "2.25"
+      },
+      "responseItemProperties": {
+        "connection_key": "2.25",
+        "created": "2.25",
+        "expires": "2.25",
+        "realm": "2.25"
+      }
+    },
+    "GET /realms": {
+      "minVersion": "2.19",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "context": "2.24",
+        "continuation_token": "2.19",
+        "errors": "2.24",
+        "items": "2.19",
+        "total": "2.19",
+        "total_item_count": "2.19"
+      },
+      "responseItemProperties": {
+        "created": "2.19",
+        "default_inbound_tls_policy": "2.19",
+        "destroyed": "2.19",
+        "id": "2.19",
+        "name": "2.19",
+        "space": "2.19",
+        "time_remaining": "2.19"
+      }
+    },
+    "GET /realms/defaults": {
+      "minVersion": "2.20",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.20",
+        "errors": "2.20",
+        "items": "2.20",
+        "total_item_count": "2.20"
+      },
+      "responseItemProperties": {
+        "context": "2.20",
+        "object_store": "2.20",
+        "realm": "2.20"
+      }
+    },
+    "GET /realms/space": {
+      "minVersion": "2.19",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.19",
+        "items": "2.19",
+        "total": "2.19",
+        "total_item_count": "2.19"
+      },
+      "responseItemProperties": {
+        "id": "2.19",
+        "name": "2.19",
+        "space": "2.19",
+        "time": "2.19"
+      }
+    },
+    "GET /realms/space/storage-classes": {
+      "minVersion": "2.19",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.19",
+        "items": "2.19",
+        "total": "2.19",
+        "total_item_count": "2.19"
+      },
+      "responseItemProperties": {
+        "id": "2.19",
+        "name": "2.19",
+        "space": "2.19",
+        "storage_class": "2.19",
+        "time": "2.19"
+      }
+    },
+    "GET /remote-arrays": {
+      "minVersion": "2.17",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.17",
+        "items": "2.17",
+        "total_item_count": "2.17"
+      },
+      "responseItemProperties": {
+        "api_versions": "2.22",
+        "fleet": "2.17",
+        "id": "2.17",
+        "is_local": "2.17",
+        "model": "2.17",
+        "name": "2.17",
+        "os": "2.17",
+        "topology_group": "2.26",
+        "version": "2.17"
+      }
+    },
+    "GET /remote-realms": {
+      "minVersion": "2.25",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.25",
+        "items": "2.25",
+        "total_item_count": "2.25"
+      },
+      "responseItemProperties": {
+        "arrays": "2.25",
+        "id": "2.25",
+        "name": "2.25"
+      }
+    },
+    "GET /resiliency-groups": {
+      "minVersion": "2.23",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.23",
+        "items": "2.23",
+        "total_item_count": "2.23"
+      },
+      "responseItemProperties": {
+        "id": "2.23",
+        "name": "2.23",
+        "status": "2.23",
+        "status_details": "2.23"
+      }
+    },
+    "GET /resiliency-groups/members": {
+      "minVersion": "2.23",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.23",
+        "items": "2.23",
+        "total_item_count": "2.23"
+      },
+      "responseItemProperties": {
+        "group": "2.23",
+        "member": "2.23"
+      }
+    },
+    "GET /resource-accesses": {
+      "minVersion": "2.19",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.19",
+        "items": "2.19",
+        "more_items_remaining": "2.19",
+        "total_item_count": "2.19"
+      },
+      "responseItemProperties": {
+        "id": "2.19",
+        "resource": "2.19",
+        "scope": "2.19"
+      }
+    },
+    "GET /roles": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "id": "2.0",
+        "name": "2.0",
+        "permissions": "2.0"
+      }
+    },
+    "GET /s3-export-policies": {
+      "minVersion": "2.20",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.20",
+        "errors": "2.20",
+        "items": "2.20",
+        "total_item_count": "2.20"
+      },
+      "responseItemProperties": {
+        "context": "2.20",
+        "enabled": "2.20",
+        "id": "2.20",
+        "is_local": "2.20",
+        "location": "2.20",
+        "name": "2.20",
+        "policy_type": "2.20",
+        "realms": "2.20",
+        "rules": "2.20"
+      }
+    },
+    "GET /s3-export-policies/rules": {
+      "minVersion": "2.20",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.20",
+        "errors": "2.20",
+        "items": "2.20",
+        "total_item_count": "2.20"
+      },
+      "responseItemProperties": {
+        "actions": "2.20",
+        "context": "2.20",
+        "effect": "2.20",
+        "name": "2.20",
+        "policy": "2.20",
+        "resources": "2.20"
+      }
+    },
+    "GET /servers": {
+      "minVersion": "2.16",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.16",
+        "errors": "2.17",
+        "items": "2.16",
+        "total_item_count": "2.16"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "created": "2.16",
+        "directory_services": "2.16",
+        "dns": "2.16",
+        "id": "2.16",
+        "local_directory_service": "2.24",
+        "name": "2.16",
+        "realms": "2.19"
+      }
+    },
+    "GET /sessions": {
+      "minVersion": "2.3",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.3",
+        "items": "2.3",
+        "total_item_count": "2.3"
+      },
+      "responseItemProperties": {
+        "end_time": "2.3",
+        "event": "2.3",
+        "event_count": "2.3",
+        "id": "2.3",
+        "identifying_details": "2.14",
+        "location": "2.3",
+        "method": "2.3",
+        "name": "2.3",
+        "start_time": "2.3",
+        "user": "2.3",
+        "user_interface": "2.3"
+      }
+    },
+    "GET /smb-client-policies": {
+      "minVersion": "2.10",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.10",
+        "errors": "2.17",
+        "items": "2.10",
+        "total_item_count": "2.10"
+      },
+      "responseItemProperties": {
+        "access_based_enumeration_enabled": "2.17",
+        "context": "2.17",
+        "enabled": "2.10",
+        "id": "2.10",
+        "is_local": "2.10",
+        "location": "2.10",
+        "name": "2.10",
+        "policy_type": "2.10",
+        "realms": "2.19",
+        "rules": "2.10",
+        "version": "2.10",
+        "workload": "2.23"
+      }
+    },
+    "GET /smb-client-policies/rules": {
+      "minVersion": "2.10",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.10",
+        "errors": "2.17",
+        "items": "2.10",
+        "total_item_count": "2.10"
+      },
+      "responseItemProperties": {
+        "client": "2.10",
+        "context": "2.17",
+        "encryption": "2.11",
+        "id": "2.10",
+        "index": "2.10",
+        "name": "2.10",
+        "permission": "2.10",
+        "policy": "2.10",
+        "policy_version": "2.10"
+      }
+    },
+    "GET /smb-share-policies": {
+      "minVersion": "2.10",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.10",
+        "errors": "2.17",
+        "items": "2.10",
+        "total_item_count": "2.10"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "enabled": "2.10",
+        "id": "2.10",
+        "is_local": "2.10",
+        "location": "2.10",
+        "name": "2.10",
+        "policy_type": "2.10",
+        "realms": "2.19",
+        "rules": "2.10",
+        "workload": "2.23"
+      }
+    },
+    "GET /smb-share-policies/rules": {
+      "minVersion": "2.10",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.10",
+        "errors": "2.17",
+        "items": "2.10",
+        "total_item_count": "2.10"
+      },
+      "responseItemProperties": {
+        "change": "2.10",
+        "context": "2.17",
+        "full_control": "2.10",
+        "id": "2.10",
+        "name": "2.10",
+        "policy": "2.10",
+        "principal": "2.10",
+        "read": "2.10"
+      }
+    },
+    "GET /smtp-servers": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "encryption_mode": "2.15",
+        "id": "2.0",
+        "name": "2.0",
+        "relay_host": "2.0",
+        "sender_domain": "2.0"
+      }
+    },
+    "GET /snmp-agents": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "engine_id": "2.0",
+        "id": "2.0",
+        "name": "2.0",
+        "v2c": "2.0",
+        "v3": "2.0",
+        "version": "2.0"
+      }
+    },
+    "GET /snmp-agents/mib": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "mib": "2.0"
+      }
+    },
+    "GET /snmp-managers": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "host": "2.0",
+        "id": "2.0",
+        "name": "2.0",
+        "notification": "2.0",
+        "v2c": "2.0",
+        "v3": "2.0",
+        "version": "2.0"
+      }
+    },
+    "GET /snmp-managers/test": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "component_address": "2.0",
+        "component_name": "2.0",
+        "description": "2.0",
+        "destination": "2.0",
+        "enabled": "2.0",
+        "resource": "2.0",
+        "result_details": "2.0",
+        "success": "2.0",
+        "test_type": "2.0"
+      }
+    },
+    "GET /software-bundle": {
+      "minVersion": "2.24",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.24",
+        "items": "2.24",
+        "total_item_count": "2.24"
+      },
+      "responseItemProperties": {
+        "created": "2.24",
+        "details": "2.24",
+        "download_progress": "2.24",
+        "id": "2.24",
+        "source": "2.24",
+        "status": "2.24"
+      }
+    },
+    "GET /software-check": {
+      "minVersion": "2.16",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.16",
+        "items": "2.16",
+        "total_item_count": "2.16"
+      },
+      "responseItemProperties": {
+        "checks": "2.16",
+        "details": "2.16",
+        "end_time": "2.16",
+        "id": "2.16",
+        "name": "2.16",
+        "software_name": "2.16",
+        "software_upgrade_hops": "2.16",
+        "software_version": "2.16",
+        "start_time": "2.16",
+        "status": "2.16"
+      }
+    },
+    "GET /software-patches": {
+      "minVersion": "2.24",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.24",
+        "items": "2.24",
+        "total_item_count": "2.24"
+      },
+      "responseItemProperties": {
+        "alert_code": "2.24",
+        "description": "2.24",
+        "details": "2.24",
+        "ha_reduction_required": "2.24",
+        "id": "2.24",
+        "name": "2.24",
+        "progress": "2.24",
+        "status": "2.24"
+      }
+    },
+    "GET /ssh-certificate-authority-policies": {
+      "minVersion": "2.14",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.14",
+        "errors": "2.24",
+        "items": "2.14",
+        "total_item_count": "2.14"
+      },
+      "responseItemProperties": {
+        "context": "2.24",
+        "enabled": "2.14",
+        "id": "2.14",
+        "is_local": "2.14",
+        "location": "2.14",
+        "name": "2.14",
+        "policy_type": "2.14",
+        "realms": "2.19",
+        "signing_authority": "2.14",
+        "static_authorized_principals": "2.14"
+      }
+    },
+    "GET /ssh-certificate-authority-policies/admins": {
+      "minVersion": "2.14",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.14",
+        "errors": "2.24",
+        "items": "2.14",
+        "total_item_count": "2.14"
+      },
+      "responseItemProperties": {
+        "context": "2.24",
+        "member": "2.14",
+        "policy": "2.14"
+      }
+    },
+    "GET /ssh-certificate-authority-policies/arrays": {
+      "minVersion": "2.14",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.14",
+        "errors": "2.24",
+        "items": "2.14",
+        "total_item_count": "2.14"
+      },
+      "responseItemProperties": {
+        "context": "2.24",
+        "member": "2.14",
+        "policy": "2.14"
+      }
+    },
+    "GET /ssh-certificate-authority-policies/members": {
+      "minVersion": "2.14",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.14",
+        "errors": "2.24",
+        "items": "2.14",
+        "total_item_count": "2.14"
+      },
+      "responseItemProperties": {
+        "context": "2.24",
+        "member": "2.14",
+        "policy": "2.14"
+      }
+    },
+    "GET /sso/oidc/idps": {
+      "minVersion": "2.17",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.17",
+        "items": "2.17",
+        "total_item_count": "2.17"
+      },
+      "responseItemProperties": {
+        "enabled": "2.17",
+        "id": "2.17",
+        "idp": "2.17",
+        "name": "2.17",
+        "prn": "2.17",
+        "services": "2.17"
+      }
+    },
+    "GET /sso/saml2/idps": {
+      "minVersion": "2.15",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.15",
+        "items": "2.15",
+        "total_item_count": "2.15"
+      },
+      "responseItemProperties": {
+        "array_url": "2.15",
+        "binding": "2.17",
+        "enabled": "2.15",
+        "id": "2.15",
+        "idp": "2.15",
+        "management": "2.24",
+        "name": "2.15",
+        "prn": "2.17",
+        "services": "2.17",
+        "sp": "2.15"
+      }
+    },
+    "GET /sso/saml2/idps/test": {
+      "minVersion": "2.16",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.16"
+      },
+      "responseItemProperties": {
+        "component_address": "2.16",
+        "component_name": "2.16",
+        "description": "2.16",
+        "destination": "2.16",
+        "enabled": "2.16",
+        "resource": "2.16",
+        "result_details": "2.16",
+        "success": "2.16",
+        "test_type": "2.16"
+      }
+    },
+    "GET /storage-class-tiering-policies": {
+      "minVersion": "2.18",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.18",
+        "items": "2.18",
+        "total_item_count": "2.18"
+      },
+      "responseItemProperties": {
+        "archival_rules": "2.18",
+        "enabled": "2.18",
+        "id": "2.18",
+        "is_local": "2.18",
+        "location": "2.18",
+        "name": "2.18",
+        "policy_type": "2.18",
+        "realms": "2.19",
+        "retrieval_rules": "2.18"
+      }
+    },
+    "GET /storage-class-tiering-policies/members": {
+      "minVersion": "2.18",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.18",
+        "errors": "2.18",
+        "items": "2.18",
+        "total_item_count": "2.18"
+      },
+      "responseItemProperties": {
+        "member": "2.18",
+        "policy": "2.18"
+      }
+    },
+    "GET /storage-classes/members": {
+      "minVersion": "2.27",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.27",
+        "items": "2.27",
+        "total_item_count": "2.27"
+      },
+      "responseItemProperties": {
+        "member": "2.27",
+        "storage_class": "2.27"
+      }
+    },
+    "GET /subnets": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "enabled": "2.0",
+        "gateway": "2.0",
+        "id": "2.0",
+        "interfaces": "2.0",
+        "link_aggregation_group": "2.0",
+        "mtu": "2.0",
+        "name": "2.0",
+        "prefix": "2.0",
+        "services": "2.0",
+        "vlan": "2.0"
+      }
+    },
+    "GET /support": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "edge_agent_update_enabled": "2.18",
+        "edge_management_enabled": "2.18",
+        "id": "2.0",
+        "name": "2.0",
+        "phonehome_enabled": "2.0",
+        "proxy": "2.0",
+        "remote_assist_active": "2.0",
+        "remote_assist_duration": "2.14",
+        "remote_assist_expires": "2.0",
+        "remote_assist_opened": "2.0",
+        "remote_assist_paths": "2.0",
+        "remote_assist_status": "2.0"
+      }
+    },
+    "GET /support-diagnostics": {
+      "minVersion": "2.16",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.16",
+        "items": "2.16",
+        "total_item_count": "2.16"
+      },
+      "responseItemProperties": {
+        "analysis_period": "2.16",
+        "id": "2.16",
+        "index": "2.16",
+        "name": "2.16",
+        "severity_count": "2.16",
+        "start_time": "2.16",
+        "status": "2.16",
+        "task_id": "2.16",
+        "version": "2.16"
+      }
+    },
+    "GET /support-diagnostics/details": {
+      "minVersion": "2.16",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.16",
+        "items": "2.16",
+        "total_item_count": "2.16"
+      },
+      "responseItemProperties": {
+        "id": "2.16",
+        "index": "2.16",
+        "name": "2.16",
+        "result_details": "2.16",
+        "severity": "2.16",
+        "task_id": "2.16",
+        "test_name": "2.16",
+        "test_type": "2.16"
+      }
+    },
+    "GET /support-diagnostics/settings": {
+      "minVersion": "2.24",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.24",
+        "items": "2.24",
+        "total_item_count": "2.24"
+      },
+      "responseItemProperties": {
+        "last_updated": "2.24",
+        "version": "2.24"
+      }
+    },
+    "GET /support/system-manifest": {
+      "minVersion": "2.26",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.26",
+        "errors": "2.26",
+        "items": "2.26",
+        "total_item_count": "2.26"
+      },
+      "responseItemProperties": {
+        "context": "2.26",
+        "system-manifest": "2.26"
+      }
+    },
+    "GET /support/test": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "component_address": "2.0",
+        "component_name": "2.0",
+        "description": "2.0",
+        "destination": "2.0",
+        "enabled": "2.0",
+        "resource": "2.0",
+        "result_details": "2.0",
+        "success": "2.0",
+        "test_type": "2.0"
+      }
+    },
+    "GET /support/verification-keys": {
+      "minVersion": "2.7",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.7",
+        "items": "2.7",
+        "total_item_count": "2.7"
+      },
+      "responseItemProperties": {
+        "key_id": "2.7",
+        "name": "2.7",
+        "verification_key": "2.7"
+      }
+    },
+    "GET /syslog-servers": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "errors": "2.17",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "id": "2.0",
+        "name": "2.0",
+        "services": "2.14",
+        "sources": "2.20",
+        "uri": "2.0"
+      }
+    },
+    "GET /syslog-servers/settings": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "ca_certificate": "2.0",
+        "ca_certificate_group": "2.0",
+        "id": "2.0",
+        "name": "2.0"
+      }
+    },
+    "GET /syslog-servers/test": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "component_address": "2.0",
+        "component_name": "2.0",
+        "description": "2.0",
+        "destination": "2.0",
+        "enabled": "2.0",
+        "resource": "2.0",
+        "result_details": "2.0",
+        "success": "2.0",
+        "test_type": "2.0"
+      }
+    },
+    "GET /targets": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "errors": "2.17",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "address": "2.0",
+        "ca_certificate_group": "2.0",
+        "context": "2.17",
+        "id": "2.0",
+        "name": "2.0",
+        "status": "2.0",
+        "status_details": "2.0"
+      }
+    },
+    "GET /targets/performance/replication": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "items": "2.0",
+        "total": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "aggregate": "2.1",
+        "continuous": "2.1",
+        "id": "2.0",
+        "name": "2.0",
+        "periodic": "2.0",
+        "time": "2.0"
+      }
+    },
+    "GET /tls-policies": {
+      "minVersion": "2.17",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.17",
+        "items": "2.17",
+        "total_item_count": "2.17"
+      },
+      "responseItemProperties": {
+        "appliance_certificate": "2.17",
+        "client_certificates_required": "2.18",
+        "disabled_tls_ciphers": "2.17",
+        "enabled": "2.17",
+        "enabled_tls_ciphers": "2.17",
+        "id": "2.17",
+        "is_local": "2.17",
+        "location": "2.17",
+        "min_tls_version": "2.17",
+        "name": "2.17",
+        "policy_type": "2.17",
+        "realms": "2.19",
+        "trusted_client_certificate_authority": "2.18",
+        "verify_client_certificate_trust": "2.18"
+      }
+    },
+    "GET /tls-policies/members": {
+      "minVersion": "2.17",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.17",
+        "items": "2.17",
+        "total_item_count": "2.17"
+      },
+      "responseItemProperties": {
+        "member": "2.17",
+        "policy": "2.17"
+      }
+    },
+    "GET /tls-policies/network-interfaces": {
+      "minVersion": "2.17",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.17",
+        "items": "2.17",
+        "total_item_count": "2.17"
+      },
+      "responseItemProperties": {
+        "member": "2.17",
+        "policy": "2.17"
+      }
+    },
+    "GET /topology-groups": {
+      "minVersion": "2.26",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.26",
+        "errors": "2.26",
+        "items": "2.26",
+        "total_item_count": "2.26"
+      },
+      "responseItemProperties": {
+        "context": "2.26",
+        "id": "2.26",
+        "name": "2.26",
+        "parent_topology_group": "2.26"
+      }
+    },
+    "GET /topology-groups/arrays": {
+      "minVersion": "2.26",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.26",
+        "errors": "2.26",
+        "items": "2.26",
+        "total_item_count": "2.26"
+      },
+      "responseItemProperties": {
+        "context": "2.26",
+        "member": "2.26",
+        "status": "2.26",
+        "status_details": "2.26",
+        "topology_group": "2.26"
+      }
+    },
+    "GET /topology-groups/members": {
+      "minVersion": "2.26",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.26",
+        "errors": "2.26",
+        "items": "2.26",
+        "total_item_count": "2.26"
+      },
+      "responseItemProperties": {
+        "context": "2.26",
+        "member": "2.26",
+        "status": "2.26",
+        "status_details": "2.26",
+        "topology_group": "2.26"
+      }
+    },
+    "GET /usage/groups": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "errors": "2.17",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "file_system": "2.0",
+        "file_system_default_quota": "2.0",
+        "group": "2.0",
+        "name": "2.0",
+        "quota": "2.0",
+        "usage": "2.0"
+      }
+    },
+    "GET /usage/users": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.0",
+        "errors": "2.17",
+        "items": "2.0",
+        "total_item_count": "2.0"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "file_system": "2.0",
+        "file_system_default_quota": "2.0",
+        "name": "2.0",
+        "quota": "2.0",
+        "usage": "2.0",
+        "user": "2.0"
+      }
+    },
+    "GET /user-group-quota-policies": {
+      "minVersion": "2.25",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.25",
+        "errors": "2.25",
+        "items": "2.25",
+        "total_item_count": "2.25"
+      },
+      "responseItemProperties": {
+        "context": "2.25",
+        "enabled": "2.25",
+        "id": "2.25",
+        "is_local": "2.25",
+        "location": "2.25",
+        "name": "2.25",
+        "policy_type": "2.25",
+        "realms": "2.25",
+        "rules": "2.25",
+        "version": "2.25"
+      }
+    },
+    "GET /user-group-quota-policies/file-systems": {
+      "minVersion": "2.25",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.25",
+        "errors": "2.25",
+        "items": "2.25",
+        "total_item_count": "2.25"
+      },
+      "responseItemProperties": {
+        "context": "2.25",
+        "member": "2.25",
+        "policy": "2.25"
+      }
+    },
+    "GET /user-group-quota-policies/members": {
+      "minVersion": "2.25",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.25",
+        "errors": "2.25",
+        "items": "2.25",
+        "total_item_count": "2.25"
+      },
+      "responseItemProperties": {
+        "context": "2.25",
+        "member": "2.25",
+        "policy": "2.25"
+      }
+    },
+    "GET /user-group-quota-policies/rules": {
+      "minVersion": "2.25",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.25",
+        "errors": "2.25",
+        "items": "2.25",
+        "total_item_count": "2.25"
+      },
+      "responseItemProperties": {
+        "context": "2.25",
+        "enforced": "2.25",
+        "id": "2.25",
+        "index": "2.25",
+        "name": "2.25",
+        "notifications": "2.25",
+        "policy": "2.25",
+        "policy_version": "2.25",
+        "quota_limit": "2.25",
+        "quota_type": "2.25",
+        "subject": "2.25"
+      }
+    },
+    "GET /workloads": {
+      "minVersion": "2.23",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.23",
+        "errors": "2.23",
+        "items": "2.23",
+        "total_item_count": "2.23"
+      },
+      "responseItemProperties": {
+        "context": "2.23",
+        "created": "2.23",
+        "destroyed": "2.23",
+        "id": "2.23",
+        "name": "2.23",
+        "preset": "2.23",
+        "status": "2.23",
+        "status_details": "2.23",
+        "time_remaining": "2.23"
+      }
+    },
+    "GET /workloads/placement-recommendations": {
+      "minVersion": "2.23",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.23",
+        "errors": "2.23",
+        "items": "2.23",
+        "total_item_count": "2.23"
+      },
+      "responseItemProperties": {
+        "additional_constraints": "2.23",
+        "context": "2.23",
+        "created": "2.23",
+        "expires": "2.23",
+        "id": "2.23",
+        "more_results_available": "2.23",
+        "name": "2.23",
+        "parameters": "2.23",
+        "placement_names": "2.23",
+        "preset": "2.23",
+        "progress": "2.23",
+        "projection_months": "2.23",
+        "recommendation_engine": "2.23",
+        "results": "2.23",
+        "results_limit": "2.23",
+        "status": "2.23"
+      }
+    },
+    "GET /workloads/tags": {
+      "minVersion": "2.23",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.23",
+        "errors": "2.23",
+        "items": "2.23",
+        "total_item_count": "2.23"
+      },
+      "responseItemProperties": {
+        "context": "2.23",
+        "copyable": "2.23",
+        "key": "2.23",
+        "namespace": "2.23",
+        "resource": "2.23",
+        "value": "2.23"
+      }
+    },
+    "GET /worm-data-policies": {
+      "minVersion": "2.15",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.15",
+        "errors": "2.17",
+        "items": "2.15",
+        "total_item_count": "2.15"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "default_retention": "2.15",
+        "enabled": "2.15",
+        "id": "2.15",
+        "is_local": "2.15",
+        "location": "2.15",
+        "max_retention": "2.15",
+        "min_retention": "2.15",
+        "mode": "2.15",
+        "name": "2.15",
+        "policy_type": "2.15",
+        "realms": "2.19",
+        "retention_lock": "2.15"
+      }
+    },
+    "GET /worm-data-policies/members": {
+      "minVersion": "2.15",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.15",
+        "errors": "2.17",
+        "items": "2.15",
+        "total_item_count": "2.15"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "member": "2.15",
+        "policy": "2.15"
+      }
+    },
+    "PATCH /active-directory": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "ca_certificate": "2.27",
+        "ca_certificate_group": "2.27",
+        "computer_name": "2.0",
+        "directory_servers": "2.0",
+        "domain": "2.0",
+        "encryption_types": "2.0",
+        "global_catalog_servers": "2.12",
+        "id": "2.0",
+        "join_ou": "2.0",
+        "kerberos_servers": "2.0",
+        "name": "2.0",
+        "realms": "2.19",
+        "server": "2.16",
+        "service_principal_names": "2.0"
+      }
+    },
+    "PATCH /active-directory/test": {
+      "minVersion": "2.27",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.27",
+        "errors": "2.27",
+        "items": "2.27",
+        "total_item_count": "2.27"
+      },
+      "responseItemProperties": {
+        "component_address": "2.27",
+        "component_name": "2.27",
+        "context": "2.27",
+        "description": "2.27",
+        "destination": "2.27",
+        "enabled": "2.27",
+        "resource": "2.27",
+        "result_details": "2.27",
+        "success": "2.27",
+        "test_type": "2.27"
+      }
+    },
+    "PATCH /admins": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "admin_type": "2.24",
+        "api_token": "2.0",
+        "authorization_model": "2.24",
+        "context": "2.22",
+        "id": "2.0",
+        "is_local": "2.0",
+        "locked": "2.3",
+        "lockout_remaining": "2.3",
+        "management_access_policies": "2.19",
+        "name": "2.0",
+        "public_key": "2.0",
+        "role": "2.0"
+      }
+    },
+    "PATCH /admins/settings": {
+      "minVersion": "2.3",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.3"
+      },
+      "responseItemProperties": {
+        "lockout_duration": "2.3",
+        "max_login_attempts": "2.3",
+        "min_password_length": "2.3"
+      }
+    },
+    "PATCH /alert-watchers": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "enabled": "2.0",
+        "id": "2.0",
+        "minimum_notification_severity": "2.0",
+        "name": "2.0"
+      }
+    },
+    "PATCH /alerts": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "action": "2.0",
+        "code": "2.0",
+        "component_name": "2.0",
+        "component_type": "2.0",
+        "created": "2.0",
+        "description": "2.0",
+        "duration": "2.20",
+        "flagged": "2.0",
+        "id": "2.0",
+        "index": "2.0",
+        "knowledge_base_url": "2.0",
+        "name": "2.0",
+        "notified": "2.0",
+        "severity": "2.0",
+        "state": "2.0",
+        "summary": "2.0",
+        "updated": "2.0",
+        "variables": "2.0"
+      }
+    },
+    "PATCH /api-clients": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "access_policies": "2.19",
+        "access_token_ttl_in_ms": "2.0",
+        "enabled": "2.0",
+        "id": "2.0",
+        "issuer": "2.0",
+        "key_id": "2.0",
+        "max_role": "2.0",
+        "name": "2.0",
+        "public_key": "2.0"
+      }
+    },
+    "PATCH /array-connections": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "ca_certificate_group": "2.0",
+        "context": "2.17",
+        "encrypted": "2.0",
+        "id": "2.0",
+        "management_address": "2.0",
+        "os": "2.17",
+        "remote": "2.0",
+        "replication_addresses": "2.0",
+        "status": "2.0",
+        "throttle": "2.3",
+        "type": "2.17",
+        "version": "2.0"
+      }
+    },
+    "PATCH /arrays": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "_as_of": "2.0",
+        "banner": "2.0",
+        "context": "2.22",
+        "default_inbound_tls_policy": "2.17",
+        "encryption": "2.8",
+        "eradication_config": "2.5",
+        "id": "2.0",
+        "idle_timeout": "2.0",
+        "name": "2.0",
+        "network_access_policy": "2.13",
+        "ntp_servers": "2.0",
+        "os": "2.0",
+        "product_type": "2.6",
+        "revision": "2.0",
+        "security_update": "2.7",
+        "smb_mode": "2.2",
+        "time_zone": "2.0",
+        "version": "2.0"
+      }
+    },
+    "PATCH /arrays/erasures": {
+      "minVersion": "2.18",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.18"
+      },
+      "responseItemProperties": {
+        "details": "2.18",
+        "name": "2.18",
+        "sanitization_certificate": "2.18",
+        "status": "2.18"
+      }
+    },
+    "PATCH /arrays/eula": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "agreement": "2.0",
+        "signature": "2.0"
+      }
+    },
+    "PATCH /audit-file-systems-policies": {
+      "minVersion": "2.14",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.14"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "control_type": "2.18",
+        "enabled": "2.14",
+        "id": "2.14",
+        "is_local": "2.14",
+        "location": "2.14",
+        "log_targets": "2.14",
+        "name": "2.14",
+        "policy_type": "2.14",
+        "realms": "2.19",
+        "rules": "2.18"
+      }
+    },
+    "PATCH /audit-object-store-policies": {
+      "minVersion": "2.20",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.20"
+      },
+      "responseItemProperties": {
+        "context": "2.20",
+        "enabled": "2.20",
+        "id": "2.20",
+        "is_local": "2.20",
+        "location": "2.20",
+        "log_targets": "2.20",
+        "name": "2.20",
+        "policy_type": "2.20",
+        "realms": "2.20"
+      }
+    },
+    "PATCH /bucket-replica-links": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0",
+        "total": "2.2"
+      },
+      "responseItemProperties": {
+        "cascading_enabled": "2.2",
+        "context": "2.17",
+        "direction": "2.0",
+        "id": "2.0",
+        "lag": "2.0",
+        "local_bucket": "2.0",
+        "object_backlog": "2.2",
+        "paused": "2.0",
+        "recovery_point": "2.0",
+        "remote": "2.0",
+        "remote_bucket": "2.0",
+        "remote_credentials": "2.0",
+        "status": "2.0",
+        "status_details": "2.0"
+      }
+    },
+    "PATCH /buckets": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "account": "2.0",
+        "bucket_type": "2.4",
+        "context": "2.17",
+        "created": "2.0",
+        "destroyed": "2.0",
+        "eradication_config": "2.8",
+        "hard_limit_enabled": "2.8",
+        "id": "2.0",
+        "name": "2.0",
+        "object_count": "2.0",
+        "object_lock_config": "2.8",
+        "public_access_config": "2.12",
+        "public_status": "2.12",
+        "qos_policy": "2.20",
+        "quota_limit": "2.8",
+        "retention_lock": "2.8",
+        "space": "2.0",
+        "storage_class": "2.19",
+        "time_remaining": "2.0",
+        "time_remaining_status": "2.14",
+        "versioning": "2.0"
+      }
+    },
+    "PATCH /buckets/audit-filters": {
+      "minVersion": "2.20",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.20"
+      },
+      "responseItemProperties": {
+        "actions": "2.20",
+        "bucket": "2.20",
+        "context": "2.20",
+        "name": "2.20",
+        "s3_prefixes": "2.20"
+      }
+    },
+    "PATCH /certificates": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "certificate": "2.0",
+        "certificate_type": "2.0",
+        "common_name": "2.0",
+        "country": "2.0",
+        "email": "2.0",
+        "id": "2.0",
+        "intermediate_certificate": "2.0",
+        "issued_by": "2.0",
+        "issued_to": "2.0",
+        "key_algorithm": "2.20",
+        "key_size": "2.0",
+        "locality": "2.0",
+        "name": "2.0",
+        "organization": "2.0",
+        "organizational_unit": "2.0",
+        "realms": "2.19",
+        "state": "2.0",
+        "status": "2.0",
+        "subject_alternative_names": "2.0",
+        "valid_from": "2.0",
+        "valid_to": "2.0"
+      }
+    },
+    "PATCH /data-eviction-policies": {
+      "minVersion": "2.21",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.21"
+      },
+      "responseItemProperties": {
+        "context": "2.21",
+        "enabled": "2.21",
+        "id": "2.21",
+        "is_local": "2.21",
+        "keep_size": "2.21",
+        "location": "2.21",
+        "name": "2.21",
+        "policy_type": "2.21",
+        "realms": "2.21"
+      }
+    },
+    "PATCH /directory-services": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "base_dn": "2.0",
+        "bind_password": "2.0",
+        "bind_user": "2.0",
+        "ca_certificate": "2.0",
+        "ca_certificate_group": "2.0",
+        "enabled": "2.0",
+        "id": "2.0",
+        "management": "2.0",
+        "name": "2.0",
+        "nfs": "2.0",
+        "services": "2.0",
+        "smb": "2.0",
+        "uris": "2.0"
+      }
+    },
+    "PATCH /directory-services/local/directory-services": {
+      "minVersion": "2.24",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.24"
+      },
+      "responseItemProperties": {
+        "context": "2.24",
+        "destroyed": "2.24",
+        "domain": "2.24",
+        "id": "2.24",
+        "name": "2.24",
+        "realms": "2.24",
+        "server": "2.24",
+        "time_remaining": "2.24"
+      }
+    },
+    "PATCH /directory-services/local/groups": {
+      "minVersion": "2.24",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.24"
+      },
+      "responseItemProperties": {
+        "built_in": "2.24",
+        "context": "2.24",
+        "email": "2.24",
+        "gid": "2.24",
+        "local_directory_service": "2.24",
+        "name": "2.24",
+        "realms": "2.24",
+        "server": "2.24",
+        "sid": "2.24"
+      }
+    },
+    "PATCH /directory-services/local/users": {
+      "minVersion": "2.24",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.24"
+      },
+      "responseItemProperties": {
+        "built_in": "2.24",
+        "context": "2.24",
+        "email": "2.24",
+        "enabled": "2.24",
+        "local_directory_service": "2.24",
+        "name": "2.24",
+        "primary_group": "2.24",
+        "realms": "2.24",
+        "server": "2.24",
+        "sid": "2.24",
+        "uid": "2.24"
+      }
+    },
+    "PATCH /directory-services/roles": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "group": "2.0",
+        "group_base": "2.0",
+        "id": "2.0",
+        "management_access_policies": "2.19",
+        "name": "2.14",
+        "role": "2.0"
+      }
+    },
+    "PATCH /directory-services/test": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.23",
+        "errors": "2.23",
+        "items": "2.0",
+        "total_item_count": "2.23"
+      },
+      "responseItemProperties": {
+        "component_address": "2.0",
+        "component_name": "2.0",
+        "context": "2.23",
+        "description": "2.0",
+        "destination": "2.0",
+        "enabled": "2.0",
+        "resource": "2.0",
+        "result_details": "2.0",
+        "success": "2.0",
+        "test_type": "2.0"
+      }
+    },
+    "PATCH /dns": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "ca_certificate": "2.25",
+        "ca_certificate_group": "2.25",
+        "context": "2.25",
+        "domain": "2.0",
+        "id": "2.0",
+        "name": "2.0",
+        "nameservers": "2.0",
+        "realms": "2.19",
+        "services": "2.16",
+        "sources": "2.16"
+      }
+    },
+    "PATCH /file-system-exports": {
+      "minVersion": "2.16",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.16"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "enabled": "2.16",
+        "export_name": "2.16",
+        "id": "2.16",
+        "member": "2.16",
+        "name": "2.16",
+        "policy": "2.16",
+        "policy_type": "2.16",
+        "server": "2.16",
+        "share_policy": "2.16",
+        "status": "2.16",
+        "workload": "2.23"
+      }
+    },
+    "PATCH /file-system-replica-links": {
+      "minVersion": "2.17",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.17"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "direction": "2.17",
+        "id": "2.17",
+        "lag": "2.17",
+        "link_type": "2.17",
+        "local_file_system": "2.17",
+        "policies": "2.17",
+        "recovery_point": "2.17",
+        "remote": "2.17",
+        "remote_file_system": "2.17",
+        "status": "2.17",
+        "status_details": "2.17"
+      }
+    },
+    "PATCH /file-system-snapshots": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "created": "2.0",
+        "destroyed": "2.0",
+        "id": "2.0",
+        "name": "2.0",
+        "owner": "2.0",
+        "owner_destroyed": "2.0",
+        "policies": "2.12",
+        "policy": "2.0",
+        "source": "2.0",
+        "suffix": "2.0",
+        "time_remaining": "2.0"
+      },
+      "removedResponseFields": [
+        {
+          "field": "copyable",
+          "location": "items",
+          "introducedVersion": "2.0",
+          "lastSeenVersion": "2.10"
+        }
+      ]
+    },
+    "PATCH /file-systems": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "created": "2.0",
+        "default_group_quota": "2.0",
+        "default_user_quota": "2.0",
+        "destroyed": "2.0",
+        "eradication_config": "2.15",
+        "fast_remove_directory_enabled": "2.0",
+        "group_ownership": "2.13",
+        "hard_limit_enabled": "2.0",
+        "http": "2.0",
+        "id": "2.0",
+        "multi_protocol": "2.0",
+        "name": "2.0",
+        "nfs": "2.0",
+        "node_group": "2.18",
+        "promotion_status": "2.0",
+        "provisioned": "2.0",
+        "qos_policy": "2.17",
+        "realms": "2.19",
+        "requested_promotion_state": "2.0",
+        "smb": "2.0",
+        "snapshot_directory_enabled": "2.0",
+        "source": "2.0",
+        "space": "2.0",
+        "storage_class": "2.16",
+        "time_remaining": "2.0",
+        "workload": "2.23",
+        "writable": "2.0"
+      }
+    },
+    "PATCH /fleets": {
+      "minVersion": "2.17",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.17"
+      },
+      "responseItemProperties": {
+        "id": "2.17",
+        "is_local": "2.17",
+        "name": "2.17"
+      }
+    },
+    "PATCH /hardware": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "data_mac": "2.16",
+        "details": "2.0",
+        "id": "2.0",
+        "identify_enabled": "2.0",
+        "index": "2.0",
+        "management_mac": "2.16",
+        "model": "2.0",
+        "name": "2.0",
+        "part_number": "2.8",
+        "sensor_readings": "2.18",
+        "serial": "2.0",
+        "slot": "2.0",
+        "speed": "2.0",
+        "status": "2.0",
+        "temperature": "2.0",
+        "type": "2.0"
+      }
+    },
+    "PATCH /hardware-connectors": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "connector_type": "2.0",
+        "id": "2.0",
+        "lane_speed": "2.0",
+        "lanes_per_port": "2.20",
+        "name": "2.0",
+        "port_count": "2.0",
+        "port_speed": "2.15",
+        "transceiver_type": "2.0"
+      }
+    },
+    "PATCH /kmip": {
+      "minVersion": "2.1",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.1"
+      },
+      "responseItemProperties": {
+        "ca_certificate": "2.1",
+        "ca_certificate_group": "2.1",
+        "id": "2.1",
+        "name": "2.1",
+        "uris": "2.1"
+      }
+    },
+    "PATCH /legal-holds": {
+      "minVersion": "2.17",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.17"
+      },
+      "responseItemProperties": {
+        "description": "2.17",
+        "id": "2.17",
+        "name": "2.17",
+        "realms": "2.19"
+      }
+    },
+    "PATCH /legal-holds/held-entities": {
+      "minVersion": "2.17",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.17"
+      },
+      "responseItemProperties": {
+        "file_system": "2.17",
+        "legal_hold": "2.17",
+        "path": "2.17",
+        "status": "2.17"
+      }
+    },
+    "PATCH /lifecycle-rules": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "abort_incomplete_multipart_uploads_after": "2.1",
+        "bucket": "2.0",
+        "cleanup_expired_object_delete_marker": "2.1",
+        "context": "2.17",
+        "enabled": "2.0",
+        "id": "2.0",
+        "keep_current_version_for": "2.1",
+        "keep_current_version_until": "2.1",
+        "keep_previous_version_for": "2.0",
+        "name": "2.0",
+        "prefix": "2.0",
+        "rule_id": "2.0"
+      }
+    },
+    "PATCH /link-aggregation-groups": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "id": "2.0",
+        "lag_speed": "2.0",
+        "mac_address": "2.0",
+        "name": "2.0",
+        "port_speed": "2.0",
+        "ports": "2.0",
+        "status": "2.0"
+      }
+    },
+    "PATCH /log-targets/file-systems": {
+      "minVersion": "2.20",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.20"
+      },
+      "responseItemProperties": {
+        "file_system": "2.20",
+        "id": "2.20",
+        "keep_for": "2.20",
+        "keep_size": "2.20",
+        "name": "2.20"
+      }
+    },
+    "PATCH /log-targets/object-store": {
+      "minVersion": "2.20",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.20"
+      },
+      "responseItemProperties": {
+        "bucket": "2.20",
+        "context": "2.20",
+        "id": "2.20",
+        "log_name_prefix": "2.20",
+        "log_rotate": "2.20",
+        "name": "2.20"
+      }
+    },
+    "PATCH /logs-async": {
+      "minVersion": "2.4",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.4"
+      },
+      "responseItemProperties": {
+        "available_files": "2.4",
+        "end_time": "2.4",
+        "hardware_components": "2.4",
+        "id": "2.4",
+        "last_request_time": "2.4",
+        "name": "2.4",
+        "processing": "2.4",
+        "progress": "2.4",
+        "start_time": "2.4"
+      }
+    },
+    "PATCH /management-access-policies": {
+      "minVersion": "2.19",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.19"
+      },
+      "responseItemProperties": {
+        "aggregation_strategy": "2.19",
+        "context": "2.24",
+        "enabled": "2.19",
+        "id": "2.19",
+        "is_local": "2.19",
+        "location": "2.19",
+        "name": "2.19",
+        "policy_type": "2.19",
+        "realms": "2.19",
+        "rules": "2.19",
+        "version": "2.19"
+      }
+    },
+    "PATCH /management-access-policies/roles/permissions": {
+      "minVersion": "2.26",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.26"
+      },
+      "responseItemProperties": {
+        "actions": "2.26",
+        "context": "2.26",
+        "id": "2.26",
+        "name": "2.26",
+        "resource": "2.26",
+        "role": "2.26"
+      }
+    },
+    "PATCH /management-access-policies/rules": {
+      "minVersion": "2.26",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.26"
+      },
+      "responseItemProperties": {
+        "context": "2.26",
+        "id": "2.26",
+        "index": "2.26",
+        "name": "2.26",
+        "policy": "2.26",
+        "policy_version": "2.26",
+        "role": "2.26",
+        "scope": "2.26"
+      }
+    },
+    "PATCH /management-authentication-policies": {
+      "minVersion": "2.22",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.22"
+      },
+      "responseItemProperties": {
+        "context": "2.22",
+        "enabled": "2.22",
+        "id": "2.22",
+        "is_local": "2.22",
+        "location": "2.22",
+        "name": "2.22",
+        "policy_type": "2.22",
+        "realms": "2.22",
+        "ssh": "2.22"
+      }
+    },
+    "PATCH /network-access-policies": {
+      "minVersion": "2.13",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.13"
+      },
+      "responseItemProperties": {
+        "enabled": "2.13",
+        "id": "2.13",
+        "is_local": "2.13",
+        "location": "2.13",
+        "name": "2.13",
+        "policy_type": "2.13",
+        "realms": "2.19",
+        "rules": "2.13",
+        "version": "2.13"
+      }
+    },
+    "PATCH /network-access-policies/rules": {
+      "minVersion": "2.13",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.13"
+      },
+      "responseItemProperties": {
+        "client": "2.13",
+        "effect": "2.13",
+        "id": "2.13",
+        "index": "2.13",
+        "interfaces": "2.13",
+        "name": "2.13",
+        "policy": "2.13",
+        "policy_version": "2.13"
+      }
+    },
+    "PATCH /network-interfaces": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "address": "2.0",
+        "attached_servers": "2.20",
+        "enabled": "2.0",
+        "gateway": "2.0",
+        "id": "2.0",
+        "mtu": "2.0",
+        "name": "2.0",
+        "netmask": "2.0",
+        "rdma_enabled": "2.28",
+        "realms": "2.19",
+        "services": "2.0",
+        "subnet": "2.0",
+        "type": "2.0",
+        "vlan": "2.0"
+      },
+      "removedResponseFields": [
+        {
+          "field": "server",
+          "location": "items",
+          "introducedVersion": "2.16",
+          "lastSeenVersion": "2.19"
+        }
+      ]
+    },
+    "PATCH /network-interfaces/connectors": {
+      "minVersion": "2.17",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.17"
+      },
+      "responseItemProperties": {
+        "connector_type": "2.17",
+        "id": "2.17",
+        "lane_speed": "2.17",
+        "lanes_per_port": "2.20",
+        "name": "2.17",
+        "port_count": "2.17",
+        "port_speed": "2.17",
+        "transceiver_type": "2.17"
+      }
+    },
+    "PATCH /nfs-export-policies": {
+      "minVersion": "2.3",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.3"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "enabled": "2.3",
+        "id": "2.3",
+        "is_local": "2.3",
+        "location": "2.3",
+        "name": "2.3",
+        "policy_type": "2.3",
+        "realms": "2.19",
+        "rules": "2.3",
+        "version": "2.3",
+        "workload": "2.23"
+      }
+    },
+    "PATCH /nfs-export-policies/rules": {
+      "minVersion": "2.3",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.3"
+      },
+      "responseItemProperties": {
+        "access": "2.3",
+        "anongid": "2.3",
+        "anonuid": "2.3",
+        "atime": "2.3",
+        "client": "2.3",
+        "context": "2.17",
+        "fileid_32bit": "2.3",
+        "id": "2.3",
+        "index": "2.3",
+        "name": "2.3",
+        "permission": "2.3",
+        "policy": "2.3",
+        "policy_version": "2.3",
+        "required_transport_security": "2.18",
+        "secure": "2.3",
+        "security": "2.3"
+      }
+    },
+    "PATCH /node-groups": {
+      "minVersion": "2.18",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.18"
+      },
+      "responseItemProperties": {
+        "id": "2.18",
+        "name": "2.18"
+      }
+    },
+    "PATCH /nodes": {
+      "minVersion": "2.18",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.18"
+      },
+      "responseItemProperties": {
+        "capacity": "2.18",
+        "chassis_serial_number": "2.23",
+        "data_addresses": "2.18",
+        "details": "2.18",
+        "id": "2.18",
+        "management_address": "2.18",
+        "name": "2.18",
+        "raw_capacity": "2.18",
+        "serial_number": "2.18",
+        "status": "2.18",
+        "unique": "2.18"
+      }
+    },
+    "PATCH /object-store-access-keys": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "access_key_id": "2.20",
+        "context": "2.17",
+        "created": "2.0",
+        "enabled": "2.0",
+        "name": "2.0",
+        "secret_access_key": "2.0",
+        "user": "2.0"
+      }
+    },
+    "PATCH /object-store-access-policies": {
+      "minVersion": "2.2",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.2"
+      },
+      "responseItemProperties": {
+        "account": "2.2",
+        "arn": "2.2",
+        "context": "2.17",
+        "created": "2.2",
+        "description": "2.2",
+        "enabled": "2.2",
+        "id": "2.2",
+        "is_local": "2.2",
+        "location": "2.2",
+        "name": "2.2",
+        "policy_type": "2.2",
+        "realms": "2.19",
+        "rules": "2.2",
+        "updated": "2.2"
+      }
+    },
+    "PATCH /object-store-access-policies/rules": {
+      "minVersion": "2.2",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.2"
+      },
+      "responseItemProperties": {
+        "actions": "2.2",
+        "conditions": "2.2",
+        "context": "2.17",
+        "effect": "2.2",
+        "name": "2.2",
+        "policy": "2.2",
+        "resources": "2.2"
+      }
+    },
+    "PATCH /object-store-account-exports": {
+      "minVersion": "2.20",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.20"
+      },
+      "responseItemProperties": {
+        "context": "2.20",
+        "enabled": "2.20",
+        "id": "2.20",
+        "member": "2.20",
+        "name": "2.20",
+        "policy": "2.20",
+        "realms": "2.20",
+        "server": "2.20"
+      }
+    },
+    "PATCH /object-store-accounts": {
+      "minVersion": "2.8",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.8"
+      },
+      "responseItemProperties": {
+        "bucket_defaults": "2.8",
+        "context": "2.17",
+        "created": "2.8",
+        "hard_limit_enabled": "2.8",
+        "id": "2.8",
+        "name": "2.8",
+        "object_count": "2.8",
+        "public_access_config": "2.12",
+        "quota_limit": "2.8",
+        "realms": "2.20",
+        "space": "2.8"
+      }
+    },
+    "PATCH /object-store-remote-credentials": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "access_key_id": "2.0",
+        "context": "2.17",
+        "id": "2.0",
+        "name": "2.0",
+        "realms": "2.20",
+        "remote": "2.0",
+        "secret_access_key": "2.0"
+      }
+    },
+    "PATCH /object-store-roles": {
+      "minVersion": "2.17",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.17"
+      },
+      "responseItemProperties": {
+        "account": "2.17",
+        "context": "2.17",
+        "created": "2.17",
+        "id": "2.17",
+        "max_session_duration": "2.17",
+        "name": "2.17",
+        "prn": "2.17",
+        "trusted_entities": "2.17"
+      }
+    },
+    "PATCH /object-store-roles/object-store-trust-policies/rules": {
+      "minVersion": "2.17",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.17"
+      },
+      "responseItemProperties": {
+        "actions": "2.17",
+        "conditions": "2.17",
+        "context": "2.17",
+        "effect": "2.17",
+        "index": "2.17",
+        "name": "2.17",
+        "policy": "2.17",
+        "principals": "2.17"
+      }
+    },
+    "PATCH /object-store-roles/object-store-trust-policies/upload": {
+      "minVersion": "2.17",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.17"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "enabled": "2.17",
+        "id": "2.17",
+        "is_local": "2.17",
+        "location": "2.17",
+        "name": "2.17",
+        "policy_type": "2.17",
+        "realms": "2.19",
+        "role": "2.17",
+        "rules": "2.17"
+      }
+    },
+    "PATCH /object-store-virtual-hosts": {
+      "minVersion": "2.20",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.20"
+      },
+      "responseItemProperties": {
+        "attached_servers": "2.20",
+        "context": "2.20",
+        "hostname": "2.20",
+        "id": "2.20",
+        "name": "2.20",
+        "realms": "2.20"
+      }
+    },
+    "PATCH /password-policies": {
+      "minVersion": "2.16",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.16"
+      },
+      "responseItemProperties": {
+        "enabled": "2.16",
+        "enforce_dictionary_check": "2.16",
+        "enforce_username_check": "2.16",
+        "id": "2.16",
+        "is_local": "2.16",
+        "location": "2.16",
+        "lockout_duration": "2.16",
+        "max_login_attempts": "2.16",
+        "max_password_age": "2.18",
+        "min_character_groups": "2.16",
+        "min_characters_per_group": "2.16",
+        "min_password_age": "2.16",
+        "min_password_length": "2.16",
+        "name": "2.16",
+        "password_history": "2.16",
+        "policy_type": "2.16",
+        "realms": "2.19"
+      }
+    },
+    "PATCH /policies": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "enabled": "2.0",
+        "id": "2.0",
+        "is_local": "2.0",
+        "location": "2.0",
+        "name": "2.0",
+        "policy_type": "2.2",
+        "realms": "2.19",
+        "retention_lock": "2.5",
+        "rules": "2.0",
+        "workload": "2.23"
+      }
+    },
+    "PATCH /presets/workload": {
+      "minVersion": "2.23",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.23"
+      },
+      "responseItemProperties": {
+        "context": "2.23",
+        "description": "2.23",
+        "directory_configurations": "2.23",
+        "export_configurations": "2.23",
+        "id": "2.23",
+        "name": "2.23",
+        "parameters": "2.23",
+        "periodic_replication_configurations": "2.23",
+        "placement_configurations": "2.23",
+        "platform_features": "2.23",
+        "qos_configurations": "2.23",
+        "quota_configurations": "2.23",
+        "revision": "2.23",
+        "snapshot_configurations": "2.23",
+        "volume_configurations": "2.23",
+        "workload_tags": "2.23",
+        "workload_type": "2.23"
+      }
+    },
+    "PATCH /qos-policies": {
+      "minVersion": "2.17",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.17"
+      },
+      "responseItemProperties": {
+        "context": "2.23",
+        "enabled": "2.17",
+        "id": "2.17",
+        "is_local": "2.17",
+        "location": "2.17",
+        "max_total_bytes_per_sec": "2.17",
+        "max_total_ops_per_sec": "2.17",
+        "name": "2.17",
+        "policy_type": "2.17",
+        "realms": "2.19"
+      }
+    },
+    "PATCH /quotas/groups": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "file_system": "2.0",
+        "file_system_default_quota": "2.0",
+        "group": "2.0",
+        "name": "2.0",
+        "quota": "2.0",
+        "usage": "2.0"
+      }
+    },
+    "PATCH /quotas/settings": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "contact": "2.0",
+        "direct_notifications_enabled": "2.0",
+        "id": "2.0",
+        "name": "2.0"
+      }
+    },
+    "PATCH /quotas/users": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "file_system": "2.0",
+        "file_system_default_quota": "2.0",
+        "name": "2.0",
+        "quota": "2.0",
+        "usage": "2.0",
+        "user": "2.0"
+      }
+    },
+    "PATCH /rapid-data-locking": {
+      "minVersion": "2.1",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.1"
+      },
+      "responseItemProperties": {
+        "enabled": "2.1",
+        "kmip_server": "2.1"
+      }
+    },
+    "PATCH /realms": {
+      "minVersion": "2.19",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.19"
+      },
+      "responseItemProperties": {
+        "created": "2.19",
+        "default_inbound_tls_policy": "2.19",
+        "destroyed": "2.19",
+        "id": "2.19",
+        "name": "2.19",
+        "space": "2.19",
+        "time_remaining": "2.19"
+      }
+    },
+    "PATCH /realms/defaults": {
+      "minVersion": "2.20",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.20"
+      },
+      "responseItemProperties": {
+        "context": "2.20",
+        "object_store": "2.20",
+        "realm": "2.20"
+      }
+    },
+    "PATCH /remote-arrays": {
+      "minVersion": "2.26",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.26"
+      },
+      "responseItemProperties": {
+        "api_versions": "2.26",
+        "fleet": "2.26",
+        "id": "2.26",
+        "is_local": "2.26",
+        "model": "2.26",
+        "name": "2.26",
+        "os": "2.26",
+        "topology_group": "2.26",
+        "version": "2.26"
+      }
+    },
+    "PATCH /s3-export-policies": {
+      "minVersion": "2.20",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.20"
+      },
+      "responseItemProperties": {
+        "context": "2.20",
+        "enabled": "2.20",
+        "id": "2.20",
+        "is_local": "2.20",
+        "location": "2.20",
+        "name": "2.20",
+        "policy_type": "2.20",
+        "realms": "2.20",
+        "rules": "2.20"
+      }
+    },
+    "PATCH /s3-export-policies/rules": {
+      "minVersion": "2.20",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.20"
+      },
+      "responseItemProperties": {
+        "actions": "2.20",
+        "context": "2.20",
+        "effect": "2.20",
+        "name": "2.20",
+        "policy": "2.20",
+        "resources": "2.20"
+      }
+    },
+    "PATCH /servers": {
+      "minVersion": "2.16",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.16"
+      },
+      "responseItemProperties": {
+        "created": "2.16",
+        "directory_services": "2.16",
+        "dns": "2.16",
+        "id": "2.16",
+        "local_directory_service": "2.24",
+        "name": "2.16",
+        "realms": "2.19"
+      }
+    },
+    "PATCH /smb-client-policies": {
+      "minVersion": "2.10",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.10"
+      },
+      "responseItemProperties": {
+        "access_based_enumeration_enabled": "2.17",
+        "context": "2.17",
+        "enabled": "2.10",
+        "id": "2.10",
+        "is_local": "2.10",
+        "location": "2.10",
+        "name": "2.10",
+        "policy_type": "2.10",
+        "realms": "2.19",
+        "rules": "2.10",
+        "version": "2.10",
+        "workload": "2.23"
+      }
+    },
+    "PATCH /smb-client-policies/rules": {
+      "minVersion": "2.10",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.10"
+      },
+      "responseItemProperties": {
+        "client": "2.10",
+        "context": "2.17",
+        "encryption": "2.11",
+        "id": "2.10",
+        "index": "2.10",
+        "name": "2.10",
+        "permission": "2.10",
+        "policy": "2.10",
+        "policy_version": "2.10"
+      }
+    },
+    "PATCH /smb-share-policies": {
+      "minVersion": "2.10",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.10"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "enabled": "2.10",
+        "id": "2.10",
+        "is_local": "2.10",
+        "location": "2.10",
+        "name": "2.10",
+        "policy_type": "2.10",
+        "realms": "2.19",
+        "rules": "2.10",
+        "workload": "2.23"
+      }
+    },
+    "PATCH /smb-share-policies/rules": {
+      "minVersion": "2.10",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.10"
+      },
+      "responseItemProperties": {
+        "change": "2.10",
+        "context": "2.17",
+        "full_control": "2.10",
+        "id": "2.10",
+        "name": "2.10",
+        "policy": "2.10",
+        "principal": "2.10",
+        "read": "2.10"
+      }
+    },
+    "PATCH /smtp-servers": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "encryption_mode": "2.15",
+        "id": "2.0",
+        "name": "2.0",
+        "relay_host": "2.0",
+        "sender_domain": "2.0"
+      }
+    },
+    "PATCH /snmp-agents": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "engine_id": "2.0",
+        "id": "2.0",
+        "name": "2.0",
+        "v2c": "2.0",
+        "v3": "2.0",
+        "version": "2.0"
+      }
+    },
+    "PATCH /snmp-managers": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "host": "2.0",
+        "id": "2.0",
+        "name": "2.0",
+        "notification": "2.0",
+        "v2c": "2.0",
+        "v3": "2.0",
+        "version": "2.0"
+      }
+    },
+    "PATCH /ssh-certificate-authority-policies": {
+      "minVersion": "2.14",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.14"
+      },
+      "responseItemProperties": {
+        "context": "2.24",
+        "enabled": "2.14",
+        "id": "2.14",
+        "is_local": "2.14",
+        "location": "2.14",
+        "name": "2.14",
+        "policy_type": "2.14",
+        "realms": "2.19",
+        "signing_authority": "2.14",
+        "static_authorized_principals": "2.14"
+      }
+    },
+    "PATCH /sso/oidc/idps": {
+      "minVersion": "2.17",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.17"
+      },
+      "responseItemProperties": {
+        "enabled": "2.17",
+        "id": "2.17",
+        "idp": "2.17",
+        "name": "2.17",
+        "prn": "2.17",
+        "services": "2.17"
+      }
+    },
+    "PATCH /sso/saml2/idps": {
+      "minVersion": "2.15",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.15"
+      },
+      "responseItemProperties": {
+        "array_url": "2.15",
+        "binding": "2.17",
+        "enabled": "2.15",
+        "id": "2.15",
+        "idp": "2.15",
+        "management": "2.24",
+        "name": "2.15",
+        "prn": "2.17",
+        "services": "2.17",
+        "sp": "2.15"
+      }
+    },
+    "PATCH /sso/saml2/idps/test": {
+      "minVersion": "2.16",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.16"
+      },
+      "responseItemProperties": {
+        "component_address": "2.16",
+        "component_name": "2.16",
+        "description": "2.16",
+        "destination": "2.16",
+        "enabled": "2.16",
+        "resource": "2.16",
+        "result_details": "2.16",
+        "success": "2.16",
+        "test_type": "2.16"
+      }
+    },
+    "PATCH /storage-class-tiering-policies": {
+      "minVersion": "2.18",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.18"
+      },
+      "responseItemProperties": {
+        "archival_rules": "2.18",
+        "enabled": "2.18",
+        "id": "2.18",
+        "is_local": "2.18",
+        "location": "2.18",
+        "name": "2.18",
+        "policy_type": "2.18",
+        "realms": "2.19",
+        "retrieval_rules": "2.18"
+      }
+    },
+    "PATCH /subnets": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "enabled": "2.0",
+        "gateway": "2.0",
+        "id": "2.0",
+        "interfaces": "2.0",
+        "link_aggregation_group": "2.0",
+        "mtu": "2.0",
+        "name": "2.0",
+        "prefix": "2.0",
+        "services": "2.0",
+        "vlan": "2.0"
+      }
+    },
+    "PATCH /support": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "edge_agent_update_enabled": "2.18",
+        "edge_management_enabled": "2.18",
+        "id": "2.0",
+        "name": "2.0",
+        "phonehome_enabled": "2.0",
+        "proxy": "2.0",
+        "remote_assist_active": "2.0",
+        "remote_assist_duration": "2.14",
+        "remote_assist_expires": "2.0",
+        "remote_assist_opened": "2.0",
+        "remote_assist_paths": "2.0",
+        "remote_assist_status": "2.0"
+      }
+    },
+    "PATCH /support-diagnostics/settings": {
+      "minVersion": "2.24",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.24"
+      },
+      "responseItemProperties": {
+        "last_updated": "2.24",
+        "version": "2.24"
+      }
+    },
+    "PATCH /support/verification-keys": {
+      "minVersion": "2.7",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.7"
+      },
+      "responseItemProperties": {
+        "key_id": "2.7",
+        "name": "2.7",
+        "verification_key": "2.7"
+      }
+    },
+    "PATCH /syslog-servers": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "id": "2.0",
+        "name": "2.0",
+        "services": "2.14",
+        "sources": "2.20",
+        "uri": "2.0"
+      }
+    },
+    "PATCH /syslog-servers/settings": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "ca_certificate": "2.0",
+        "ca_certificate_group": "2.0",
+        "id": "2.0",
+        "name": "2.0"
+      }
+    },
+    "PATCH /targets": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "address": "2.0",
+        "ca_certificate_group": "2.0",
+        "id": "2.0",
+        "name": "2.0",
+        "status": "2.0",
+        "status_details": "2.0"
+      }
+    },
+    "PATCH /tls-policies": {
+      "minVersion": "2.17",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.17"
+      },
+      "responseItemProperties": {
+        "appliance_certificate": "2.17",
+        "client_certificates_required": "2.18",
+        "disabled_tls_ciphers": "2.17",
+        "enabled": "2.17",
+        "enabled_tls_ciphers": "2.17",
+        "id": "2.17",
+        "is_local": "2.17",
+        "location": "2.17",
+        "min_tls_version": "2.17",
+        "name": "2.17",
+        "policy_type": "2.17",
+        "realms": "2.19",
+        "trusted_client_certificate_authority": "2.18",
+        "verify_client_certificate_trust": "2.18"
+      }
+    },
+    "PATCH /topology-groups": {
+      "minVersion": "2.26",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.26"
+      },
+      "responseItemProperties": {
+        "context": "2.26",
+        "id": "2.26",
+        "name": "2.26",
+        "parent_topology_group": "2.26"
+      }
+    },
+    "PATCH /user-group-quota-policies": {
+      "minVersion": "2.25",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.25"
+      },
+      "responseItemProperties": {
+        "context": "2.25",
+        "enabled": "2.25",
+        "id": "2.25",
+        "is_local": "2.25",
+        "location": "2.25",
+        "name": "2.25",
+        "policy_type": "2.25",
+        "realms": "2.25",
+        "rules": "2.25",
+        "version": "2.25"
+      }
+    },
+    "PATCH /user-group-quota-policies/rules": {
+      "minVersion": "2.25",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.25"
+      },
+      "responseItemProperties": {
+        "context": "2.25",
+        "enforced": "2.25",
+        "id": "2.25",
+        "index": "2.25",
+        "name": "2.25",
+        "notifications": "2.25",
+        "policy": "2.25",
+        "policy_version": "2.25",
+        "quota_limit": "2.25",
+        "quota_type": "2.25",
+        "subject": "2.25"
+      }
+    },
+    "PATCH /workloads": {
+      "minVersion": "2.23",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.23"
+      },
+      "responseItemProperties": {
+        "context": "2.23",
+        "created": "2.23",
+        "destroyed": "2.23",
+        "id": "2.23",
+        "name": "2.23",
+        "preset": "2.23",
+        "status": "2.23",
+        "status_details": "2.23",
+        "time_remaining": "2.23"
+      }
+    },
+    "PATCH /worm-data-policies": {
+      "minVersion": "2.15",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.15"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "default_retention": "2.15",
+        "enabled": "2.15",
+        "id": "2.15",
+        "is_local": "2.15",
+        "location": "2.15",
+        "max_retention": "2.15",
+        "min_retention": "2.15",
+        "mode": "2.15",
+        "name": "2.15",
+        "policy_type": "2.15",
+        "realms": "2.19",
+        "retention_lock": "2.15"
+      }
+    },
+    "POST /active-directory": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "ca_certificate": "2.27",
+        "ca_certificate_group": "2.27",
+        "computer_name": "2.0",
+        "directory_servers": "2.0",
+        "domain": "2.0",
+        "encryption_types": "2.0",
+        "global_catalog_servers": "2.12",
+        "id": "2.0",
+        "join_ou": "2.0",
+        "kerberos_servers": "2.0",
+        "name": "2.0",
+        "realms": "2.19",
+        "server": "2.16",
+        "service_principal_names": "2.0"
+      }
+    },
+    "POST /admins": {
+      "minVersion": "2.15",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.15"
+      },
+      "responseItemProperties": {
+        "admin_type": "2.24",
+        "api_token": "2.15",
+        "authorization_model": "2.24",
+        "context": "2.22",
+        "id": "2.15",
+        "is_local": "2.15",
+        "locked": "2.15",
+        "lockout_remaining": "2.15",
+        "management_access_policies": "2.19",
+        "name": "2.15",
+        "public_key": "2.15",
+        "role": "2.15"
+      }
+    },
+    "POST /admins/api-tokens": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "admin": "2.0",
+        "api_token": "2.0",
+        "context": "2.24"
+      }
+    },
+    "POST /admins/management-access-policies": {
+      "minVersion": "2.19",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.19"
+      },
+      "responseItemProperties": {
+        "context": "2.24",
+        "member": "2.19",
+        "policy": "2.19"
+      }
+    },
+    "POST /admins/management-authentication-policies": {
+      "minVersion": "2.22",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.22"
+      },
+      "responseItemProperties": {
+        "context": "2.22",
+        "member": "2.22",
+        "policy": "2.22"
+      }
+    },
+    "POST /admins/ssh-certificate-authority-policies": {
+      "minVersion": "2.14",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.14"
+      },
+      "responseItemProperties": {
+        "context": "2.24",
+        "member": "2.14",
+        "policy": "2.14"
+      }
+    },
+    "POST /alert-watchers": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "enabled": "2.0",
+        "id": "2.0",
+        "minimum_notification_severity": "2.0",
+        "name": "2.0"
+      }
+    },
+    "POST /api-clients": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "access_policies": "2.19",
+        "access_token_ttl_in_ms": "2.0",
+        "enabled": "2.0",
+        "id": "2.0",
+        "issuer": "2.0",
+        "key_id": "2.0",
+        "max_role": "2.0",
+        "name": "2.0",
+        "public_key": "2.0"
+      }
+    },
+    "POST /api/login": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "username": "2.0"
+      },
+      "responseItemProperties": {}
+    },
+    "POST /array-connections": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "ca_certificate_group": "2.0",
+        "context": "2.17",
+        "encrypted": "2.0",
+        "id": "2.0",
+        "management_address": "2.0",
+        "os": "2.17",
+        "remote": "2.0",
+        "replication_addresses": "2.0",
+        "status": "2.0",
+        "throttle": "2.3",
+        "type": "2.17",
+        "version": "2.0"
+      }
+    },
+    "POST /array-connections/connection-key": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "connection_key": "2.0",
+        "created": "2.0",
+        "expires": "2.0"
+      }
+    },
+    "POST /arrays/erasures": {
+      "minVersion": "2.18",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.18"
+      },
+      "responseItemProperties": {
+        "details": "2.18",
+        "name": "2.18",
+        "sanitization_certificate": "2.18",
+        "status": "2.18"
+      }
+    },
+    "POST /arrays/factory-reset-token": {
+      "minVersion": "2.1",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.1"
+      },
+      "responseItemProperties": {
+        "name": "2.1",
+        "token": "2.1"
+      }
+    },
+    "POST /arrays/management-authentication-policies": {
+      "minVersion": "2.22",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.22"
+      },
+      "responseItemProperties": {
+        "context": "2.22",
+        "member": "2.22",
+        "policy": "2.22"
+      }
+    },
+    "POST /arrays/ssh-certificate-authority-policies": {
+      "minVersion": "2.14",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.14"
+      },
+      "responseItemProperties": {
+        "context": "2.24",
+        "member": "2.14",
+        "policy": "2.14"
+      }
+    },
+    "POST /audit-file-systems-policies": {
+      "minVersion": "2.14",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.14"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "control_type": "2.18",
+        "enabled": "2.14",
+        "id": "2.14",
+        "is_local": "2.14",
+        "location": "2.14",
+        "log_targets": "2.14",
+        "name": "2.14",
+        "policy_type": "2.14",
+        "realms": "2.19",
+        "rules": "2.18"
+      }
+    },
+    "POST /audit-file-systems-policies/members": {
+      "minVersion": "2.14",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.14"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "member": "2.14",
+        "policy": "2.14"
+      }
+    },
+    "POST /audit-object-store-policies": {
+      "minVersion": "2.20",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.20"
+      },
+      "responseItemProperties": {
+        "context": "2.20",
+        "enabled": "2.20",
+        "id": "2.20",
+        "is_local": "2.20",
+        "location": "2.20",
+        "log_targets": "2.20",
+        "name": "2.20",
+        "policy_type": "2.20",
+        "realms": "2.20"
+      }
+    },
+    "POST /audit-object-store-policies/members": {
+      "minVersion": "2.20",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.20"
+      },
+      "responseItemProperties": {
+        "context": "2.20",
+        "member": "2.20",
+        "policy": "2.20"
+      }
+    },
+    "POST /bucket-replica-links": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0",
+        "total": "2.2"
+      },
+      "responseItemProperties": {
+        "cascading_enabled": "2.2",
+        "context": "2.17",
+        "direction": "2.0",
+        "id": "2.0",
+        "lag": "2.0",
+        "local_bucket": "2.0",
+        "object_backlog": "2.2",
+        "paused": "2.0",
+        "recovery_point": "2.0",
+        "remote": "2.0",
+        "remote_bucket": "2.0",
+        "remote_credentials": "2.0",
+        "status": "2.0",
+        "status_details": "2.0"
+      }
+    },
+    "POST /buckets": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "account": "2.0",
+        "bucket_type": "2.4",
+        "context": "2.17",
+        "created": "2.0",
+        "destroyed": "2.0",
+        "eradication_config": "2.8",
+        "hard_limit_enabled": "2.8",
+        "id": "2.0",
+        "name": "2.0",
+        "object_count": "2.0",
+        "object_lock_config": "2.8",
+        "public_access_config": "2.12",
+        "public_status": "2.12",
+        "qos_policy": "2.20",
+        "quota_limit": "2.8",
+        "retention_lock": "2.8",
+        "space": "2.0",
+        "storage_class": "2.19",
+        "time_remaining": "2.0",
+        "time_remaining_status": "2.14",
+        "versioning": "2.0"
+      }
+    },
+    "POST /buckets/audit-filters": {
+      "minVersion": "2.20",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.20"
+      },
+      "responseItemProperties": {
+        "actions": "2.20",
+        "bucket": "2.20",
+        "context": "2.20",
+        "name": "2.20",
+        "s3_prefixes": "2.20"
+      }
+    },
+    "POST /buckets/bucket-access-policies": {
+      "minVersion": "2.12",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.12"
+      },
+      "responseItemProperties": {
+        "bucket": "2.12",
+        "context": "2.17",
+        "enabled": "2.12",
+        "id": "2.12",
+        "is_local": "2.12",
+        "location": "2.12",
+        "name": "2.12",
+        "policy_type": "2.12",
+        "realms": "2.19",
+        "rules": "2.12"
+      }
+    },
+    "POST /buckets/bucket-access-policies/rules": {
+      "minVersion": "2.12",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.12"
+      },
+      "responseItemProperties": {
+        "actions": "2.12",
+        "context": "2.17",
+        "effect": "2.12",
+        "name": "2.12",
+        "policy": "2.12",
+        "principals": "2.12",
+        "resources": "2.12"
+      }
+    },
+    "POST /buckets/cross-origin-resource-sharing-policies": {
+      "minVersion": "2.12",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.12"
+      },
+      "responseItemProperties": {
+        "bucket": "2.12",
+        "context": "2.17",
+        "enabled": "2.12",
+        "id": "2.12",
+        "is_local": "2.12",
+        "location": "2.12",
+        "name": "2.12",
+        "policy_type": "2.12",
+        "realms": "2.19",
+        "rules": "2.12"
+      }
+    },
+    "POST /buckets/cross-origin-resource-sharing-policies/rules": {
+      "minVersion": "2.12",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.12"
+      },
+      "responseItemProperties": {
+        "allowed_headers": "2.12",
+        "allowed_methods": "2.12",
+        "allowed_origins": "2.12",
+        "context": "2.17",
+        "name": "2.12",
+        "policy": "2.12"
+      }
+    },
+    "POST /certificate-groups": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "id": "2.0",
+        "name": "2.0",
+        "realms": "2.19"
+      }
+    },
+    "POST /certificate-groups/certificates": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "group": "2.0",
+        "member": "2.0"
+      }
+    },
+    "POST /certificates": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "certificate": "2.0",
+        "certificate_type": "2.0",
+        "common_name": "2.0",
+        "country": "2.0",
+        "email": "2.0",
+        "id": "2.0",
+        "intermediate_certificate": "2.0",
+        "issued_by": "2.0",
+        "issued_to": "2.0",
+        "key_algorithm": "2.20",
+        "key_size": "2.0",
+        "locality": "2.0",
+        "name": "2.0",
+        "organization": "2.0",
+        "organizational_unit": "2.0",
+        "realms": "2.19",
+        "state": "2.0",
+        "status": "2.0",
+        "subject_alternative_names": "2.0",
+        "valid_from": "2.0",
+        "valid_to": "2.0"
+      }
+    },
+    "POST /certificates/certificate-groups": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "group": "2.0",
+        "member": "2.0"
+      }
+    },
+    "POST /certificates/certificate-signing-requests": {
+      "minVersion": "2.20",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.20"
+      },
+      "responseItemProperties": {
+        "certificate_signing_request": "2.20"
+      }
+    },
+    "POST /data-eviction-policies": {
+      "minVersion": "2.21",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.21"
+      },
+      "responseItemProperties": {
+        "context": "2.21",
+        "enabled": "2.21",
+        "id": "2.21",
+        "is_local": "2.21",
+        "keep_size": "2.21",
+        "location": "2.21",
+        "name": "2.21",
+        "policy_type": "2.21",
+        "realms": "2.21"
+      }
+    },
+    "POST /data-eviction-policies/file-systems": {
+      "minVersion": "2.21",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.21"
+      },
+      "responseItemProperties": {
+        "context": "2.21",
+        "member": "2.21",
+        "policy": "2.21"
+      }
+    },
+    "POST /directory-services/local/directory-services": {
+      "minVersion": "2.24",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.24"
+      },
+      "responseItemProperties": {
+        "context": "2.24",
+        "destroyed": "2.24",
+        "domain": "2.24",
+        "id": "2.24",
+        "name": "2.24",
+        "realms": "2.24",
+        "server": "2.24",
+        "time_remaining": "2.24"
+      }
+    },
+    "POST /directory-services/local/groups": {
+      "minVersion": "2.24",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.24"
+      },
+      "responseItemProperties": {
+        "built_in": "2.24",
+        "context": "2.24",
+        "email": "2.24",
+        "gid": "2.24",
+        "local_directory_service": "2.24",
+        "name": "2.24",
+        "realms": "2.24",
+        "server": "2.24",
+        "sid": "2.24"
+      }
+    },
+    "POST /directory-services/local/groups/members": {
+      "minVersion": "2.24",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.24"
+      },
+      "responseItemProperties": {
+        "context": "2.24",
+        "group": "2.24",
+        "group_gid": "2.24",
+        "is_primary_group": "2.24",
+        "local_directory_service": "2.24",
+        "member": "2.24",
+        "member_id": "2.24",
+        "realms": "2.24",
+        "server": "2.24"
+      }
+    },
+    "POST /directory-services/local/users": {
+      "minVersion": "2.24",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.24"
+      },
+      "responseItemProperties": {
+        "built_in": "2.24",
+        "context": "2.24",
+        "email": "2.24",
+        "enabled": "2.24",
+        "local_directory_service": "2.24",
+        "name": "2.24",
+        "primary_group": "2.24",
+        "realms": "2.24",
+        "server": "2.24",
+        "sid": "2.24",
+        "uid": "2.24"
+      }
+    },
+    "POST /directory-services/local/users/members": {
+      "minVersion": "2.24",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.24"
+      },
+      "responseItemProperties": {
+        "context": "2.24",
+        "group": "2.24",
+        "group_gid": "2.24",
+        "is_primary_group": "2.24",
+        "local_directory_service": "2.24",
+        "member": "2.24",
+        "member_id": "2.24",
+        "realms": "2.24",
+        "server": "2.24"
+      }
+    },
+    "POST /directory-services/roles": {
+      "minVersion": "2.14",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.14"
+      },
+      "responseItemProperties": {
+        "group": "2.14",
+        "group_base": "2.14",
+        "id": "2.14",
+        "management_access_policies": "2.19",
+        "name": "2.14",
+        "role": "2.14"
+      }
+    },
+    "POST /directory-services/roles/management-access-policies": {
+      "minVersion": "2.19",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.19"
+      },
+      "responseItemProperties": {
+        "member": "2.19",
+        "policy": "2.19"
+      }
+    },
+    "POST /dns": {
+      "minVersion": "2.16",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.16"
+      },
+      "responseItemProperties": {
+        "ca_certificate": "2.25",
+        "ca_certificate_group": "2.25",
+        "context": "2.25",
+        "domain": "2.16",
+        "id": "2.16",
+        "name": "2.16",
+        "nameservers": "2.16",
+        "realms": "2.19",
+        "services": "2.16",
+        "sources": "2.16"
+      }
+    },
+    "POST /file-system-exports": {
+      "minVersion": "2.16",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.16"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "enabled": "2.16",
+        "export_name": "2.16",
+        "id": "2.16",
+        "member": "2.16",
+        "name": "2.16",
+        "policy": "2.16",
+        "policy_type": "2.16",
+        "server": "2.16",
+        "share_policy": "2.16",
+        "status": "2.16",
+        "workload": "2.23"
+      }
+    },
+    "POST /file-system-junctions": {
+      "minVersion": "2.25",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.25"
+      },
+      "responseItemProperties": {
+        "context": "2.25",
+        "destination_file_system": "2.25",
+        "id": "2.25",
+        "junction_origin_path": "2.25",
+        "name": "2.25",
+        "origin_file_system": "2.25",
+        "status": "2.25"
+      }
+    },
+    "POST /file-system-replica-links": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "direction": "2.0",
+        "id": "2.0",
+        "lag": "2.0",
+        "link_type": "2.17",
+        "local_file_system": "2.0",
+        "policies": "2.0",
+        "recovery_point": "2.0",
+        "remote": "2.0",
+        "remote_file_system": "2.0",
+        "status": "2.0",
+        "status_details": "2.0"
+      }
+    },
+    "POST /file-system-replica-links/policies": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "context": "2.22",
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "link": "2.0",
+        "member": "2.0",
+        "policy": "2.0"
+      }
+    },
+    "POST /file-system-snapshots": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "created": "2.0",
+        "destroyed": "2.0",
+        "id": "2.0",
+        "name": "2.0",
+        "owner": "2.0",
+        "owner_destroyed": "2.0",
+        "policies": "2.12",
+        "policy": "2.0",
+        "source": "2.0",
+        "suffix": "2.0",
+        "time_remaining": "2.0"
+      },
+      "removedResponseFields": [
+        {
+          "field": "copyable",
+          "location": "items",
+          "introducedVersion": "2.0",
+          "lastSeenVersion": "2.10"
+        }
+      ]
+    },
+    "POST /file-systems": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "created": "2.0",
+        "default_group_quota": "2.0",
+        "default_user_quota": "2.0",
+        "destroyed": "2.0",
+        "eradication_config": "2.15",
+        "fast_remove_directory_enabled": "2.0",
+        "group_ownership": "2.13",
+        "hard_limit_enabled": "2.0",
+        "http": "2.0",
+        "id": "2.0",
+        "multi_protocol": "2.0",
+        "name": "2.0",
+        "nfs": "2.0",
+        "node_group": "2.18",
+        "promotion_status": "2.0",
+        "provisioned": "2.0",
+        "qos_policy": "2.17",
+        "realms": "2.19",
+        "requested_promotion_state": "2.0",
+        "smb": "2.0",
+        "snapshot_directory_enabled": "2.0",
+        "source": "2.0",
+        "space": "2.0",
+        "storage_class": "2.16",
+        "time_remaining": "2.0",
+        "workload": "2.23",
+        "writable": "2.0"
+      }
+    },
+    "POST /file-systems/audit-policies": {
+      "minVersion": "2.14",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.14"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "member": "2.14",
+        "policy": "2.14"
+      }
+    },
+    "POST /file-systems/data-eviction-policies": {
+      "minVersion": "2.21",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.21"
+      },
+      "responseItemProperties": {
+        "context": "2.21",
+        "member": "2.21",
+        "policy": "2.21"
+      }
+    },
+    "POST /file-systems/locks/nlm-reclamations": {
+      "minVersion": "2.8",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.8"
+      },
+      "responseItemProperties": {
+        "context": "2.22",
+        "end": "2.8",
+        "start": "2.8"
+      }
+    },
+    "POST /file-systems/policies": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "member": "2.0",
+        "policy": "2.0"
+      }
+    },
+    "POST /file-systems/user-group-quota-policies": {
+      "minVersion": "2.25",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.25"
+      },
+      "responseItemProperties": {
+        "context": "2.25",
+        "member": "2.25",
+        "policy": "2.25"
+      }
+    },
+    "POST /fleets": {
+      "minVersion": "2.17",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.17"
+      },
+      "responseItemProperties": {
+        "id": "2.17",
+        "is_local": "2.17",
+        "name": "2.17"
+      }
+    },
+    "POST /fleets/fleet-key": {
+      "minVersion": "2.17",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.17"
+      },
+      "responseItemProperties": {
+        "created": "2.17",
+        "expires": "2.17",
+        "fleet_key": "2.17"
+      }
+    },
+    "POST /fleets/members": {
+      "minVersion": "2.17",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.17"
+      },
+      "responseItemProperties": {
+        "coordinator_of": "2.20",
+        "fleet": "2.17",
+        "member": "2.17",
+        "status": "2.17",
+        "status_details": "2.17"
+      }
+    },
+    "POST /fleets/members/batch": {
+      "minVersion": "2.27",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.27"
+      },
+      "responseItemProperties": {
+        "certificate_details": "2.27",
+        "management_address": "2.27",
+        "member": "2.27",
+        "status": "2.27",
+        "status_details": "2.27"
+      }
+    },
+    "POST /keytabs": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "encryption_type": "2.0",
+        "fqdn": "2.0",
+        "id": "2.0",
+        "kvno": "2.0",
+        "name": "2.0",
+        "prefix": "2.0",
+        "principal": "2.0",
+        "realm": "2.0",
+        "server": "2.16",
+        "source": "2.0",
+        "suffix": "2.0"
+      }
+    },
+    "POST /keytabs/upload": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {},
+      "responseItemProperties": {}
+    },
+    "POST /kmip": {
+      "minVersion": "2.1",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.1"
+      },
+      "responseItemProperties": {
+        "ca_certificate": "2.1",
+        "ca_certificate_group": "2.1",
+        "id": "2.1",
+        "name": "2.1",
+        "uris": "2.1"
+      }
+    },
+    "POST /legal-holds": {
+      "minVersion": "2.17",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.17"
+      },
+      "responseItemProperties": {
+        "description": "2.17",
+        "id": "2.17",
+        "name": "2.17",
+        "realms": "2.19"
+      }
+    },
+    "POST /legal-holds/held-entities": {
+      "minVersion": "2.17",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.17"
+      },
+      "responseItemProperties": {
+        "file_system": "2.17",
+        "legal_hold": "2.17",
+        "path": "2.17",
+        "status": "2.17"
+      }
+    },
+    "POST /lifecycle-rules": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "abort_incomplete_multipart_uploads_after": "2.1",
+        "bucket": "2.0",
+        "cleanup_expired_object_delete_marker": "2.1",
+        "context": "2.17",
+        "enabled": "2.0",
+        "id": "2.0",
+        "keep_current_version_for": "2.1",
+        "keep_current_version_until": "2.1",
+        "keep_previous_version_for": "2.0",
+        "name": "2.0",
+        "prefix": "2.0",
+        "rule_id": "2.0"
+      }
+    },
+    "POST /link-aggregation-groups": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "id": "2.0",
+        "lag_speed": "2.0",
+        "mac_address": "2.0",
+        "name": "2.0",
+        "port_speed": "2.0",
+        "ports": "2.0",
+        "status": "2.0"
+      }
+    },
+    "POST /log-targets/file-systems": {
+      "minVersion": "2.20",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.20"
+      },
+      "responseItemProperties": {
+        "file_system": "2.20",
+        "id": "2.20",
+        "keep_for": "2.20",
+        "keep_size": "2.20",
+        "name": "2.20"
+      }
+    },
+    "POST /log-targets/object-store": {
+      "minVersion": "2.20",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.20"
+      },
+      "responseItemProperties": {
+        "bucket": "2.20",
+        "context": "2.20",
+        "id": "2.20",
+        "log_name_prefix": "2.20",
+        "log_rotate": "2.20",
+        "name": "2.20"
+      }
+    },
+    "POST /maintenance-windows": {
+      "minVersion": "2.16",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.16"
+      },
+      "responseItemProperties": {
+        "created": "2.16",
+        "expires": "2.16",
+        "id": "2.16",
+        "name": "2.16"
+      }
+    },
+    "POST /management-access-policies": {
+      "minVersion": "2.19",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.19"
+      },
+      "responseItemProperties": {
+        "aggregation_strategy": "2.19",
+        "context": "2.24",
+        "enabled": "2.19",
+        "id": "2.19",
+        "is_local": "2.19",
+        "location": "2.19",
+        "name": "2.19",
+        "policy_type": "2.19",
+        "realms": "2.19",
+        "rules": "2.19",
+        "version": "2.19"
+      }
+    },
+    "POST /management-access-policies/admins": {
+      "minVersion": "2.19",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.19"
+      },
+      "responseItemProperties": {
+        "context": "2.24",
+        "member": "2.19",
+        "policy": "2.19"
+      }
+    },
+    "POST /management-access-policies/directory-services/roles": {
+      "minVersion": "2.19",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.19"
+      },
+      "responseItemProperties": {
+        "member": "2.19",
+        "policy": "2.19"
+      }
+    },
+    "POST /management-access-policies/roles": {
+      "minVersion": "2.26",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.26"
+      },
+      "responseItemProperties": {
+        "context": "2.26",
+        "description": "2.26",
+        "id": "2.26",
+        "name": "2.26",
+        "pure_defined": "2.26"
+      }
+    },
+    "POST /management-access-policies/roles/permissions": {
+      "minVersion": "2.26",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.26"
+      },
+      "responseItemProperties": {
+        "actions": "2.26",
+        "context": "2.26",
+        "id": "2.26",
+        "name": "2.26",
+        "resource": "2.26",
+        "role": "2.26"
+      }
+    },
+    "POST /management-access-policies/rules": {
+      "minVersion": "2.26",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.26"
+      },
+      "responseItemProperties": {
+        "context": "2.26",
+        "id": "2.26",
+        "index": "2.26",
+        "name": "2.26",
+        "policy": "2.26",
+        "policy_version": "2.26",
+        "role": "2.26",
+        "scope": "2.26"
+      }
+    },
+    "POST /management-authentication-policies": {
+      "minVersion": "2.22",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.22"
+      },
+      "responseItemProperties": {
+        "context": "2.22",
+        "enabled": "2.22",
+        "id": "2.22",
+        "is_local": "2.22",
+        "location": "2.22",
+        "name": "2.22",
+        "policy_type": "2.22",
+        "realms": "2.22",
+        "ssh": "2.22"
+      }
+    },
+    "POST /management-authentication-policies/members": {
+      "minVersion": "2.22",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.22"
+      },
+      "responseItemProperties": {
+        "context": "2.22",
+        "member": "2.22",
+        "policy": "2.22"
+      }
+    },
+    "POST /network-access-policies/rules": {
+      "minVersion": "2.13",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.13"
+      },
+      "responseItemProperties": {
+        "client": "2.13",
+        "effect": "2.13",
+        "id": "2.13",
+        "index": "2.13",
+        "interfaces": "2.13",
+        "name": "2.13",
+        "policy": "2.13",
+        "policy_version": "2.13"
+      }
+    },
+    "POST /network-interfaces": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "address": "2.0",
+        "attached_servers": "2.20",
+        "enabled": "2.0",
+        "gateway": "2.0",
+        "id": "2.0",
+        "mtu": "2.0",
+        "name": "2.0",
+        "netmask": "2.0",
+        "rdma_enabled": "2.28",
+        "realms": "2.19",
+        "services": "2.0",
+        "subnet": "2.0",
+        "type": "2.0",
+        "vlan": "2.0"
+      },
+      "removedResponseFields": [
+        {
+          "field": "server",
+          "location": "items",
+          "introducedVersion": "2.16",
+          "lastSeenVersion": "2.19"
+        }
+      ]
+    },
+    "POST /network-interfaces/tls-policies": {
+      "minVersion": "2.17",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.17"
+      },
+      "responseItemProperties": {
+        "member": "2.17",
+        "policy": "2.17"
+      }
+    },
+    "POST /nfs-export-policies": {
+      "minVersion": "2.3",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.3"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "enabled": "2.3",
+        "id": "2.3",
+        "is_local": "2.3",
+        "location": "2.3",
+        "name": "2.3",
+        "policy_type": "2.3",
+        "realms": "2.19",
+        "rules": "2.3",
+        "version": "2.3",
+        "workload": "2.23"
+      }
+    },
+    "POST /nfs-export-policies/rules": {
+      "minVersion": "2.3",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.3"
+      },
+      "responseItemProperties": {
+        "access": "2.3",
+        "anongid": "2.3",
+        "anonuid": "2.3",
+        "atime": "2.3",
+        "client": "2.3",
+        "context": "2.17",
+        "fileid_32bit": "2.3",
+        "id": "2.3",
+        "index": "2.3",
+        "name": "2.3",
+        "permission": "2.3",
+        "policy": "2.3",
+        "policy_version": "2.3",
+        "required_transport_security": "2.18",
+        "secure": "2.3",
+        "security": "2.3"
+      }
+    },
+    "POST /node-groups": {
+      "minVersion": "2.18",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.18"
+      },
+      "responseItemProperties": {
+        "id": "2.18",
+        "name": "2.18"
+      }
+    },
+    "POST /node-groups/nodes": {
+      "minVersion": "2.18",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.18"
+      },
+      "responseItemProperties": {
+        "group": "2.18",
+        "member": "2.18"
+      }
+    },
+    "POST /nodes/batch": {
+      "minVersion": "2.18",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.18"
+      },
+      "responseItemProperties": {
+        "capacity": "2.18",
+        "chassis_serial_number": "2.23",
+        "data_addresses": "2.18",
+        "details": "2.18",
+        "id": "2.18",
+        "management_address": "2.18",
+        "name": "2.18",
+        "raw_capacity": "2.18",
+        "serial_number": "2.18",
+        "status": "2.18",
+        "unique": "2.18"
+      }
+    },
+    "POST /oauth2/1.0/token": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "access_token": "2.0",
+        "expires_in": "2.0",
+        "issued_token_type": "2.0",
+        "token_type": "2.0"
+      },
+      "responseItemProperties": {}
+    },
+    "POST /object-store-access-keys": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "access_key_id": "2.20",
+        "context": "2.17",
+        "created": "2.0",
+        "enabled": "2.0",
+        "name": "2.0",
+        "secret_access_key": "2.0",
+        "user": "2.0"
+      }
+    },
+    "POST /object-store-access-policies": {
+      "minVersion": "2.2",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.2"
+      },
+      "responseItemProperties": {
+        "account": "2.2",
+        "arn": "2.2",
+        "context": "2.17",
+        "created": "2.2",
+        "description": "2.2",
+        "enabled": "2.2",
+        "id": "2.2",
+        "is_local": "2.2",
+        "location": "2.2",
+        "name": "2.2",
+        "policy_type": "2.2",
+        "realms": "2.19",
+        "rules": "2.2",
+        "updated": "2.2"
+      }
+    },
+    "POST /object-store-access-policies/object-store-roles": {
+      "minVersion": "2.17",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.17"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "member": "2.17",
+        "policy": "2.17"
+      }
+    },
+    "POST /object-store-access-policies/object-store-users": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "member": "2.0",
+        "policy": "2.0"
+      }
+    },
+    "POST /object-store-access-policies/rules": {
+      "minVersion": "2.2",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.2"
+      },
+      "responseItemProperties": {
+        "actions": "2.2",
+        "conditions": "2.2",
+        "context": "2.17",
+        "effect": "2.2",
+        "name": "2.2",
+        "policy": "2.2",
+        "resources": "2.2"
+      }
+    },
+    "POST /object-store-account-exports": {
+      "minVersion": "2.20",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.20"
+      },
+      "responseItemProperties": {
+        "context": "2.20",
+        "enabled": "2.20",
+        "id": "2.20",
+        "member": "2.20",
+        "name": "2.20",
+        "policy": "2.20",
+        "realms": "2.20",
+        "server": "2.20"
+      }
+    },
+    "POST /object-store-accounts": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "bucket_defaults": "2.8",
+        "context": "2.17",
+        "created": "2.0",
+        "hard_limit_enabled": "2.8",
+        "id": "2.0",
+        "name": "2.0",
+        "object_count": "2.0",
+        "public_access_config": "2.12",
+        "quota_limit": "2.8",
+        "realms": "2.20",
+        "space": "2.0"
+      }
+    },
+    "POST /object-store-remote-credentials": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "access_key_id": "2.0",
+        "context": "2.17",
+        "id": "2.0",
+        "name": "2.0",
+        "realms": "2.20",
+        "remote": "2.0",
+        "secret_access_key": "2.0"
+      }
+    },
+    "POST /object-store-roles": {
+      "minVersion": "2.17",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.17"
+      },
+      "responseItemProperties": {
+        "account": "2.17",
+        "context": "2.17",
+        "created": "2.17",
+        "id": "2.17",
+        "max_session_duration": "2.17",
+        "name": "2.17",
+        "prn": "2.17",
+        "trusted_entities": "2.17"
+      }
+    },
+    "POST /object-store-roles/object-store-access-policies": {
+      "minVersion": "2.17",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.17"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "member": "2.17",
+        "policy": "2.17"
+      }
+    },
+    "POST /object-store-roles/object-store-trust-policies/rules": {
+      "minVersion": "2.17",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.17"
+      },
+      "responseItemProperties": {
+        "actions": "2.17",
+        "conditions": "2.17",
+        "context": "2.17",
+        "effect": "2.17",
+        "index": "2.17",
+        "name": "2.17",
+        "policy": "2.17",
+        "principals": "2.17"
+      }
+    },
+    "POST /object-store-users": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "access_keys": "2.0",
+        "account": "2.0",
+        "context": "2.17",
+        "created": "2.0",
+        "id": "2.0",
+        "name": "2.0"
+      }
+    },
+    "POST /object-store-users/object-store-access-policies": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "member": "2.0",
+        "policy": "2.0"
+      }
+    },
+    "POST /object-store-virtual-hosts": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "attached_servers": "2.20",
+        "context": "2.17",
+        "hostname": "2.20",
+        "id": "2.0",
+        "name": "2.0",
+        "realms": "2.20"
+      }
+    },
+    "POST /policies": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "enabled": "2.0",
+        "id": "2.0",
+        "is_local": "2.0",
+        "location": "2.0",
+        "name": "2.0",
+        "policy_type": "2.2",
+        "realms": "2.19",
+        "retention_lock": "2.5",
+        "rules": "2.0",
+        "workload": "2.23"
+      }
+    },
+    "POST /policies/file-system-replica-links": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "context": "2.22",
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "link": "2.0",
+        "member": "2.0",
+        "policy": "2.0"
+      }
+    },
+    "POST /policies/file-systems": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "member": "2.0",
+        "policy": "2.0"
+      }
+    },
+    "POST /presets/workload": {
+      "minVersion": "2.23",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.23"
+      },
+      "responseItemProperties": {
+        "context": "2.23",
+        "description": "2.23",
+        "directory_configurations": "2.23",
+        "export_configurations": "2.23",
+        "id": "2.23",
+        "name": "2.23",
+        "parameters": "2.23",
+        "periodic_replication_configurations": "2.23",
+        "placement_configurations": "2.23",
+        "platform_features": "2.23",
+        "qos_configurations": "2.23",
+        "quota_configurations": "2.23",
+        "revision": "2.23",
+        "snapshot_configurations": "2.23",
+        "volume_configurations": "2.23",
+        "workload_tags": "2.23",
+        "workload_type": "2.23"
+      }
+    },
+    "POST /public-keys": {
+      "minVersion": "2.14",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.14"
+      },
+      "responseItemProperties": {
+        "algorithm": "2.14",
+        "id": "2.14",
+        "key_size": "2.14",
+        "name": "2.14",
+        "public_key": "2.14"
+      }
+    },
+    "POST /qos-policies": {
+      "minVersion": "2.17",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.17"
+      },
+      "responseItemProperties": {
+        "context": "2.23",
+        "enabled": "2.17",
+        "id": "2.17",
+        "is_local": "2.17",
+        "location": "2.17",
+        "max_total_bytes_per_sec": "2.17",
+        "max_total_ops_per_sec": "2.17",
+        "name": "2.17",
+        "policy_type": "2.17",
+        "realms": "2.19"
+      }
+    },
+    "POST /qos-policies/members": {
+      "minVersion": "2.20",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.20"
+      },
+      "responseItemProperties": {
+        "context": "2.23",
+        "member": "2.20",
+        "policy": "2.20"
+      }
+    },
+    "POST /quotas/groups": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "file_system": "2.0",
+        "file_system_default_quota": "2.0",
+        "group": "2.0",
+        "name": "2.0",
+        "quota": "2.0",
+        "usage": "2.0"
+      }
+    },
+    "POST /quotas/users": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "file_system": "2.0",
+        "file_system_default_quota": "2.0",
+        "name": "2.0",
+        "quota": "2.0",
+        "usage": "2.0",
+        "user": "2.0"
+      }
+    },
+    "POST /realm-connections": {
+      "minVersion": "2.25",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.25"
+      },
+      "responseItemProperties": {
+        "id": "2.25",
+        "local_realm": "2.25",
+        "remote_realm": "2.25",
+        "status": "2.25"
+      }
+    },
+    "POST /realm-connections/connection-key": {
+      "minVersion": "2.25",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.25"
+      },
+      "responseItemProperties": {
+        "connection_key": "2.25",
+        "created": "2.25",
+        "expires": "2.25",
+        "realm": "2.25"
+      }
+    },
+    "POST /realms": {
+      "minVersion": "2.19",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.19"
+      },
+      "responseItemProperties": {
+        "created": "2.19",
+        "default_inbound_tls_policy": "2.19",
+        "destroyed": "2.19",
+        "id": "2.19",
+        "name": "2.19",
+        "space": "2.19",
+        "time_remaining": "2.19"
+      }
+    },
+    "POST /resource-accesses/batch": {
+      "minVersion": "2.19",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.19"
+      },
+      "responseItemProperties": {
+        "id": "2.19",
+        "resource": "2.19",
+        "scope": "2.19"
+      }
+    },
+    "POST /s3-export-policies": {
+      "minVersion": "2.20",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.20"
+      },
+      "responseItemProperties": {
+        "context": "2.20",
+        "enabled": "2.20",
+        "id": "2.20",
+        "is_local": "2.20",
+        "location": "2.20",
+        "name": "2.20",
+        "policy_type": "2.20",
+        "realms": "2.20",
+        "rules": "2.20"
+      }
+    },
+    "POST /s3-export-policies/rules": {
+      "minVersion": "2.20",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.20"
+      },
+      "responseItemProperties": {
+        "actions": "2.20",
+        "context": "2.20",
+        "effect": "2.20",
+        "name": "2.20",
+        "policy": "2.20",
+        "resources": "2.20"
+      }
+    },
+    "POST /servers": {
+      "minVersion": "2.16",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.16"
+      },
+      "responseItemProperties": {
+        "created": "2.16",
+        "directory_services": "2.16",
+        "dns": "2.16",
+        "id": "2.16",
+        "local_directory_service": "2.24",
+        "name": "2.16",
+        "realms": "2.19"
+      }
+    },
+    "POST /smb-client-policies": {
+      "minVersion": "2.10",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.10"
+      },
+      "responseItemProperties": {
+        "access_based_enumeration_enabled": "2.17",
+        "context": "2.17",
+        "enabled": "2.10",
+        "id": "2.10",
+        "is_local": "2.10",
+        "location": "2.10",
+        "name": "2.10",
+        "policy_type": "2.10",
+        "realms": "2.19",
+        "rules": "2.10",
+        "version": "2.10",
+        "workload": "2.23"
+      }
+    },
+    "POST /smb-client-policies/rules": {
+      "minVersion": "2.10",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.10"
+      },
+      "responseItemProperties": {
+        "client": "2.10",
+        "context": "2.17",
+        "encryption": "2.11",
+        "id": "2.10",
+        "index": "2.10",
+        "name": "2.10",
+        "permission": "2.10",
+        "policy": "2.10",
+        "policy_version": "2.10"
+      }
+    },
+    "POST /smb-share-policies": {
+      "minVersion": "2.10",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.10"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "enabled": "2.10",
+        "id": "2.10",
+        "is_local": "2.10",
+        "location": "2.10",
+        "name": "2.10",
+        "policy_type": "2.10",
+        "realms": "2.19",
+        "rules": "2.10",
+        "workload": "2.23"
+      }
+    },
+    "POST /smb-share-policies/rules": {
+      "minVersion": "2.10",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.10"
+      },
+      "responseItemProperties": {
+        "change": "2.10",
+        "context": "2.17",
+        "full_control": "2.10",
+        "id": "2.10",
+        "name": "2.10",
+        "policy": "2.10",
+        "principal": "2.10",
+        "read": "2.10"
+      }
+    },
+    "POST /snmp-managers": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "host": "2.0",
+        "id": "2.0",
+        "name": "2.0",
+        "notification": "2.0",
+        "v2c": "2.0",
+        "v3": "2.0",
+        "version": "2.0"
+      }
+    },
+    "POST /software-bundle": {
+      "minVersion": "2.24",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.24"
+      },
+      "responseItemProperties": {
+        "created": "2.24",
+        "details": "2.24",
+        "download_progress": "2.24",
+        "id": "2.24",
+        "source": "2.24",
+        "status": "2.24"
+      }
+    },
+    "POST /software-check": {
+      "minVersion": "2.16",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.16"
+      },
+      "responseItemProperties": {
+        "checks": "2.16",
+        "details": "2.16",
+        "end_time": "2.16",
+        "id": "2.16",
+        "name": "2.16",
+        "software_name": "2.16",
+        "software_upgrade_hops": "2.16",
+        "software_version": "2.16",
+        "start_time": "2.16",
+        "status": "2.16"
+      }
+    },
+    "POST /software-patches": {
+      "minVersion": "2.24",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.24"
+      },
+      "responseItemProperties": {
+        "alert_code": "2.24",
+        "description": "2.24",
+        "details": "2.24",
+        "ha_reduction_required": "2.24",
+        "id": "2.24",
+        "name": "2.24",
+        "progress": "2.24",
+        "status": "2.24"
+      }
+    },
+    "POST /ssh-certificate-authority-policies": {
+      "minVersion": "2.14",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.14"
+      },
+      "responseItemProperties": {
+        "context": "2.24",
+        "enabled": "2.14",
+        "id": "2.14",
+        "is_local": "2.14",
+        "location": "2.14",
+        "name": "2.14",
+        "policy_type": "2.14",
+        "realms": "2.19",
+        "signing_authority": "2.14",
+        "static_authorized_principals": "2.14"
+      }
+    },
+    "POST /ssh-certificate-authority-policies/admins": {
+      "minVersion": "2.14",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.14"
+      },
+      "responseItemProperties": {
+        "context": "2.24",
+        "member": "2.14",
+        "policy": "2.14"
+      }
+    },
+    "POST /ssh-certificate-authority-policies/arrays": {
+      "minVersion": "2.14",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.14"
+      },
+      "responseItemProperties": {
+        "context": "2.24",
+        "member": "2.14",
+        "policy": "2.14"
+      }
+    },
+    "POST /sso/oidc/idps": {
+      "minVersion": "2.17",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.17"
+      },
+      "responseItemProperties": {
+        "enabled": "2.17",
+        "id": "2.17",
+        "idp": "2.17",
+        "name": "2.17",
+        "prn": "2.17",
+        "services": "2.17"
+      }
+    },
+    "POST /sso/saml2/idps": {
+      "minVersion": "2.15",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.15"
+      },
+      "responseItemProperties": {
+        "array_url": "2.15",
+        "binding": "2.17",
+        "enabled": "2.15",
+        "id": "2.15",
+        "idp": "2.15",
+        "management": "2.24",
+        "name": "2.15",
+        "prn": "2.17",
+        "services": "2.17",
+        "sp": "2.15"
+      }
+    },
+    "POST /storage-class-tiering-policies": {
+      "minVersion": "2.18",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.18"
+      },
+      "responseItemProperties": {
+        "archival_rules": "2.18",
+        "enabled": "2.18",
+        "id": "2.18",
+        "is_local": "2.18",
+        "location": "2.18",
+        "name": "2.18",
+        "policy_type": "2.18",
+        "realms": "2.19",
+        "retrieval_rules": "2.18"
+      }
+    },
+    "POST /subnets": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "enabled": "2.0",
+        "gateway": "2.0",
+        "id": "2.0",
+        "interfaces": "2.0",
+        "link_aggregation_group": "2.0",
+        "mtu": "2.0",
+        "name": "2.0",
+        "prefix": "2.0",
+        "services": "2.0",
+        "vlan": "2.0"
+      }
+    },
+    "POST /support-diagnostics": {
+      "minVersion": "2.16",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "continuation_token": "2.16",
+        "items": "2.16",
+        "total_item_count": "2.16"
+      },
+      "responseItemProperties": {
+        "analysis_period": "2.16",
+        "id": "2.16",
+        "index": "2.16",
+        "name": "2.16",
+        "severity_count": "2.16",
+        "start_time": "2.16",
+        "status": "2.16",
+        "task_id": "2.16",
+        "version": "2.16"
+      }
+    },
+    "POST /syslog-servers": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "id": "2.0",
+        "name": "2.0",
+        "services": "2.14",
+        "sources": "2.20",
+        "uri": "2.0"
+      }
+    },
+    "POST /targets": {
+      "minVersion": "2.0",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.0"
+      },
+      "responseItemProperties": {
+        "address": "2.0",
+        "ca_certificate_group": "2.0",
+        "id": "2.0",
+        "name": "2.0",
+        "status": "2.0",
+        "status_details": "2.0"
+      }
+    },
+    "POST /tls-policies": {
+      "minVersion": "2.17",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.17"
+      },
+      "responseItemProperties": {
+        "appliance_certificate": "2.17",
+        "client_certificates_required": "2.18",
+        "disabled_tls_ciphers": "2.17",
+        "enabled": "2.17",
+        "enabled_tls_ciphers": "2.17",
+        "id": "2.17",
+        "is_local": "2.17",
+        "location": "2.17",
+        "min_tls_version": "2.17",
+        "name": "2.17",
+        "policy_type": "2.17",
+        "realms": "2.19",
+        "trusted_client_certificate_authority": "2.18",
+        "verify_client_certificate_trust": "2.18"
+      }
+    },
+    "POST /tls-policies/network-interfaces": {
+      "minVersion": "2.17",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.17"
+      },
+      "responseItemProperties": {
+        "member": "2.17",
+        "policy": "2.17"
+      }
+    },
+    "POST /topology-groups": {
+      "minVersion": "2.26",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.26"
+      },
+      "responseItemProperties": {
+        "context": "2.26",
+        "id": "2.26",
+        "name": "2.26",
+        "parent_topology_group": "2.26"
+      }
+    },
+    "POST /topology-groups/members": {
+      "minVersion": "2.26",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.26"
+      },
+      "responseItemProperties": {
+        "context": "2.26",
+        "member": "2.26",
+        "status": "2.26",
+        "status_details": "2.26",
+        "topology_group": "2.26"
+      }
+    },
+    "POST /user-group-quota-policies": {
+      "minVersion": "2.25",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.25"
+      },
+      "responseItemProperties": {
+        "context": "2.25",
+        "enabled": "2.25",
+        "id": "2.25",
+        "is_local": "2.25",
+        "location": "2.25",
+        "name": "2.25",
+        "policy_type": "2.25",
+        "realms": "2.25",
+        "rules": "2.25",
+        "version": "2.25"
+      }
+    },
+    "POST /user-group-quota-policies/file-systems": {
+      "minVersion": "2.25",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.25"
+      },
+      "responseItemProperties": {
+        "context": "2.25",
+        "member": "2.25",
+        "policy": "2.25"
+      }
+    },
+    "POST /user-group-quota-policies/rules": {
+      "minVersion": "2.25",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.25"
+      },
+      "responseItemProperties": {
+        "context": "2.25",
+        "enforced": "2.25",
+        "id": "2.25",
+        "index": "2.25",
+        "name": "2.25",
+        "notifications": "2.25",
+        "policy": "2.25",
+        "policy_version": "2.25",
+        "quota_limit": "2.25",
+        "quota_type": "2.25",
+        "subject": "2.25"
+      }
+    },
+    "POST /workloads": {
+      "minVersion": "2.23",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.23"
+      },
+      "responseItemProperties": {
+        "context": "2.23",
+        "created": "2.23",
+        "destroyed": "2.23",
+        "id": "2.23",
+        "name": "2.23",
+        "preset": "2.23",
+        "status": "2.23",
+        "status_details": "2.23",
+        "time_remaining": "2.23"
+      }
+    },
+    "POST /workloads/placement-recommendations": {
+      "minVersion": "2.23",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.23"
+      },
+      "responseItemProperties": {
+        "additional_constraints": "2.23",
+        "context": "2.23",
+        "created": "2.23",
+        "expires": "2.23",
+        "id": "2.23",
+        "more_results_available": "2.23",
+        "name": "2.23",
+        "parameters": "2.23",
+        "placement_names": "2.23",
+        "preset": "2.23",
+        "progress": "2.23",
+        "projection_months": "2.23",
+        "recommendation_engine": "2.23",
+        "results": "2.23",
+        "results_limit": "2.23",
+        "status": "2.23"
+      }
+    },
+    "POST /worm-data-policies": {
+      "minVersion": "2.15",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.15"
+      },
+      "responseItemProperties": {
+        "context": "2.17",
+        "default_retention": "2.15",
+        "enabled": "2.15",
+        "id": "2.15",
+        "is_local": "2.15",
+        "location": "2.15",
+        "max_retention": "2.15",
+        "min_retention": "2.15",
+        "mode": "2.15",
+        "name": "2.15",
+        "policy_type": "2.15",
+        "realms": "2.19",
+        "retention_lock": "2.15"
+      }
+    },
+    "PUT /presets/workload": {
+      "minVersion": "2.23",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.23"
+      },
+      "responseItemProperties": {
+        "context": "2.23",
+        "description": "2.23",
+        "directory_configurations": "2.23",
+        "export_configurations": "2.23",
+        "id": "2.23",
+        "name": "2.23",
+        "parameters": "2.23",
+        "periodic_replication_configurations": "2.23",
+        "placement_configurations": "2.23",
+        "platform_features": "2.23",
+        "qos_configurations": "2.23",
+        "quota_configurations": "2.23",
+        "revision": "2.23",
+        "snapshot_configurations": "2.23",
+        "volume_configurations": "2.23",
+        "workload_tags": "2.23",
+        "workload_type": "2.23"
+      }
+    },
+    "PUT /workloads/tags/batch": {
+      "minVersion": "2.23",
+      "lastSeenVersion": "2.28",
+      "responseEnvelope": {
+        "items": "2.23"
+      },
+      "responseItemProperties": {
+        "context": "2.23",
+        "copyable": "2.23",
+        "key": "2.23",
+        "namespace": "2.23",
+        "resource": "2.23",
+        "value": "2.23"
+      }
+    }
+  }
+}

--- a/Reports/PfbApiDriftReport.json
+++ b/Reports/PfbApiDriftReport.json
@@ -20509,6 +20509,126 @@
       "recommendation": "ArgumentCompleter"
     }
   ],
+  "responseFieldRemovals": [
+    {
+      "endpoint": "GET /arrays/performance/replication",
+      "field": "remote",
+      "location": "items",
+      "introducedVersion": "2.0",
+      "lastSeenVersion": "2.10"
+    },
+    {
+      "endpoint": "GET /file-system-snapshots",
+      "field": "copyable",
+      "location": "items",
+      "introducedVersion": "2.0",
+      "lastSeenVersion": "2.10"
+    },
+    {
+      "endpoint": "GET /network-interfaces",
+      "field": "server",
+      "location": "items",
+      "introducedVersion": "2.16",
+      "lastSeenVersion": "2.19"
+    },
+    {
+      "endpoint": "PATCH /file-system-snapshots",
+      "field": "copyable",
+      "location": "items",
+      "introducedVersion": "2.0",
+      "lastSeenVersion": "2.10"
+    },
+    {
+      "endpoint": "PATCH /network-interfaces",
+      "field": "server",
+      "location": "items",
+      "introducedVersion": "2.16",
+      "lastSeenVersion": "2.19"
+    },
+    {
+      "endpoint": "POST /file-system-snapshots",
+      "field": "copyable",
+      "location": "items",
+      "introducedVersion": "2.0",
+      "lastSeenVersion": "2.10"
+    },
+    {
+      "endpoint": "POST /network-interfaces",
+      "field": "server",
+      "location": "items",
+      "introducedVersion": "2.16",
+      "lastSeenVersion": "2.19"
+    }
+  ],
+  "responseFieldRenameCandidates": [
+    {
+      "endpoint": "GET /network-interfaces",
+      "location": "items",
+      "from": "server",
+      "to": "attached_servers",
+      "version": "2.20"
+    },
+    {
+      "endpoint": "PATCH /network-interfaces",
+      "location": "items",
+      "from": "server",
+      "to": "attached_servers",
+      "version": "2.20"
+    },
+    {
+      "endpoint": "POST /network-interfaces",
+      "location": "items",
+      "from": "server",
+      "to": "attached_servers",
+      "version": "2.20"
+    }
+  ],
+  "unhandledResponseEnvelopeFields": [
+    {
+      "field": "errors",
+      "endpointCount": 140
+    },
+    {
+      "field": "total",
+      "endpointCount": 28
+    },
+    {
+      "field": "context",
+      "endpointCount": 7
+    },
+    {
+      "field": "access_token",
+      "endpointCount": 1
+    },
+    {
+      "field": "expires_in",
+      "endpointCount": 1
+    },
+    {
+      "field": "issued_token_type",
+      "endpointCount": 1
+    },
+    {
+      "field": "login_banner",
+      "endpointCount": 1
+    },
+    {
+      "field": "more_items_remaining",
+      "endpointCount": 1
+    },
+    {
+      "field": "token_type",
+      "endpointCount": 1
+    },
+    {
+      "field": "username",
+      "endpointCount": 1
+    },
+    {
+      "field": "versions",
+      "endpointCount": 1
+    }
+  ],
   "contextCardinality": {
     "componentSourceVersion": "2.28",
     "http207SignalAvailable": true,

--- a/Reports/PfbApiDriftReport.md
+++ b/Reports/PfbApiDriftReport.md
@@ -31,6 +31,9 @@ This report accepts **false positives in order to eliminate false negatives**. A
 - ValidateSet drift: 0
 - New ValidateSet candidates: 1
 - Context cardinality signal disagreements (fb2.28): 9
+- Removed response fields: **7**
+- Response rename candidates: **3**
+- Envelope fields not read by `Invoke-PfbApiRequest`: **11**
 
 ## Systemic gaps
 
@@ -709,6 +712,50 @@ The capability map knows these body properties exist, but the newest analysed sp
 | `POST /user-group-quota-policies` | New-PfbUserGroupQuotaPolicy | id, is_local, policy_type, realms |
 | `POST /workloads/placement-recommendations` | New-PfbWorkloadPlacementRecommendation | context, created, expires, id, more_results_available, name, progress, results, status |
 | `POST /worm-data-policies` | New-PfbWormPolicy | context, id, is_local, name, policy_type, realms |
+
+## Response-shape drift
+
+Cmdlets pass API responses through raw -- there is no projection anywhere in `Public/`, so the module holds no schema of its own. A **removed or renamed** response field therefore reaches user scripts as a silent `$null`, which no other report category can detect. **Added** response fields are deliberately not reported: they surface automatically and need no module change.
+
+### Removed response fields
+
+| Endpoint | Location | Field | Introduced | Last seen |
+|---|---|---|---|---|
+| `GET /arrays/performance/replication` | items | `remote` | 2.0 | 2.10 |
+| `GET /file-system-snapshots` | items | `copyable` | 2.0 | 2.10 |
+| `GET /network-interfaces` | items | `server` | 2.16 | 2.19 |
+| `PATCH /file-system-snapshots` | items | `copyable` | 2.0 | 2.10 |
+| `PATCH /network-interfaces` | items | `server` | 2.16 | 2.19 |
+| `POST /file-system-snapshots` | items | `copyable` | 2.0 | 2.10 |
+| `POST /network-interfaces` | items | `server` | 2.16 | 2.19 |
+
+### Rename candidates
+
+_A removal and an addition adjacent in version on the same endpoint. Suggestive, not proof -- confirm against the spec before acting._
+
+| Endpoint | Location | From | To | Version |
+|---|---|---|---|---|
+| `GET /network-interfaces` | items | `server` | `attached_servers` | 2.20 |
+| `PATCH /network-interfaces` | items | `server` | `attached_servers` | 2.20 |
+| `POST /network-interfaces` | items | `server` | `attached_servers` | 2.20 |
+
+### Response envelope fields not read by `Invoke-PfbApiRequest`
+
+_Informational coverage observation, not a correctness claim -- many envelope keys legitimately need no handling there. It cannot tell whether a field is handled correctly, only whether it is referenced at all._
+
+| Envelope field | Endpoints declaring it |
+|---|---|
+| `errors` | 140 |
+| `total` | 28 |
+| `context` | 7 |
+| `access_token` | 1 |
+| `expires_in` | 1 |
+| `issued_token_type` | 1 |
+| `login_banner` | 1 |
+| `more_items_remaining` | 1 |
+| `token_type` | 1 |
+| `username` | 1 |
+| `versions` | 1 |
 
 ## Uncovered endpoints
 

--- a/Tests/Build-PfbApiDriftReport.Tests.ps1
+++ b/Tests/Build-PfbApiDriftReport.Tests.ps1
@@ -963,7 +963,7 @@ function Get-PfbFixtureGamma {
     }
 }
 
-Describe 'Build-PfbApiDriftReport response-shape integration' {
+Describe 'Build-PfbApiDriftReport response-shape integration' -Skip:($PSVersionTable.PSVersion.Major -lt 7) {
     # BeforeDiscovery, NOT BeforeAll: Pester evaluates -Skip: at DISCOVERY time, before any
     # BeforeAll block has run. Setting these in BeforeAll would leave $script:realJson null
     # during discovery, so every -Skip: would evaluate `-not (Test-Path $null)` = $true and
@@ -972,6 +972,7 @@ Describe 'Build-PfbApiDriftReport response-shape integration' {
         $script:reportRoot = Split-Path -Parent $PSScriptRoot
         $script:realJson = Join-Path $script:reportRoot 'Reports/PfbApiDriftReport.json'
         $script:realMd = Join-Path $script:reportRoot 'Reports/PfbApiDriftReport.md'
+        $script:realShapeMap = Join-Path $script:reportRoot 'Data/PfbResponseShapeMap.json'
     }
 
     # BeforeDiscovery above is what feeds the -Skip: expressions and must stay. It is not
@@ -982,6 +983,7 @@ Describe 'Build-PfbApiDriftReport response-shape integration' {
         $script:reportRoot = Split-Path -Parent $PSScriptRoot
         $script:realJson = Join-Path $script:reportRoot 'Reports/PfbApiDriftReport.json'
         $script:realMd = Join-Path $script:reportRoot 'Reports/PfbApiDriftReport.md'
+        $script:realShapeMap = Join-Path $script:reportRoot 'Data/PfbResponseShapeMap.json'
     }
 
     It 'emits the three response-shape keys in the JSON manifest' -Skip:(-not (Test-Path $script:realJson)) {
@@ -1000,7 +1002,38 @@ Describe 'Build-PfbApiDriftReport response-shape integration' {
         # NOT max_total_ops_per_sec: it is absent at 2.20 only and present at 2.28, so it is
         # correctly not a removal. Asserting it here would lock in a false positive.
         $fields | Should -Not -Contain 'max_total_ops_per_sec'
-        @($r.responseFieldRemovals).Count | Should -Be 7
+    }
+
+    It 'surfaces every removal the response shape map holds, and invents none' -Skip:((-not (Test-Path $script:realJson)) -or (-not (Test-Path $script:realShapeMap))) {
+        # DERIVED, never a literal. A hardcoded count here would not be an artifact-regression
+        # check: .github/workflows/update-api-capability-map.yml regenerates
+        # Data/PfbResponseShapeMap.json from FRESHLY FETCHED specs (step "Build response shape
+        # map"), rebuilds the report from it, and only THEN runs this suite with
+        # Run.Exit = $true. A literal would therefore be an assertion about what FlashBlade
+        # currently publishes, and the first genuine new removal -- exactly the event this
+        # whole axis exists to detect -- would fail this test, abort the job before its
+        # "Check for changes"/"Open pull request" steps, and silently freeze EVERY map and
+        # report the workflow maintains. The detector's own success case must not disable the
+        # pipeline it lives in.
+        #
+        # The property asserted instead is the one actually worth pinning and the one that
+        # stays true across spec versions: the report faithfully surfaces the map's removals,
+        # one row per record, neither dropping nor inventing any.
+        $map = Get-Content $script:realShapeMap -Raw | ConvertFrom-Json
+        $expected = 0
+        foreach ($endpointProperty in $map.endpoints.PSObject.Properties) {
+            if ($endpointProperty.Value.PSObject.Properties.Name -contains 'removedResponseFields') {
+                $expected += @($endpointProperty.Value.removedResponseFields).Count
+            }
+        }
+
+        # Keeps the assertion non-vacuous. Without this, a map that somehow held zero removals
+        # would make the comparison below 0 -eq 0 and pass while testing nothing -- the same
+        # failure mode as asserting $null against a collection matcher.
+        $expected | Should -BeGreaterThan 0 -Because 'the committed map holds real removals; a zero expectation would make the comparison below vacuous'
+
+        $report = Get-Content $script:realJson -Raw | ConvertFrom-Json
+        @($report.responseFieldRemovals).Count | Should -Be $expected
     }
 
     It 'surfaces the $response.errors worked example' -Skip:(-not (Test-Path $script:realJson)) {

--- a/Tests/Build-PfbApiDriftReport.Tests.ps1
+++ b/Tests/Build-PfbApiDriftReport.Tests.ps1
@@ -962,3 +962,55 @@ function Get-PfbFixtureGamma {
         $t7ReportText | Should -Match 'Systemic gaps \(distinct field names[^:]*: 1'
     }
 }
+
+Describe 'Build-PfbApiDriftReport response-shape integration' {
+    # BeforeDiscovery, NOT BeforeAll: Pester evaluates -Skip: at DISCOVERY time, before any
+    # BeforeAll block has run. Setting these in BeforeAll would leave $script:realJson null
+    # during discovery, so every -Skip: would evaluate `-not (Test-Path $null)` = $true and
+    # silently skip the whole Describe -- a green run that tested nothing.
+    BeforeDiscovery {
+        $script:reportRoot = Split-Path -Parent $PSScriptRoot
+        $script:realJson = Join-Path $script:reportRoot 'Reports/PfbApiDriftReport.json'
+        $script:realMd = Join-Path $script:reportRoot 'Reports/PfbApiDriftReport.md'
+    }
+
+    # BeforeDiscovery above is what feeds the -Skip: expressions and must stay. It is not
+    # sufficient on its own: Pester's RUN phase uses a separate scope, so variables set during
+    # discovery read back as $null inside each It body. This block re-binds the same paths for
+    # the run phase. Both blocks are required -- neither replaces the other.
+    BeforeAll {
+        $script:reportRoot = Split-Path -Parent $PSScriptRoot
+        $script:realJson = Join-Path $script:reportRoot 'Reports/PfbApiDriftReport.json'
+        $script:realMd = Join-Path $script:reportRoot 'Reports/PfbApiDriftReport.md'
+    }
+
+    It 'emits the three response-shape keys in the JSON manifest' -Skip:(-not (Test-Path $script:realJson)) {
+        $r = Get-Content $script:realJson -Raw | ConvertFrom-Json
+        $r.PSObject.Properties.Name | Should -Contain 'responseFieldRemovals'
+        $r.PSObject.Properties.Name | Should -Contain 'responseFieldRenameCandidates'
+        $r.PSObject.Properties.Name | Should -Contain 'unhandledResponseEnvelopeFields'
+    }
+
+    It 'reports the known real removals' -Skip:(-not (Test-Path $script:realJson)) {
+        $r = Get-Content $script:realJson -Raw | ConvertFrom-Json
+        $fields = @($r.responseFieldRemovals | ForEach-Object { $_.field })
+        $fields | Should -Contain 'copyable'
+        $fields | Should -Contain 'server'
+        $fields | Should -Contain 'remote'
+        # NOT max_total_ops_per_sec: it is absent at 2.20 only and present at 2.28, so it is
+        # correctly not a removal. Asserting it here would lock in a false positive.
+        $fields | Should -Not -Contain 'max_total_ops_per_sec'
+        @($r.responseFieldRemovals).Count | Should -Be 7
+    }
+
+    It 'surfaces the $response.errors worked example' -Skip:(-not (Test-Path $script:realJson)) {
+        $r = Get-Content $script:realJson -Raw | ConvertFrom-Json
+        $errorsRow = $r.unhandledResponseEnvelopeFields | Where-Object { $_.field -eq 'errors' }
+        $errorsRow | Should -Not -BeNullOrEmpty
+        $errorsRow.endpointCount | Should -BeGreaterThan 100
+    }
+
+    It 'renders a Response-shape drift section in the Markdown' -Skip:(-not (Test-Path $script:realMd)) {
+        (Get-Content $script:realMd -Raw) | Should -Match '## Response-shape drift'
+    }
+}

--- a/Tests/Build-PfbResponseShapeMap.Tests.ps1
+++ b/Tests/Build-PfbResponseShapeMap.Tests.ps1
@@ -36,6 +36,21 @@ BeforeAll {
             }
         }
     }
+
+    # Same response node as above, but lets several paths be declared in a CHOSEN order within
+    # one spec, so emission order can be asserted against insertion order.
+    function New-MultiPathShapeSpecFixture {
+        param(
+            # Ordered array of [PSCustomObject]@{ Path; EnvelopeProperties; ItemProperties }
+            [Parameter(Mandatory)][object[]]$Endpoints
+        )
+        $paths = [PSCustomObject]@{}
+        foreach ($ep in $Endpoints) {
+            $single = New-ShapeSpecFixture -EnvelopeProperties $ep.EnvelopeProperties -ItemProperties $ep.ItemProperties
+            $paths | Add-Member -NotePropertyName $ep.Path -NotePropertyValue $single.paths.'/api/2.0/widgets'
+        }
+        [PSCustomObject]@{ paths = $paths }
+    }
 }
 
 Describe 'Build-PfbResponseShapeMap' {
@@ -135,6 +150,43 @@ Describe 'Build-PfbResponseShapeMap' {
         & $script:BuilderPath -SpecsDirectory $specs -OutputPath $b | Out-Null
 
         (Get-FileHash $a -Algorithm SHA256).Hash | Should -Be (Get-FileHash $b -Algorithm SHA256).Hash
+    }
+
+    It 'emits endpoint keys and field names in sorted order, not insertion order' {
+        # Dictionary<T> enumeration is stable for a fixed insertion sequence, so a
+        # two-runs-hash-equal check passes even with every Sort-Object deleted. This asserts the
+        # literal emitted order instead. Both fixtures declare paths zebras-before-alphas, and
+        # 'alpha' is introduced at 9.1 AFTER 'mango'/'zebra' were inserted at 9.0 -- so without
+        # sorting the emission would be zebras-then-alphas and mango,zebra,alpha.
+        $specs = Join-Path $TestDrive 'specs8'; New-Item -ItemType Directory -Path $specs -Force | Out-Null
+        New-MultiPathShapeSpecFixture -Endpoints @(
+            [PSCustomObject]@{ Path = '/api/2.0/zebras'; EnvelopeProperties = @('items'); ItemProperties = @('mango', 'zebra') }
+            [PSCustomObject]@{ Path = '/api/2.0/alphas'; EnvelopeProperties = @('items'); ItemProperties = @('name') }
+        ) | ConvertTo-Json -Depth 20 | Set-Content (Join-Path $specs 'fb9.0.json')
+        New-MultiPathShapeSpecFixture -Endpoints @(
+            [PSCustomObject]@{ Path = '/api/2.0/zebras'; EnvelopeProperties = @('items'); ItemProperties = @('mango', 'zebra', 'alpha') }
+            [PSCustomObject]@{ Path = '/api/2.0/alphas'; EnvelopeProperties = @('items'); ItemProperties = @('name') }
+        ) | ConvertTo-Json -Depth 20 | Set-Content (Join-Path $specs 'fb9.1.json')
+
+        $out = Join-Path $TestDrive 'map8.json'
+        & $script:BuilderPath -SpecsDirectory $specs -OutputPath $out | Out-Null
+
+        $map = Get-Content $out -Raw | ConvertFrom-Json
+        @($map.endpoints.PSObject.Properties.Name) | Should -Be @('GET /alphas', 'GET /zebras')
+        @($map.endpoints.'GET /zebras'.responseItemProperties.PSObject.Properties.Name) |
+            Should -Be @('alpha', 'mango', 'zebra')
+    }
+
+    It 'throws rather than emitting an empty map when no spec filename parses' {
+        $specs = Join-Path $TestDrive 'specs9'; New-Item -ItemType Directory -Path $specs -Force | Out-Null
+        # Matches the fb*.json glob but not the fb<major>.<minor> version regex.
+        New-ShapeSpecFixture -EnvelopeProperties @('items') -ItemProperties @('name') |
+            ConvertTo-Json -Depth 20 | Set-Content (Join-Path $specs 'fbXYZ.json')
+
+        $out = Join-Path $TestDrive 'map9.json'
+        { & $script:BuilderPath -SpecsDirectory $specs -OutputPath $out -WarningAction SilentlyContinue } |
+            Should -Throw -ExpectedMessage '*parseable*'
+        Test-Path $out | Should -BeFalse
     }
 
     It 'does not let an API field named "keys" shadow dictionary members' {

--- a/Tests/Build-PfbResponseShapeMap.Tests.ps1
+++ b/Tests/Build-PfbResponseShapeMap.Tests.ps1
@@ -1,0 +1,154 @@
+BeforeAll {
+    $script:RepoRoot = Split-Path -Parent $PSScriptRoot
+    $script:BuilderPath = Join-Path $script:RepoRoot 'tools/Build-PfbResponseShapeMap.ps1'
+
+    function New-ShapeSpecFixture {
+        param(
+            [Parameter(Mandatory)][string[]]$EnvelopeProperties,
+            [Parameter(Mandatory)][string[]]$ItemProperties
+        )
+        $envProps = [PSCustomObject]@{}
+        foreach ($p in $EnvelopeProperties) {
+            if ($p -eq 'items') { continue }
+            $envProps | Add-Member -NotePropertyName $p -NotePropertyValue ([PSCustomObject]@{ type = 'integer' })
+        }
+        $itemProps = [PSCustomObject]@{}
+        foreach ($p in $ItemProperties) {
+            $itemProps | Add-Member -NotePropertyName $p -NotePropertyValue ([PSCustomObject]@{ type = 'string' })
+        }
+        $envProps | Add-Member -NotePropertyName 'items' -NotePropertyValue ([PSCustomObject]@{
+                type = 'array'; items = [PSCustomObject]@{ properties = $itemProps }
+            })
+
+        [PSCustomObject]@{
+            paths = [PSCustomObject]@{
+                '/api/2.0/widgets' = [PSCustomObject]@{
+                    get = [PSCustomObject]@{
+                        responses = [PSCustomObject]@{
+                            '200' = [PSCustomObject]@{
+                                content = [PSCustomObject]@{
+                                    'application/json' = [PSCustomObject]@{ schema = [PSCustomObject]@{ properties = $envProps } }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+Describe 'Build-PfbResponseShapeMap' {
+    It 'records first-seen introducedVersion for fields present throughout' {
+        $specs = Join-Path $TestDrive 'specs'; New-Item -ItemType Directory -Path $specs -Force | Out-Null
+        New-ShapeSpecFixture -EnvelopeProperties @('items') -ItemProperties @('name') |
+            ConvertTo-Json -Depth 20 | Set-Content (Join-Path $specs 'fb9.0.json')
+        New-ShapeSpecFixture -EnvelopeProperties @('items') -ItemProperties @('name', 'added_later') |
+            ConvertTo-Json -Depth 20 | Set-Content (Join-Path $specs 'fb9.1.json')
+
+        $out = Join-Path $TestDrive 'map.json'
+        & $script:BuilderPath -SpecsDirectory $specs -OutputPath $out | Out-Null
+
+        $map = Get-Content $out -Raw | ConvertFrom-Json
+        $ep = $map.endpoints.'GET /widgets'
+        $ep.responseItemProperties.name | Should -Be '9.0'
+        $ep.responseItemProperties.added_later | Should -Be '9.1'
+        $ep.minVersion | Should -Be '9.0'
+        $ep.lastSeenVersion | Should -Be '9.1'
+    }
+
+    It 'moves a field that disappears into removedResponseFields, not responseItemProperties' {
+        $specs = Join-Path $TestDrive 'specs2'; New-Item -ItemType Directory -Path $specs -Force | Out-Null
+        New-ShapeSpecFixture -EnvelopeProperties @('items') -ItemProperties @('name', 'copyable') |
+            ConvertTo-Json -Depth 20 | Set-Content (Join-Path $specs 'fb9.0.json')
+        New-ShapeSpecFixture -EnvelopeProperties @('items') -ItemProperties @('name') |
+            ConvertTo-Json -Depth 20 | Set-Content (Join-Path $specs 'fb9.1.json')
+
+        $out = Join-Path $TestDrive 'map2.json'
+        & $script:BuilderPath -SpecsDirectory $specs -OutputPath $out | Out-Null
+
+        $map = Get-Content $out -Raw | ConvertFrom-Json
+        $ep = $map.endpoints.'GET /widgets'
+        $ep.responseItemProperties.PSObject.Properties.Name | Should -Not -Contain 'copyable'
+        @($ep.removedResponseFields).Count | Should -Be 1
+        $ep.removedResponseFields[0].field | Should -Be 'copyable'
+        $ep.removedResponseFields[0].location | Should -Be 'items'
+        $ep.removedResponseFields[0].introducedVersion | Should -Be '9.0'
+        $ep.removedResponseFields[0].lastSeenVersion | Should -Be '9.0'
+    }
+
+    It 'detects envelope-level removal too' {
+        $specs = Join-Path $TestDrive 'specs3'; New-Item -ItemType Directory -Path $specs -Force | Out-Null
+        New-ShapeSpecFixture -EnvelopeProperties @('items', 'total_item_count') -ItemProperties @('name') |
+            ConvertTo-Json -Depth 20 | Set-Content (Join-Path $specs 'fb9.0.json')
+        New-ShapeSpecFixture -EnvelopeProperties @('items') -ItemProperties @('name') |
+            ConvertTo-Json -Depth 20 | Set-Content (Join-Path $specs 'fb9.1.json')
+
+        $out = Join-Path $TestDrive 'map3.json'
+        & $script:BuilderPath -SpecsDirectory $specs -OutputPath $out | Out-Null
+
+        $map = Get-Content $out -Raw | ConvertFrom-Json
+        $removed = @($map.endpoints.'GET /widgets'.removedResponseFields)
+        $removed.Count | Should -Be 1
+        $removed[0].field | Should -Be 'total_item_count'
+        $removed[0].location | Should -Be 'envelope'
+    }
+
+    It 'omits removedResponseFields entirely when nothing was removed' {
+        $specs = Join-Path $TestDrive 'specs4'; New-Item -ItemType Directory -Path $specs -Force | Out-Null
+        New-ShapeSpecFixture -EnvelopeProperties @('items') -ItemProperties @('name') |
+            ConvertTo-Json -Depth 20 | Set-Content (Join-Path $specs 'fb9.0.json')
+
+        $out = Join-Path $TestDrive 'map4.json'
+        & $script:BuilderPath -SpecsDirectory $specs -OutputPath $out | Out-Null
+
+        $map = Get-Content $out -Raw | ConvertFrom-Json
+        $map.endpoints.'GET /widgets'.PSObject.Properties.Name | Should -Not -Contain 'removedResponseFields'
+    }
+
+    It 'sorts versions numerically, not lexically (9.9 before 9.10)' {
+        $specs = Join-Path $TestDrive 'specs5'; New-Item -ItemType Directory -Path $specs -Force | Out-Null
+        New-ShapeSpecFixture -EnvelopeProperties @('items') -ItemProperties @('name') |
+            ConvertTo-Json -Depth 20 | Set-Content (Join-Path $specs 'fb9.9.json')
+        New-ShapeSpecFixture -EnvelopeProperties @('items') -ItemProperties @('name', 'newer') |
+            ConvertTo-Json -Depth 20 | Set-Content (Join-Path $specs 'fb9.10.json')
+
+        $out = Join-Path $TestDrive 'map5.json'
+        & $script:BuilderPath -SpecsDirectory $specs -OutputPath $out | Out-Null
+
+        $map = Get-Content $out -Raw | ConvertFrom-Json
+        $map.generatedFrom[-1] | Should -Be '9.10'
+        # 'newer' appears only in 9.10; if sorting were lexical, 9.10 would be processed
+        # first and 'newer' would be recorded as removed.
+        $map.endpoints.'GET /widgets'.responseItemProperties.newer | Should -Be '9.10'
+        $map.endpoints.'GET /widgets'.PSObject.Properties.Name | Should -Not -Contain 'removedResponseFields'
+    }
+
+    It 'is deterministic across two runs' {
+        $specs = Join-Path $TestDrive 'specs6'; New-Item -ItemType Directory -Path $specs -Force | Out-Null
+        New-ShapeSpecFixture -EnvelopeProperties @('items', 'errors') -ItemProperties @('name', 'id', 'created') |
+            ConvertTo-Json -Depth 20 | Set-Content (Join-Path $specs 'fb9.0.json')
+
+        $a = Join-Path $TestDrive 'runA.json'
+        $b = Join-Path $TestDrive 'runB.json'
+        & $script:BuilderPath -SpecsDirectory $specs -OutputPath $a | Out-Null
+        & $script:BuilderPath -SpecsDirectory $specs -OutputPath $b | Out-Null
+
+        (Get-FileHash $a -Algorithm SHA256).Hash | Should -Be (Get-FileHash $b -Algorithm SHA256).Hash
+    }
+
+    It 'does not let an API field named "keys" shadow dictionary members' {
+        $specs = Join-Path $TestDrive 'specs7'; New-Item -ItemType Directory -Path $specs -Force | Out-Null
+        New-ShapeSpecFixture -EnvelopeProperties @('items') -ItemProperties @('keys', 'count', 'values') |
+            ConvertTo-Json -Depth 20 | Set-Content (Join-Path $specs 'fb9.0.json')
+
+        $out = Join-Path $TestDrive 'map7.json'
+        & $script:BuilderPath -SpecsDirectory $specs -OutputPath $out | Out-Null
+
+        $map = Get-Content $out -Raw | ConvertFrom-Json
+        $names = $map.endpoints.'GET /widgets'.responseItemProperties.PSObject.Properties.Name
+        $names | Should -Contain 'keys'
+        $names | Should -Contain 'count'
+        $names | Should -Contain 'values'
+    }
+}

--- a/Tests/Build-PfbResponseShapeMap.Tests.ps1
+++ b/Tests/Build-PfbResponseShapeMap.Tests.ps1
@@ -53,7 +53,7 @@ BeforeAll {
     }
 }
 
-Describe 'Build-PfbResponseShapeMap' {
+Describe 'Build-PfbResponseShapeMap' -Skip:($PSVersionTable.PSVersion.Major -lt 7) {
     It 'records first-seen introducedVersion for fields present throughout' {
         $specs = Join-Path $TestDrive 'specs'; New-Item -ItemType Directory -Path $specs -Force | Out-Null
         New-ShapeSpecFixture -EnvelopeProperties @('items') -ItemProperties @('name') |

--- a/Tests/PfbApiDriftTools.Tests.ps1
+++ b/Tests/PfbApiDriftTools.Tests.ps1
@@ -1398,49 +1398,113 @@ if ($response.continuation_token) { $more = $true }
         ($f.UnhandledEnvelopeFields | Where-Object { $_.Field -eq 'errors' }).EndpointCount | Should -Be 2
     }
 
-    It 'sorts removals and unhandled envelope fields deterministically, independent of JSON key order' {
-        # Fixture deliberately declares endpoints in reverse-alphabetical order: Z, G, P
-        # and field names in non-alphabetical order. The function must emit them sorted
-        # regardless, so assert literal expected sequences.
+    It 'sorts removals by Endpoint/Location/Field independent of JSON key order' {
+        # Removals declared in non-alphabetical order on GET /apple
         $map = [PSCustomObject]@{
             generatedFrom = @('2.0', '2.1')
             endpoints     = [PSCustomObject]@{
-                'POST /zebra'   = [PSCustomObject]@{
+                'GET /apple' = [PSCustomObject]@{
                     minVersion             = '2.0'
                     lastSeenVersion        = '2.1'
-                    responseEnvelope       = [PSCustomObject]@{ zulu = '2.0'; bravo = '2.0' }
+                    responseEnvelope       = [PSCustomObject]@{ items = '2.0' }
                     responseItemProperties = [PSCustomObject]@{}
                     removedResponseFields  = @(
                         [PSCustomObject]@{ field = 'yankee'; location = 'items'; introducedVersion = '2.0'; lastSeenVersion = '2.1' }
                         [PSCustomObject]@{ field = 'alpha'; location = 'items'; introducedVersion = '2.0'; lastSeenVersion = '2.1' }
                     )
                 }
-                'GET /apple'    = [PSCustomObject]@{
-                    minVersion             = '2.0'
-                    lastSeenVersion        = '2.1'
-                    responseEnvelope       = [PSCustomObject]@{ charlie = '2.0' }
-                    responseItemProperties = [PSCustomObject]@{}
-                    removedResponseFields  = @(
-                        [PSCustomObject]@{ field = 'zulu'; location = 'items'; introducedVersion = '2.0'; lastSeenVersion = '2.1' }
-                    )
-                }
             }
         }
-        $handler = Join-Path $TestDrive 'Invoke-PfbApiRequest-sort.ps1'
+        $handler = Join-Path $TestDrive 'Invoke-PfbApiRequest-removals.ps1'
         @'
 if ($null -ne $response.items) { $allItems.Add($response.items) }
 '@ | Set-Content $handler
         $f = Get-PfbResponseShapeFindings -ResponseShapeMap $map -RequestHandlerPath $handler
-        # Removals must be sorted by Endpoint, Location, Field
-        $f.Removals[0].Endpoint | Should -Be 'GET /apple'
-        $f.Removals[1].Endpoint | Should -Be 'POST /zebra'
-        $f.Removals[1].Field | Should -Be 'alpha'
-        $f.Removals[2].Field | Should -Be 'yankee'
-        # UnhandledEnvelopeFields must be sorted by EndpointCount desc, then Field asc
-        # All three unhandled fields appear on 1 endpoint, so sorted by name: bravo, charlie, zulu
-        $f.UnhandledEnvelopeFields[0].Field | Should -Be 'bravo'
-        $f.UnhandledEnvelopeFields[1].Field | Should -Be 'charlie'
-        $f.UnhandledEnvelopeFields[2].Field | Should -Be 'zulu'
+        # Natural emission order from removedResponseFields array: [yankee, alpha]
+        # Sorted order by Endpoint, Location, Field: [alpha, yankee]
+        @($f.Removals).Count | Should -Be 2
+        $f.Removals[0].Field | Should -Be 'alpha'
+        $f.Removals[1].Field | Should -Be 'yankee'
+    }
+
+    It 'sorts rename candidates by Endpoint/Location/From independent of removal declaration order' {
+        # Three candidates whose NATURAL emission order (removedResponseFields declaration
+        # order) contradicts the sorted order on BOTH remaining sort keys. The Endpoint key
+        # cannot be defeated by a fixture -- the endpoint loop itself already iterates
+        # $endpointNames sorted -- so this fixture puts all three on one endpoint and
+        # exercises Location (envelope < items) and From (alpha < zulu) instead.
+        #
+        # Each removal is given a DISTINCT successor version, and each bag holds exactly one
+        # field at that version, so every removal yields exactly one candidate rather than a
+        # cross-product of every same-version field in the bag.
+        #   zulu  (items)    lastSeen 2.0 -> successor 2.1 -> zulu_new  (2.1)
+        #   alpha (items)    lastSeen 2.1 -> successor 2.2 -> alpha_new (2.2)
+        #   mike  (envelope) lastSeen 2.2 -> successor 2.3 -> mike_new  (2.3)
+        $map = [PSCustomObject]@{
+            generatedFrom = @('2.0', '2.1', '2.2', '2.3')
+            endpoints     = [PSCustomObject]@{
+                'POST /apple' = [PSCustomObject]@{
+                    minVersion             = '2.0'
+                    lastSeenVersion        = '2.3'
+                    responseEnvelope       = [PSCustomObject]@{ items = '2.0'; mike_new = '2.3' }
+                    responseItemProperties = [PSCustomObject]@{ zulu_new = '2.1'; alpha_new = '2.2' }
+                    removedResponseFields  = @(
+                        [PSCustomObject]@{ field = 'zulu'; location = 'items'; introducedVersion = '2.0'; lastSeenVersion = '2.0' }
+                        [PSCustomObject]@{ field = 'alpha'; location = 'items'; introducedVersion = '2.0'; lastSeenVersion = '2.1' }
+                        [PSCustomObject]@{ field = 'mike'; location = 'envelope'; introducedVersion = '2.0'; lastSeenVersion = '2.2' }
+                    )
+                }
+            }
+        }
+        $handler = Join-Path $TestDrive 'Invoke-PfbApiRequest-candidates.ps1'
+        @'
+if ($null -ne $response.items) { $allItems.Add($response.items) }
+'@ | Set-Content $handler
+        $f = Get-PfbResponseShapeFindings -ResponseShapeMap $map -RequestHandlerPath $handler
+        # Natural emission order (declaration order): [zulu(items), alpha(items), mike(envelope)]
+        # Sorted by Endpoint, Location, From:          [mike(envelope), alpha(items), zulu(items)]
+        @($f.RenameCandidates).Count | Should -Be 3
+        @($f.RenameCandidates | ForEach-Object { "$($_.Location)/$($_.From)->$($_.To)" }) | Should -Be @(
+            'envelope/mike->mike_new'
+            'items/alpha->alpha_new'
+            'items/zulu->zulu_new'
+        )
+    }
+
+    It 'sorts unhandled envelope fields by EndpointCount desc/Field asc with differing counts' {
+        # zulu appears on 2 endpoints, alpha and bravo on 1 each
+        # Correct sort: zulu (2), alpha (1), bravo (1) — count takes precedence
+        $map = [PSCustomObject]@{
+            generatedFrom = @('2.0', '2.1')
+            endpoints     = [PSCustomObject]@{
+                'GET /zebra' = [PSCustomObject]@{
+                    minVersion             = '2.0'
+                    lastSeenVersion        = '2.1'
+                    responseEnvelope       = [PSCustomObject]@{ zulu = '2.0'; alpha = '2.0' }
+                    responseItemProperties = [PSCustomObject]@{}
+                }
+                'POST /apple' = [PSCustomObject]@{
+                    minVersion             = '2.0'
+                    lastSeenVersion        = '2.1'
+                    responseEnvelope       = [PSCustomObject]@{ zulu = '2.0'; bravo = '2.0' }
+                    responseItemProperties = [PSCustomObject]@{}
+                }
+            }
+        }
+        $handler = Join-Path $TestDrive 'Invoke-PfbApiRequest-envelope.ps1'
+        @'
+if ($null -ne $response.items) { $allItems.Add($response.items) }
+'@ | Set-Content $handler
+        $f = Get-PfbResponseShapeFindings -ResponseShapeMap $map -RequestHandlerPath $handler
+        # Alphabetical order alone: alpha (1), bravo (1), zulu (2)
+        # With EndpointCount desc: zulu (2), alpha (1), bravo (1)
+        @($f.UnhandledEnvelopeFields).Count | Should -Be 3
+        $f.UnhandledEnvelopeFields[0].Field | Should -Be 'zulu'
+        $f.UnhandledEnvelopeFields[0].EndpointCount | Should -Be 2
+        $f.UnhandledEnvelopeFields[1].Field | Should -Be 'alpha'
+        $f.UnhandledEnvelopeFields[1].EndpointCount | Should -Be 1
+        $f.UnhandledEnvelopeFields[2].Field | Should -Be 'bravo'
+        $f.UnhandledEnvelopeFields[2].EndpointCount | Should -Be 1
     }
 
     It 'does not throw when an endpoint has an empty responseEnvelope' {

--- a/Tests/PfbApiDriftTools.Tests.ps1
+++ b/Tests/PfbApiDriftTools.Tests.ps1
@@ -1330,3 +1330,92 @@ Describe 'Task 6 real-data invariants (systemic gaps + convention strength, skip
         $ratio | Should -BeLessThan 0.55
     }
 }
+
+Describe 'Get-PfbResponseShapeFindings' {
+    BeforeAll {
+        $script:fixtureMap = [PSCustomObject]@{
+            schemaVersion = 1
+            generatedFrom = @('2.0', '2.1', '2.2')
+            endpoints     = [PSCustomObject]@{
+                'GET /widgets'  = [PSCustomObject]@{
+                    minVersion             = '2.0'
+                    lastSeenVersion        = '2.2'
+                    responseEnvelope       = [PSCustomObject]@{ items = '2.0'; errors = '2.1' }
+                    responseItemProperties = [PSCustomObject]@{ name = '2.0'; widget_name = '2.2' }
+                    removedResponseFields  = @(
+                        [PSCustomObject]@{ field = 'wname'; location = 'items'; introducedVersion = '2.0'; lastSeenVersion = '2.1' }
+                    )
+                }
+                'GET /gadgets' = [PSCustomObject]@{
+                    minVersion             = '2.0'
+                    lastSeenVersion        = '2.2'
+                    responseEnvelope       = [PSCustomObject]@{ items = '2.0' }
+                    responseItemProperties = [PSCustomObject]@{ name = '2.0' }
+                }
+            }
+        }
+
+        $script:handlerPath = Join-Path $TestDrive 'Invoke-PfbApiRequest.ps1'
+        @'
+if ($null -ne $response.items) { $allItems.Add($response.items) }
+if ($null -ne $response.total_item_count) { $totalItemCount = $response.total_item_count }
+if ($response.continuation_token) { $more = $true }
+'@ | Set-Content $script:handlerPath
+    }
+
+    It 'flattens removals one record per endpoint and field' {
+        $f = Get-PfbResponseShapeFindings -ResponseShapeMap $script:fixtureMap -RequestHandlerPath $script:handlerPath
+        @($f.Removals).Count | Should -Be 1
+        $f.Removals[0].Endpoint | Should -Be 'GET /widgets'
+        $f.Removals[0].Field | Should -Be 'wname'
+        $f.Removals[0].LastSeenVersion | Should -Be '2.1'
+    }
+
+    It 'pairs a removal with a same-version addition as a rename CANDIDATE' {
+        $f = Get-PfbResponseShapeFindings -ResponseShapeMap $script:fixtureMap -RequestHandlerPath $script:handlerPath
+        @($f.RenameCandidates).Count | Should -Be 1
+        $f.RenameCandidates[0].From | Should -Be 'wname'
+        $f.RenameCandidates[0].To | Should -Be 'widget_name'
+        $f.RenameCandidates[0].Endpoint | Should -Be 'GET /widgets'
+    }
+
+    It 'reports errors as an envelope field the request handler never reads' {
+        $f = Get-PfbResponseShapeFindings -ResponseShapeMap $script:fixtureMap -RequestHandlerPath $script:handlerPath
+        $names = @($f.UnhandledEnvelopeFields | ForEach-Object { $_.Field })
+        $names | Should -Contain 'errors'
+        $names | Should -Not -Contain 'items'
+        $names | Should -Not -Contain 'total_item_count'
+    }
+
+    It 'counts how many endpoints declare each unhandled envelope field' {
+        $f = Get-PfbResponseShapeFindings -ResponseShapeMap $script:fixtureMap -RequestHandlerPath $script:handlerPath
+        ($f.UnhandledEnvelopeFields | Where-Object { $_.Field -eq 'errors' }).EndpointCount | Should -Be 1
+    }
+
+    It 'emits deterministically sorted collections' {
+        $a = Get-PfbResponseShapeFindings -ResponseShapeMap $script:fixtureMap -RequestHandlerPath $script:handlerPath
+        $b = Get-PfbResponseShapeFindings -ResponseShapeMap $script:fixtureMap -RequestHandlerPath $script:handlerPath
+        ($a.Removals | ConvertTo-Json -Depth 6) | Should -Be ($b.Removals | ConvertTo-Json -Depth 6)
+        ($a.UnhandledEnvelopeFields | ConvertTo-Json -Depth 6) | Should -Be ($b.UnhandledEnvelopeFields | ConvertTo-Json -Depth 6)
+    }
+
+    It 'does not treat an unrelated later addition as a rename' {
+        $map = [PSCustomObject]@{
+            generatedFrom = @('2.0', '2.1', '2.2')
+            endpoints     = [PSCustomObject]@{
+                'GET /widgets' = [PSCustomObject]@{
+                    minVersion             = '2.0'
+                    lastSeenVersion        = '2.2'
+                    responseEnvelope       = [PSCustomObject]@{ items = '2.0' }
+                    # introduced at 2.2, but the removal was last seen at 2.0 -> not adjacent
+                    responseItemProperties = [PSCustomObject]@{ unrelated = '2.2' }
+                    removedResponseFields  = @(
+                        [PSCustomObject]@{ field = 'gone'; location = 'items'; introducedVersion = '2.0'; lastSeenVersion = '2.0' }
+                    )
+                }
+            }
+        }
+        $f = Get-PfbResponseShapeFindings -ResponseShapeMap $map -RequestHandlerPath $script:handlerPath
+        @($f.RenameCandidates).Count | Should -Be 0
+    }
+}

--- a/Tests/PfbApiDriftTools.Tests.ps1
+++ b/Tests/PfbApiDriftTools.Tests.ps1
@@ -1340,7 +1340,7 @@ Describe 'Get-PfbResponseShapeFindings' {
                 'GET /widgets'  = [PSCustomObject]@{
                     minVersion             = '2.0'
                     lastSeenVersion        = '2.2'
-                    responseEnvelope       = [PSCustomObject]@{ items = '2.0'; errors = '2.1' }
+                    responseEnvelope       = [PSCustomObject]@{ items = '2.0'; errors = '2.1'; total_item_count = '2.0' }
                     responseItemProperties = [PSCustomObject]@{ name = '2.0'; widget_name = '2.2' }
                     removedResponseFields  = @(
                         [PSCustomObject]@{ field = 'wname'; location = 'items'; introducedVersion = '2.0'; lastSeenVersion = '2.1' }
@@ -1349,8 +1349,14 @@ Describe 'Get-PfbResponseShapeFindings' {
                 'GET /gadgets' = [PSCustomObject]@{
                     minVersion             = '2.0'
                     lastSeenVersion        = '2.2'
-                    responseEnvelope       = [PSCustomObject]@{ items = '2.0' }
+                    responseEnvelope       = [PSCustomObject]@{ items = '2.0'; errors = '2.1' }
                     responseItemProperties = [PSCustomObject]@{ name = '2.0' }
+                }
+                'POST /keytabs/upload' = [PSCustomObject]@{
+                    minVersion             = '2.0'
+                    lastSeenVersion        = '2.2'
+                    responseEnvelope       = [PSCustomObject]@{}
+                    responseItemProperties = [PSCustomObject]@{}
                 }
             }
         }
@@ -1387,16 +1393,61 @@ if ($response.continuation_token) { $more = $true }
         $names | Should -Not -Contain 'total_item_count'
     }
 
-    It 'counts how many endpoints declare each unhandled envelope field' {
+    It 'counts how many endpoints declare each unhandled envelope field, with endpoint count not occurrence count' {
         $f = Get-PfbResponseShapeFindings -ResponseShapeMap $script:fixtureMap -RequestHandlerPath $script:handlerPath
-        ($f.UnhandledEnvelopeFields | Where-Object { $_.Field -eq 'errors' }).EndpointCount | Should -Be 1
+        ($f.UnhandledEnvelopeFields | Where-Object { $_.Field -eq 'errors' }).EndpointCount | Should -Be 2
     }
 
-    It 'emits deterministically sorted collections' {
-        $a = Get-PfbResponseShapeFindings -ResponseShapeMap $script:fixtureMap -RequestHandlerPath $script:handlerPath
-        $b = Get-PfbResponseShapeFindings -ResponseShapeMap $script:fixtureMap -RequestHandlerPath $script:handlerPath
-        ($a.Removals | ConvertTo-Json -Depth 6) | Should -Be ($b.Removals | ConvertTo-Json -Depth 6)
-        ($a.UnhandledEnvelopeFields | ConvertTo-Json -Depth 6) | Should -Be ($b.UnhandledEnvelopeFields | ConvertTo-Json -Depth 6)
+    It 'sorts removals and unhandled envelope fields deterministically, independent of JSON key order' {
+        # Fixture deliberately declares endpoints in reverse-alphabetical order: Z, G, P
+        # and field names in non-alphabetical order. The function must emit them sorted
+        # regardless, so assert literal expected sequences.
+        $map = [PSCustomObject]@{
+            generatedFrom = @('2.0', '2.1')
+            endpoints     = [PSCustomObject]@{
+                'POST /zebra'   = [PSCustomObject]@{
+                    minVersion             = '2.0'
+                    lastSeenVersion        = '2.1'
+                    responseEnvelope       = [PSCustomObject]@{ zulu = '2.0'; bravo = '2.0' }
+                    responseItemProperties = [PSCustomObject]@{}
+                    removedResponseFields  = @(
+                        [PSCustomObject]@{ field = 'yankee'; location = 'items'; introducedVersion = '2.0'; lastSeenVersion = '2.1' }
+                        [PSCustomObject]@{ field = 'alpha'; location = 'items'; introducedVersion = '2.0'; lastSeenVersion = '2.1' }
+                    )
+                }
+                'GET /apple'    = [PSCustomObject]@{
+                    minVersion             = '2.0'
+                    lastSeenVersion        = '2.1'
+                    responseEnvelope       = [PSCustomObject]@{ charlie = '2.0' }
+                    responseItemProperties = [PSCustomObject]@{}
+                    removedResponseFields  = @(
+                        [PSCustomObject]@{ field = 'zulu'; location = 'items'; introducedVersion = '2.0'; lastSeenVersion = '2.1' }
+                    )
+                }
+            }
+        }
+        $handler = Join-Path $TestDrive 'Invoke-PfbApiRequest-sort.ps1'
+        @'
+if ($null -ne $response.items) { $allItems.Add($response.items) }
+'@ | Set-Content $handler
+        $f = Get-PfbResponseShapeFindings -ResponseShapeMap $map -RequestHandlerPath $handler
+        # Removals must be sorted by Endpoint, Location, Field
+        $f.Removals[0].Endpoint | Should -Be 'GET /apple'
+        $f.Removals[1].Endpoint | Should -Be 'POST /zebra'
+        $f.Removals[1].Field | Should -Be 'alpha'
+        $f.Removals[2].Field | Should -Be 'yankee'
+        # UnhandledEnvelopeFields must be sorted by EndpointCount desc, then Field asc
+        # All three unhandled fields appear on 1 endpoint, so sorted by name: bravo, charlie, zulu
+        $f.UnhandledEnvelopeFields[0].Field | Should -Be 'bravo'
+        $f.UnhandledEnvelopeFields[1].Field | Should -Be 'charlie'
+        $f.UnhandledEnvelopeFields[2].Field | Should -Be 'zulu'
+    }
+
+    It 'does not throw when an endpoint has an empty responseEnvelope' {
+        # This covers the null-handling fix for envelopes that are empty objects {}
+        $f = Get-PfbResponseShapeFindings -ResponseShapeMap $script:fixtureMap -RequestHandlerPath $script:handlerPath
+        $f | Should -Not -BeNullOrEmpty
+        @($f.Removals).Count | Should -Be 1
     }
 
     It 'does not treat an unrelated later addition as a rename' {

--- a/Tests/PfbSpecTools.Tests.ps1
+++ b/Tests/PfbSpecTools.Tests.ps1
@@ -560,3 +560,141 @@ Describe 'Get-PfbSwaggerIndexVersions' {
         Get-PfbSwaggerIndexVersions -IndexHtml '<html></html>' | Should -BeNullOrEmpty
     }
 }
+
+Describe 'Get-PfbResponseSchema' {
+    It 'returns the first 2xx application/json response schema' {
+        $op = [PSCustomObject]@{
+            responses = [PSCustomObject]@{
+                '200' = [PSCustomObject]@{
+                    content = [PSCustomObject]@{
+                        'application/json' = [PSCustomObject]@{
+                            schema = [PSCustomObject]@{ marker = 'yes' }
+                        }
+                    }
+                }
+                '400' = [PSCustomObject]@{ description = 'bad' }
+            }
+        }
+        $result = Get-PfbResponseSchema -Operation $op -Spec ([PSCustomObject]@{})
+        $result.marker | Should -Be 'yes'
+    }
+
+    It 'returns $null when no 2xx response carries a schema' {
+        $op = [PSCustomObject]@{
+            responses = [PSCustomObject]@{ '400' = [PSCustomObject]@{ description = 'bad' } }
+        }
+        Get-PfbResponseSchema -Operation $op -Spec ([PSCustomObject]@{}) | Should -BeNullOrEmpty
+    }
+}
+
+Describe 'Get-PfbSpecResponseShapes' {
+    BeforeAll {
+        $script:shapeSpec = [PSCustomObject]@{
+            paths = [PSCustomObject]@{
+                '/api/2.0/file-systems' = [PSCustomObject]@{
+                    get = [PSCustomObject]@{
+                        responses = [PSCustomObject]@{
+                            '200' = [PSCustomObject]@{
+                                content = [PSCustomObject]@{
+                                    'application/json' = [PSCustomObject]@{
+                                        schema = [PSCustomObject]@{
+                                            properties = [PSCustomObject]@{
+                                                items              = [PSCustomObject]@{
+                                                    type  = 'array'
+                                                    items = [PSCustomObject]@{
+                                                        properties = [PSCustomObject]@{
+                                                            name      = [PSCustomObject]@{ type = 'string' }
+                                                            destroyed = [PSCustomObject]@{ type = 'boolean' }
+                                                        }
+                                                    }
+                                                }
+                                                total_item_count   = [PSCustomObject]@{ type = 'integer' }
+                                                errors             = [PSCustomObject]@{ type = 'array' }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    It 'extracts envelope properties including errors' {
+        $shapes = @(Get-PfbSpecResponseShapes -Spec $script:shapeSpec)
+        $shapes.Count | Should -Be 1
+        $shapes[0].Method | Should -Be 'GET'
+        $shapes[0].Path | Should -Be '/file-systems'
+        $shapes[0].EnvelopeProperties | Should -Contain 'errors'
+        $shapes[0].EnvelopeProperties | Should -Contain 'total_item_count'
+    }
+
+    It 'descends one level into items[] and no further' {
+        $shapes = @(Get-PfbSpecResponseShapes -Spec $script:shapeSpec)
+        $shapes[0].ItemProperties | Should -Contain 'name'
+        $shapes[0].ItemProperties | Should -Contain 'destroyed'
+        # depth 3 is deliberately excluded -- nothing dotted is ever emitted
+        @($shapes[0].ItemProperties | Where-Object { $_ -like '*.*' }).Count | Should -Be 0
+    }
+
+    It 'emits deterministically sorted collections' {
+        $shapes = @(Get-PfbSpecResponseShapes -Spec $script:shapeSpec)
+        $shapes[0].EnvelopeProperties | Should -Be (@($shapes[0].EnvelopeProperties) | Sort-Object)
+        $shapes[0].ItemProperties | Should -Be (@($shapes[0].ItemProperties) | Sort-Object)
+    }
+}
+
+Describe 'Get-PfbSpecResponseShapes -MaxDepth (regression: the 184-false-removal trap)' {
+    BeforeAll {
+        # An allOf chain 10 levels deep -- deeper than the walker's default MaxDepth of 8.
+        # This mirrors components.schemas.FileSystem in fb2.13-2.16, which reads 4 properties
+        # at depth 8 and 21 at depth 16. Reading it at the default would report the deep
+        # property as absent, which the accumulator would then record as a REMOVAL.
+        $schemas = [PSCustomObject]@{}
+        $schemas | Add-Member -NotePropertyName 'Level9' -NotePropertyValue ([PSCustomObject]@{
+                properties = [PSCustomObject]@{ deep_field = [PSCustomObject]@{ type = 'string' } }
+            })
+        foreach ($i in 8..0) {
+            $schemas | Add-Member -NotePropertyName "Level$i" -NotePropertyValue ([PSCustomObject]@{
+                    allOf = @([PSCustomObject]@{ '$ref' = "#/components/schemas/Level$($i + 1)" })
+                })
+        }
+        $script:deepSpec = [PSCustomObject]@{
+            components = [PSCustomObject]@{ schemas = $schemas }
+            paths      = [PSCustomObject]@{
+                '/api/2.0/deep' = [PSCustomObject]@{
+                    get = [PSCustomObject]@{
+                        responses = [PSCustomObject]@{
+                            '200' = [PSCustomObject]@{
+                                content = [PSCustomObject]@{
+                                    'application/json' = [PSCustomObject]@{
+                                        schema = [PSCustomObject]@{
+                                            properties = [PSCustomObject]@{
+                                                items = [PSCustomObject]@{
+                                                    type  = 'array'
+                                                    items = [PSCustomObject]@{ '$ref' = '#/components/schemas/Level0' }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    It 'finds a property nested deeper than the default MaxDepth of 8' {
+        $shapes = @(Get-PfbSpecResponseShapes -Spec $script:deepSpec)
+        $shapes[0].ItemProperties | Should -Contain 'deep_field'
+    }
+
+    It 'would MISS that property at the default depth -- proving the constraint is real' {
+        $shapes = @(Get-PfbSpecResponseShapes -Spec $script:deepSpec -MaxDepth 8)
+        $shapes[0].ItemProperties | Should -Not -Contain 'deep_field'
+    }
+}

--- a/Tests/PfbSpecTools.Tests.ps1
+++ b/Tests/PfbSpecTools.Tests.ps1
@@ -674,7 +674,16 @@ Describe 'Get-PfbSpecResponseShapes -MaxDepth (regression: the 184-false-removal
                                             properties = [PSCustomObject]@{
                                                 items = [PSCustomObject]@{
                                                     type  = 'array'
-                                                    items = [PSCustomObject]@{ '$ref' = '#/components/schemas/Level0' }
+                                                    # 'shallow_field' sits inline on the items element schema, ALONGSIDE the
+                                                    # deep allOf chain, and is reachable at any MaxDepth. It exists purely to
+                                                    # give the depth-8 test below a positive anchor: without it, that test's
+                                                    # only assertion is a negative one, and an implementation that returned
+                                                    # nothing at all would satisfy it just as well as a correctly
+                                                    # depth-truncated one. See that It's own comment.
+                                                    items = [PSCustomObject]@{
+                                                        properties = [PSCustomObject]@{ shallow_field = [PSCustomObject]@{ type = 'string' } }
+                                                        allOf      = @([PSCustomObject]@{ '$ref' = '#/components/schemas/Level0' })
+                                                    }
                                                 }
                                             }
                                         }
@@ -691,10 +700,28 @@ Describe 'Get-PfbSpecResponseShapes -MaxDepth (regression: the 184-false-removal
     It 'finds a property nested deeper than the default MaxDepth of 8' {
         $shapes = @(Get-PfbSpecResponseShapes -Spec $script:deepSpec)
         $shapes[0].ItemProperties | Should -Contain 'deep_field'
+        # At the real default BOTH are reached; contrast with the depth-8 test below, where
+        # only the shallow one survives. The pair is what makes the difference attributable
+        # to depth rather than to the walk having failed outright.
+        $shapes[0].ItemProperties | Should -Contain 'shallow_field'
     }
 
     It 'would MISS that property at the default depth -- proving the constraint is real' {
         $shapes = @(Get-PfbSpecResponseShapes -Spec $script:deepSpec -MaxDepth 8)
+
+        # POSITIVE ANCHORS FIRST, and they are the entire point of this ordering. The
+        # assertion this test exists for is a NEGATIVE one, and a negative assertion about a
+        # collection is satisfied by every degenerate outcome as well as by the intended one:
+        # if the function returned an empty list, $shapes[0] would be $null and
+        # `$null | Should -Not -Contain 'deep_field'` would pass, testing nothing. (Confirmed
+        # by mutation: gutting Get-PfbSpecResponseShapes to return an empty list left this
+        # test green.) These two anchors fail on that mutant, so reaching the negative below
+        # proves the walk really ran, really produced this endpoint's record, and really
+        # populated ItemProperties -- and that the ONLY thing missing at depth 8 is the
+        # property that needs more than 8 levels to reach.
+        $shapes.Count | Should -Be 1
+        $shapes[0].ItemProperties | Should -Contain 'shallow_field'
+
         $shapes[0].ItemProperties | Should -Not -Contain 'deep_field'
     }
 }

--- a/tools/Build-PfbApiDriftReport.ps1
+++ b/tools/Build-PfbApiDriftReport.ps1
@@ -153,9 +153,27 @@ $responseFindings = [PSCustomObject]@{
 $responseShapeMapPresent = Test-Path $ResponseShapeMapPath
 if ($responseShapeMapPresent) {
     $responseShapeMap = Get-Content -Path $ResponseShapeMapPath -Raw | ConvertFrom-Json
+
+    # Built from $PrivateDirectory, NOT from $repoRoot. It defaults to <repoRoot>/Private
+    # (line 129) so the real run is unchanged, but a caller that passes -PrivateDirectory
+    # -- every synthetic-fixture test in Tests/Build-PfbApiDriftReport.Tests.ps1 does --
+    # must have that honoured here exactly as it is at the Get-PfbModuleCalledEndpoints and
+    # Get-PfbNonActionableParameters call sites below. Hardcoding $repoRoot here made those
+    # runs silently analyse the REAL Private/ tree.
+    $requestHandlerPath = Join-Path $PrivateDirectory 'Invoke-PfbApiRequest.ps1'
+
+    # Warn loudly on absence. Get-PfbResponseShapeFindings returns an EMPTY
+    # UnhandledEnvelopeFields list when the handler cannot be read, which is
+    # indistinguishable in the rendered report from "every envelope field is handled" --
+    # a broken lookup that reads as a clean bill of health. The removals and rename
+    # candidates are unaffected; only the envelope-coverage category needs the handler.
+    if (-not (Test-Path $requestHandlerPath)) {
+        Write-Warning "Request handler not found at '$requestHandlerPath'; the unhandled-response-envelope-fields category will be EMPTY. That is a skipped analysis, not a finding of zero."
+    }
+
     $responseFindings = Get-PfbResponseShapeFindings `
         -ResponseShapeMap $responseShapeMap `
-        -RequestHandlerPath (Join-Path $repoRoot 'Private/Invoke-PfbApiRequest.ps1')
+        -RequestHandlerPath $requestHandlerPath
 }
 else {
     Write-Warning "Response shape map not found at '$ResponseShapeMapPath'; response-shape drift categories will be empty. Run tools/Build-PfbResponseShapeMap.ps1."

--- a/tools/Build-PfbApiDriftReport.ps1
+++ b/tools/Build-PfbApiDriftReport.ps1
@@ -108,6 +108,7 @@ param(
     [string]$PrivateDirectory,
     [string]$CapabilityMapPath,
     [string]$FieldCmdletMapPath,
+    [string]$ResponseShapeMapPath,
     [string]$OutputPath,
     [string]$ReportPath,
     [string]$SinceVersion
@@ -136,6 +137,29 @@ if (-not (Test-Path $FieldCmdletMapPath)) { throw "Field-cmdlet map not found at
 
 $capabilityMap = Get-Content -Path $CapabilityMapPath -Raw | ConvertFrom-Json -Depth 20
 $fieldCmdletMap = Get-Content -Path $FieldCmdletMapPath -Raw | ConvertFrom-Json -Depth 20
+
+if (-not $ResponseShapeMapPath) {
+    $ResponseShapeMapPath = Join-Path $repoRoot 'Data/PfbResponseShapeMap.json'
+}
+
+# Response-shape findings are optional: the map is a separate artifact with no runtime
+# consumer, so a report generated before it exists should degrade to empty lists rather
+# than fail. Absence is reported honestly below rather than rendered as "no drift".
+$responseFindings = [PSCustomObject]@{
+    Removals                = @()
+    RenameCandidates        = @()
+    UnhandledEnvelopeFields = @()
+}
+$responseShapeMapPresent = Test-Path $ResponseShapeMapPath
+if ($responseShapeMapPresent) {
+    $responseShapeMap = Get-Content -Path $ResponseShapeMapPath -Raw | ConvertFrom-Json
+    $responseFindings = Get-PfbResponseShapeFindings `
+        -ResponseShapeMap $responseShapeMap `
+        -RequestHandlerPath (Join-Path $repoRoot 'Private/Invoke-PfbApiRequest.ps1')
+}
+else {
+    Write-Warning "Response shape map not found at '$ResponseShapeMapPath'; response-shape drift categories will be empty. Run tools/Build-PfbResponseShapeMap.ps1."
+}
 
 $inventory = Get-PfbCmdletParameterInventory -PublicDirectory $PublicDirectory
 $calledEndpoints = Get-PfbModuleCalledEndpoints -PublicDirectory $PublicDirectory -PrivateDirectory $PrivateDirectory
@@ -607,6 +631,27 @@ $manifest = [ordered]@{
     conventionStrength        = $conventionStrength
     validateSetDrift          = $validateSetDrift
     newValidateSetCandidates  = $newValidateSetCandidates
+    responseFieldRemovals           = @($responseFindings.Removals | ForEach-Object {
+            [ordered]@{
+                endpoint          = $_.Endpoint
+                field             = $_.Field
+                location          = $_.Location
+                introducedVersion = $_.IntroducedVersion
+                lastSeenVersion   = $_.LastSeenVersion
+            }
+        })
+    responseFieldRenameCandidates   = @($responseFindings.RenameCandidates | ForEach-Object {
+            [ordered]@{
+                endpoint = $_.Endpoint
+                location = $_.Location
+                from     = $_.From
+                to       = $_.To
+                version  = $_.Version
+            }
+        })
+    unhandledResponseEnvelopeFields = @($responseFindings.UnhandledEnvelopeFields | ForEach-Object {
+            [ordered]@{ field = $_.Field; endpointCount = $_.EndpointCount }
+        })
     contextCardinality        = [ordered]@{
         # The version this category's numbers describe -- never omit it, see the block
         # where these are computed.
@@ -676,6 +721,9 @@ $mdLines.Add("- Systemic gaps (distinct field names collapsed across high-confid
 $mdLines.Add("- ValidateSet drift: $($validateSetDrift.Count)")
 $mdLines.Add("- New ValidateSet candidates: $($newValidateSetCandidates.Count)")
 $mdLines.Add("- Context cardinality signal disagreements (fb$newestAnalysedVersion): $($contextSignalDisagreements.Count)")
+$mdLines.Add(('- Removed response fields: **{0}**' -f @($responseFindings.Removals).Count))
+$mdLines.Add(('- Response rename candidates: **{0}**' -f @($responseFindings.RenameCandidates).Count))
+$mdLines.Add(('- Envelope fields not read by `Invoke-PfbApiRequest`: **{0}**' -f @($responseFindings.UnhandledEnvelopeFields).Count))
 
 if ($systemicGaps.Count -gt 0) {
     $mdLines.Add(''); $mdLines.Add('## Systemic gaps'); $mdLines.Add('')
@@ -739,6 +787,60 @@ if ($readOnlyRows.Count -gt 0) {
     $mdLines.Add('')
     $mdLines.Add('| Endpoint | Cmdlets | Read-only fields |'); $mdLines.Add('|---|---|---|')
     foreach ($g in $readOnlyRows) { $mdLines.Add("| ``$($g.endpoint)`` | $($g.cmdlets -join ', ') | $($g.readOnlyFields -join ', ') |") }
+}
+
+$mdLines.Add(''); $mdLines.Add('## Response-shape drift'); $mdLines.Add('')
+if (-not $responseShapeMapPresent) {
+    $mdLines.Add('> **Not analysed.** `Data/PfbResponseShapeMap.json` was not found when this report was generated. Run `tools/Build-PfbResponseShapeMap.ps1`. The absence of findings below does *not* mean there is no response drift.')
+}
+else {
+    $mdLines.Add('Cmdlets pass API responses through raw -- there is no projection anywhere in `Public/`, so the module holds no schema of its own. A **removed or renamed** response field therefore reaches user scripts as a silent `$null`, which no other report category can detect. **Added** response fields are deliberately not reported: they surface automatically and need no module change.')
+    $mdLines.Add('')
+
+    $mdLines.Add('### Removed response fields')
+    $mdLines.Add('')
+    if (@($responseFindings.Removals).Count -eq 0) {
+        $mdLines.Add('_None._')
+    }
+    else {
+        $mdLines.Add('| Endpoint | Location | Field | Introduced | Last seen |')
+        $mdLines.Add('|---|---|---|---|---|')
+        foreach ($r in $responseFindings.Removals) {
+            $mdLines.Add(('| `{0}` | {1} | `{2}` | {3} | {4} |' -f $r.Endpoint, $r.Location, $r.Field, $r.IntroducedVersion, $r.LastSeenVersion))
+        }
+    }
+    $mdLines.Add('')
+
+    $mdLines.Add('### Rename candidates')
+    $mdLines.Add('')
+    $mdLines.Add('_A removal and an addition adjacent in version on the same endpoint. Suggestive, not proof -- confirm against the spec before acting._')
+    $mdLines.Add('')
+    if (@($responseFindings.RenameCandidates).Count -eq 0) {
+        $mdLines.Add('_None._')
+    }
+    else {
+        $mdLines.Add('| Endpoint | Location | From | To | Version |')
+        $mdLines.Add('|---|---|---|---|---|')
+        foreach ($r in $responseFindings.RenameCandidates) {
+            $mdLines.Add(('| `{0}` | {1} | `{2}` | `{3}` | {4} |' -f $r.Endpoint, $r.Location, $r.From, $r.To, $r.Version))
+        }
+    }
+    $mdLines.Add('')
+
+    $mdLines.Add('### Response envelope fields not read by `Invoke-PfbApiRequest`')
+    $mdLines.Add('')
+    $mdLines.Add('_Informational coverage observation, not a correctness claim -- many envelope keys legitimately need no handling there. It cannot tell whether a field is handled correctly, only whether it is referenced at all._')
+    $mdLines.Add('')
+    if (@($responseFindings.UnhandledEnvelopeFields).Count -eq 0) {
+        $mdLines.Add('_None._')
+    }
+    else {
+        $mdLines.Add('| Envelope field | Endpoints declaring it |')
+        $mdLines.Add('|---|---|')
+        foreach ($r in $responseFindings.UnhandledEnvelopeFields) {
+            $mdLines.Add(('| `{0}` | {1} |' -f $r.Field, $r.EndpointCount))
+        }
+    }
 }
 
 if ($uncoveredEndpoints.Count -gt 0) {

--- a/tools/Build-PfbResponseShapeMap.ps1
+++ b/tools/Build-PfbResponseShapeMap.ps1
@@ -9,8 +9,8 @@
 
     THIS ARTIFACT HAS NO RUNTIME CONSUMER BY DESIGN. It is deliberately a separate file
     from Data/PfbCapabilityMap.json, which Private/Get-PfbCapabilityMap.ps1 lazily loads and
-    caches into every user session: merging this axis in would cost +35% on every module
-    import for data no runtime code reads. Nothing may gate an API call on response data --
+    caches into every user session: merging this axis in would add 242,917 bytes to a
+    298,841-byte file -- +81% on every module import -- for data no runtime code reads. Nothing may gate an API call on response data --
     Assert-PfbApiCapability guards request construction only, and a missing response field
     is never a reason to refuse a call.
 

--- a/tools/Build-PfbResponseShapeMap.ps1
+++ b/tools/Build-PfbResponseShapeMap.ps1
@@ -1,0 +1,165 @@
+<#
+.SYNOPSIS
+    Builds Data/PfbResponseShapeMap.json -- the response-side counterpart to
+    Data/PfbCapabilityMap.json.
+.DESCRIPTION
+    For every endpoint with a 2xx JSON response, records the top-level envelope properties
+    and the items[] element properties one level deep, each with the version it was first
+    seen in, plus any that have since disappeared.
+
+    THIS ARTIFACT HAS NO RUNTIME CONSUMER BY DESIGN. It is deliberately a separate file
+    from Data/PfbCapabilityMap.json, which Private/Get-PfbCapabilityMap.ps1 lazily loads and
+    caches into every user session: merging this axis in would cost +35% on every module
+    import for data no runtime code reads. Nothing may gate an API call on response data --
+    Assert-PfbApiCapability guards request construction only, and a missing response field
+    is never a reason to refuse a call.
+
+    Monotonicity rule -- first-seen for introduction, last-seen for presence:
+      * responseEnvelope / responseItemProperties are {field: introducedVersion}, holding
+        only fields still present in the endpoint's lastSeenVersion.
+      * A field last seen before its endpoint's lastSeenVersion has been REMOVED and moves
+        to removedResponseFields.
+    This differs from readOnly's last-seen-wins because presence is what is tracked, not an
+    attribute whose value flips.
+.NOTES
+    Does NOT fetch specs. Run tools/Update-PfbApiSpecs.ps1 separately and deliberately.
+#>
+[CmdletBinding()]
+param(
+    [string]$SpecsDirectory,
+    [string]$OutputPath
+)
+
+# Deliberately NOT Set-StrictMode, matching tools/Build-PfbCapabilityMap.ps1. StrictMode is
+# dynamically scoped, so setting it here would leak into the dot-sourced PfbSpecTools
+# functions, which document (lib/PfbSpecTools.ps1:43) that they are intentionally
+# null-tolerant walkers over heterogeneous spec nodes -- under StrictMode a response with no
+# .content throws instead of being skipped, and real cached specs contain such responses.
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+if (-not $SpecsDirectory) { $SpecsDirectory = Join-Path $PSScriptRoot 'specs' }
+if (-not $OutputPath) { $OutputPath = Join-Path $repoRoot 'Data/PfbResponseShapeMap.json' }
+
+. (Join-Path $PSScriptRoot 'lib/PfbSpecTools.ps1')
+
+$specFiles = Get-ChildItem -Path $SpecsDirectory -Filter 'fb*.json' -ErrorAction SilentlyContinue
+if (-not $specFiles) {
+    throw "No cached specs found in '$SpecsDirectory'. Run Update-PfbApiSpecs.ps1 first."
+}
+
+# Numeric sort -- 'fb2.9' must precede 'fb2.10'. A string sort puts 2.9 above 2.27 and would
+# invert the whole accumulation, turning every newer field into a phantom removal.
+$specFiles = $specFiles | ForEach-Object {
+    if ($_.BaseName -match '^fb(\d+)\.(\d+)$') {
+        [PSCustomObject]@{ File = $_; Major = [int]$Matches[1]; Minor = [int]$Matches[2] }
+    }
+    else {
+        Write-Warning "Skipping unrecognized spec filename: $($_.Name)"
+        $null
+    }
+} | Where-Object { $_ } | Sort-Object Major, Minor
+
+# endpointKey -> record. Typed Dictionary, not a Hashtable: endpoint keys are safe, but the
+# per-field dictionaries below hold API field names, where a field named 'keys'/'count'/
+# 'values' would shadow real member access on a Hashtable.
+$endpoints = [System.Collections.Generic.Dictionary[string, object]]::new()
+$processedVersions = [System.Collections.Generic.List[string]]::new()
+
+foreach ($entry in $specFiles) {
+    $version = "$($entry.Major).$($entry.Minor)"
+    Write-Host "Processing $version ($($entry.File.Name))..." -ForegroundColor Cyan
+    $processedVersions.Add($version)
+
+    $spec = Get-Content -Path $entry.File.FullName -Raw | ConvertFrom-Json -Depth 64
+    # MaxDepth is left at the function's own default of 32 -- see its help. Do not pass 8.
+    $shapes = Get-PfbSpecResponseShapes -Spec $spec
+
+    foreach ($shape in $shapes) {
+        $epKey = "$($shape.Method) $($shape.Path)"
+
+        if (-not $endpoints.ContainsKey($epKey)) {
+            $endpoints[$epKey] = [PSCustomObject]@{
+                MinVersion      = $version
+                LastSeenVersion = $version
+                # field -> [PSCustomObject]@{ Introduced; LastSeen }
+                Envelope        = [System.Collections.Generic.Dictionary[string, object]]::new()
+                Items           = [System.Collections.Generic.Dictionary[string, object]]::new()
+            }
+        }
+
+        $record = $endpoints[$epKey]
+        $record.LastSeenVersion = $version
+
+        foreach ($pair in @(
+                @{ Names = $shape.EnvelopeProperties; Bag = $record.Envelope },
+                @{ Names = $shape.ItemProperties; Bag = $record.Items }
+            )) {
+            foreach ($name in $pair.Names) {
+                if ($pair.Bag.ContainsKey($name)) {
+                    $pair.Bag[$name].LastSeen = $version
+                }
+                else {
+                    $pair.Bag[$name] = [PSCustomObject]@{ Introduced = $version; LastSeen = $version }
+                }
+            }
+        }
+    }
+}
+
+$emitted = [ordered]@{}
+foreach ($epKey in ($endpoints.get_Keys() | Sort-Object)) {
+    $record = $endpoints[$epKey]
+
+    $present = [ordered]@{ envelope = [ordered]@{}; items = [ordered]@{} }
+    $removed = [System.Collections.Generic.List[object]]::new()
+
+    foreach ($locationPair in @(
+            @{ Location = 'envelope'; Bag = $record.Envelope },
+            @{ Location = 'items'; Bag = $record.Items }
+        )) {
+        foreach ($name in ($locationPair.Bag.get_Keys() | Sort-Object)) {
+            $field = $locationPair.Bag[$name]
+            if ($field.LastSeen -eq $record.LastSeenVersion) {
+                $present[$locationPair.Location][$name] = $field.Introduced
+            }
+            else {
+                $removed.Add([ordered]@{
+                        field             = $name
+                        location          = $locationPair.Location
+                        introducedVersion = $field.Introduced
+                        lastSeenVersion   = $field.LastSeen
+                    })
+            }
+        }
+    }
+
+    $endpointRecord = [ordered]@{
+        minVersion             = $record.MinVersion
+        lastSeenVersion        = $record.LastSeenVersion
+        responseEnvelope       = $present['envelope']
+        responseItemProperties = $present['items']
+    }
+
+    # Emitted only when non-empty: 11 removal records exist across the entire API surface,
+    # so ~500 empty arrays would be pure noise in a tracked artifact.
+    if ($removed.Count -gt 0) {
+        $endpointRecord.removedResponseFields = @($removed | Sort-Object { $_.location }, { $_.field })
+    }
+
+    $emitted[$epKey] = $endpointRecord
+}
+
+$manifest = [ordered]@{
+    schemaVersion = 1
+    generatedFrom = @($processedVersions)
+    endpoints     = $emitted
+}
+
+$outputDirectory = Split-Path -Parent $OutputPath
+if ($outputDirectory -and -not (Test-Path $outputDirectory)) {
+    New-Item -ItemType Directory -Path $outputDirectory -Force | Out-Null
+}
+
+$manifest | ConvertTo-Json -Depth 20 | Set-Content -Path $OutputPath -Encoding UTF8
+Write-Host "`nWrote $($emitted.Count) endpoints from $($processedVersions.Count) versions to $OutputPath"

--- a/tools/Build-PfbResponseShapeMap.ps1
+++ b/tools/Build-PfbResponseShapeMap.ps1
@@ -60,6 +60,14 @@ $specFiles = $specFiles | ForEach-Object {
     }
 } | Where-Object { $_ } | Sort-Object Major, Minor
 
+# Guard AGAIN on the parsed set, not just the glob. A directory whose fb*.json files all fail
+# the version regex clears the check above, and without this the run would go on to write a
+# well-formed artifact with an empty generatedFrom -- silently replacing the real
+# Data/PfbResponseShapeMap.json with an empty one.
+if (-not $specFiles) {
+    throw "No spec files in '$SpecsDirectory' have a parseable fb<major>.<minor>.json name. Run Update-PfbApiSpecs.ps1 first."
+}
+
 # endpointKey -> record. Typed Dictionary, not a Hashtable: endpoint keys are safe, but the
 # per-field dictionaries below hold API field names, where a field named 'keys'/'count'/
 # 'values' would shadow real member access on a Hashtable.
@@ -141,8 +149,13 @@ foreach ($epKey in ($endpoints.get_Keys() | Sort-Object)) {
         responseItemProperties = $present['items']
     }
 
-    # Emitted only when non-empty: 11 removal records exist across the entire API surface,
-    # so ~500 empty arrays would be pure noise in a tracked artifact.
+    # Emitted only when non-empty -- across all 496 endpoints just 7 removal records exist, so
+    # ~500 empty arrays would be pure noise in a tracked artifact. The count is 7 rather than
+    # the larger number a naive version-to-version diff reports because "removed" here means
+    # absent from the endpoint's own lastSeenVersion: a field that disappears for a single
+    # version and then returns is still present in the newest spec and is deliberately NOT
+    # counted. (Both known instances -- GET /active-directory at 2.12, GET /buckets/performance
+    # at 2.20 -- were spec-authoring errors corrected in the following release.)
     if ($removed.Count -gt 0) {
         $endpointRecord.removedResponseFields = @($removed | Sort-Object { $_.location }, { $_.field })
     }

--- a/tools/Build-PfbResponseShapeMap.ps1
+++ b/tools/Build-PfbResponseShapeMap.ps1
@@ -1,3 +1,4 @@
+#Requires -Version 7.0
 <#
 .SYNOPSIS
     Builds Data/PfbResponseShapeMap.json -- the response-side counterpart to
@@ -79,6 +80,11 @@ foreach ($entry in $specFiles) {
     Write-Host "Processing $version ($($entry.File.Name))..." -ForegroundColor Cyan
     $processedVersions.Add($version)
 
+    # This line is the sole reason for the #Requires -Version 7.0 above: ConvertFrom-Json
+    # only gained -Depth in PowerShell 6.2, so under Windows PowerShell 5.1 it fails with
+    # "A parameter cannot be found that matches parameter name 'Depth'". Matches the -Depth
+    # the other tools/Build-*.ps1 spec readers pass; keep the #Requires and this line
+    # together if either ever changes.
     $spec = Get-Content -Path $entry.File.FullName -Raw | ConvertFrom-Json -Depth 64
     # MaxDepth is left at the function's own default of 32 -- see its help. Do not pass 8.
     $shapes = Get-PfbSpecResponseShapes -Spec $spec

--- a/tools/README.md
+++ b/tools/README.md
@@ -118,7 +118,18 @@ Run in this order:
    ./tools/Build-PfbValueEnumMap.ps1
    ```
 
-5. **`Build-PfbApiDriftReport.ps1`** — the newest addition (see `Reports/README.md`): composes
+5. **`Build-PfbResponseShapeMap.ps1`** — builds `Data/PfbResponseShapeMap.json`, the
+   *response*-side counterpart to the capability map (see "Response-shape drift" below).
+   Loads the same cached specs and diffs each endpoint's response body across versions.
+   Must run **before** `Build-PfbApiDriftReport.ps1`, which reads the file it writes (and
+   which degrades to an explicit "Not analysed" banner, never a silent empty section, if
+   it is missing).
+
+   ```powershell
+   ./tools/Build-PfbResponseShapeMap.ps1
+   ```
+
+6. **`Build-PfbApiDriftReport.ps1`** — the newest addition (see `Reports/README.md`): composes
    the capability map, cmdlet inventory, and value-enum data above into one combined
    "what's changed that we haven't caught up to" report, covering uncovered endpoints, new
    parameters on endpoints we already call, drift on existing `ValidateSet`s, and new
@@ -395,6 +406,77 @@ Run in this order:
    Use resolved (endpoint, field) pairs (`Get-PfbSchemaPropertyDetails`'s own single resolving
    walker, decision 3) for any future metric here, never a raw annotation-site count.
 
+## Response-shape drift (`Build-PfbResponseShapeMap.ps1`)
+
+Everything above tracks the **request** side — which endpoints, query parameters, and
+request-body fields exist in which REST version. `Data/PfbResponseShapeMap.json` is the
+**response** side: for every endpoint (496 of them, across the 29 analysed REST versions
+2.0-2.28), the set of fields the spec says its response returns, each with the version it
+was first seen in and the version it was last seen in, plus each endpoint's own
+first/last-seen version. `Get-PfbResponseShapeFindings` (`tools/lib/PfbApiDriftTools.ps1`)
+turns that history into the drift report's response-side categories: field **removals**,
+**rename candidates** (a removal and an addition on the same endpoint in the same
+version), and unhandled envelope fields such as `errors`.
+
+**It is a separate file from `Data/PfbCapabilityMap.json`, deliberately, because it has no
+runtime consumer.** `Private/Get-PfbCapabilityMap.ps1` loads the 298,841-byte capability
+map into *every* user session; merging the response axis into it would add 242,917 bytes,
+**+81%**, to that load — paid by every user of the module, forever, to serve an analysis
+that only the drift report reads. And nothing may ever gate an API call on response data:
+the capability check runs *before* the HTTP call, so response shape is not information it
+could act on even in principle. The two artifacts answer different questions for different
+audiences, so they stay in different files.
+
+**The monotonicity rule.** Presence is tracked at both ends: `introducedVersion` is
+**first-seen** (once a field has appeared, the version it appeared in never changes), and
+presence is **last-seen** (the newest analysed version whose spec still declares it). A
+field is a **removal** when its last-seen version is older than its endpoint's own
+`lastSeenVersion` — i.e. the endpoint is still in the newest analysed spec, but the field
+is not. This is deliberately *not* the same rule as `readOnly`/`deprecated`, which are
+**last-seen-wins** (see item 2 above): `readOnly` is an attribute that flips back and forth
+and only its *current* value is meaningful, whereas presence is a monotonic timeline whose
+endpoints are both meaningful — when a field first appeared and whether it is still there.
+Applying last-seen-wins to presence would lose the introduction history; applying
+first-sight to `readOnly` would report a stale annotation as current.
+
+**Known blind spot: transient fields are not reported at all.** There are 11 field-removal
+*transition events* in the history but only **7** true removals. The other four are fields
+that vanish for exactly one release and come back, all caused by upstream spec-authoring
+defects, and all four are present again in fb2.28. The rule above — absent from the newest
+analysed version in which the endpoint still exists — correctly excludes them, at the cost
+of never surfacing a transient wobble as a finding. The two known cases:
+`GET /active-directory`'s `continuation_token` and `total_item_count` (broken in 2.12,
+fixed in 2.13 — the response schema dropped its `allOf` composition), and
+`GET /buckets/performance`'s `max_total_bytes_per_sec` and `max_total_ops_per_sec` (broken
+in 2.20, fixed in 2.21 — `items[]` `$ref`s the wrong sibling component). Accepted: a
+one-release wobble that the vendor has already fixed is not actionable for this module,
+and reporting it would put four known-false rows in front of every reader of the 7 real
+ones.
+
+**The depth trap — read this before changing any `MaxDepth`.** `Get-PfbSpecResponseShapes`
+(`tools/lib/PfbSpecTools.ps1`) defaults to **`MaxDepth 32`**, not the `8` used by the other
+walkers in that same file. This is not a stylistic inconsistency and must not be
+"normalised". fb2.12-2.16 contain deep `allOf` composition chains; at depth 8 those chains
+truncate, whole field sets go unseen in the middle of the history, and the presence
+accumulator then reports them as vanished — **184 false removals against a true total of
+7**. Worse, the failure is invisible from the newest spec: on fb2.28 every depth from 8 to
+32 produces identical results, so any check written against current data will look
+perfectly correct while the historical middle of the map is silently wrong. 184 removals is
+the depth-8 signature — if that number (or anything near it) ever appears, suspect the
+depth before suspecting the API.
+
+**Granularity: envelope plus `items[]`, one level deep.** Each endpoint records its
+top-level response envelope fields and the fields of one level of `items[]`. Depth 3 was
+measured and rejected: it produced 13 findings, of which 11 were duplicates of a level-1
+parent already reported and the remaining 2 were a spec-authoring false positive — zero new
+real signal, at **2.2x** the artifact size.
+
+**Why additions are not findings.** 508 of the module's 523 cmdlets emit
+`Invoke-PfbApiRequest`'s result directly, without reshaping it, so a field the API *adds*
+to a response reaches the caller automatically with no code change at all. There is nothing
+to fix and therefore nothing to report. Only removals (a property callers may already
+depend on that has gone away), renames, and unread envelope fields represent work.
+
 ## What's deliberately NOT in the capability map
 
 The FlashBlade OpenAPI spec has no structural JSON Schema `enum` anywhere — verified
@@ -567,3 +649,9 @@ all run as part of the same weekly/dispatch job, right after the capability map 
 so `Reports/PfbValueEnumMap.json`, `Reports/PfbFieldCmdletMap.json`, and
 `Reports/PfbApiDriftReport.json` (+ their Markdown companions) stay fresh alongside
 `Data/PfbCapabilityMap.json`.
+
+`Build-PfbResponseShapeMap.ps1` is **not** in that workflow yet, so a CI-generated drift
+report currently reuses the committed `Data/PfbResponseShapeMap.json` rather than
+regenerating it (and would emit the explicit "Not analysed" banner rather than a silent
+empty section if the file were ever absent). Adding it to the workflow — before the
+drift-report step, since the report reads its output — is a follow-on decision.

--- a/tools/README.md
+++ b/tools/README.md
@@ -412,11 +412,17 @@ Everything above tracks the **request** side — which endpoints, query paramete
 request-body fields exist in which REST version. `Data/PfbResponseShapeMap.json` is the
 **response** side: for every endpoint (496 of them, across the 29 analysed REST versions
 2.0-2.28), the set of fields the spec says its response returns, each with the version it
-was first seen in and the version it was last seen in, plus each endpoint's own
-first/last-seen version. `Get-PfbResponseShapeFindings` (`tools/lib/PfbApiDriftTools.ps1`)
-turns that history into the drift report's response-side categories: field **removals**,
-**rename candidates** (a removal and an addition on the same endpoint in the same
-version), and unhandled envelope fields such as `errors`.
+was first seen in — plus, for fields that have since disappeared, the version they were
+last seen in — and each endpoint's own first/last-seen version. (Present fields carry a
+scalar `introducedVersion` only: `responseEnvelope`/`responseItemProperties` are
+`{field: version}`, and their last-seen version is implicitly the endpoint's own
+`lastSeenVersion`. An explicit `lastSeenVersion` appears only on `removedResponseFields`
+entries.) `Get-PfbResponseShapeFindings` (`tools/lib/PfbApiDriftTools.ps1`) turns that
+history into the drift report's response-side categories: field **removals**, **rename
+candidates** (a removal paired with a still-present field on the same endpoint and in the
+same location that first appears in the version *immediately after* the removed field's
+last-seen version — adjacency, not co-occurrence, and reported as a candidate rather than
+asserted), and unhandled envelope fields such as `errors`.
 
 **It is a separate file from `Data/PfbCapabilityMap.json`, deliberately, because it has no
 runtime consumer.** `Private/Get-PfbCapabilityMap.ps1` loads the 298,841-byte capability
@@ -448,7 +454,10 @@ of never surfacing a transient wobble as a finding. The two known cases:
 `GET /active-directory`'s `continuation_token` and `total_item_count` (broken in 2.12,
 fixed in 2.13 — the response schema dropped its `allOf` composition), and
 `GET /buckets/performance`'s `max_total_bytes_per_sec` and `max_total_ops_per_sec` (broken
-in 2.20, fixed in 2.21 — `items[]` `$ref`s the wrong sibling component). Accepted: a
+in 2.20, fixed in 2.21 — fb2.20 drops the `BucketPerformanceItems` component from the
+document **entirely** (it is defined in both 2.19 and 2.21) and repoints the response's
+`items[]` at the sibling `BucketPerformance` component, which has never carried those two
+fields; this is a dropped component, not a mistyped `$ref`). Accepted: a
 one-release wobble that the vendor has already fixed is not actionable for this module,
 and reporting it would put four known-false rows in front of every reader of the 7 real
 ones.
@@ -471,9 +480,21 @@ measured and rejected: it produced 13 findings, of which 11 were duplicates of a
 parent already reported and the remaining 2 were a spec-authoring false positive — zero new
 real signal, at **2.2x** the artifact size.
 
-**Why additions are not findings.** 508 of the module's 523 cmdlets emit
-`Invoke-PfbApiRequest`'s result directly, without reshaping it, so a field the API *adds*
-to a response reaches the caller automatically with no code change at all. There is nothing
+**Why additions are not findings.** The module reshapes almost nothing on the way out.
+Measured over `Public/` on 2026-08-01 (542 `.ps1` files, one function each): **533 call
+`Invoke-PfbApiRequest` at all** — the 9 that never do are session/credential helpers
+(`Connect-PfbArray`, `Disconnect-PfbArray`, `Get-PfbConnection`, `Get-PfbApiVersion`, the
+three `*-PfbCredential` cmdlets) plus two cmdlets that deliberately bypass
+`Invoke-PfbApiRequest` and issue their REST call directly, because its `-Method`
+`ValidateSet`/hashtable-only `-Body` cannot express what they need
+(`Set-PfbPresetWorkload`, `Set-PfbWorkloadTag`) — and in
+**526 of those 533, every one of those calls is a statement-level pipeline whose result is
+emitted directly**, never captured into a variable or piped onward. (Only 7 capture or
+post-process it, e.g. `Test-PfbConnection`, `Remove-PfbFileSystem`, `Get-PfbQuotaUser`.)
+State the counting rule whenever you quote these: "calls it at all" and "emits its result
+directly" are different questions with different answers, and an unqualified figure is what
+made an earlier version of this paragraph wrong. Consequently a field the API *adds* to a
+response reaches the caller automatically with no code change at all. There is nothing
 to fix and therefore nothing to report. Only removals (a property callers may already
 depend on that has gone away), renames, and unread envelope fields represent work.
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -437,9 +437,14 @@ audiences, so they stay in different files.
 **first-seen** (once a field has appeared, the version it appeared in never changes), and
 presence is **last-seen** (the newest analysed version whose spec still declares it). A
 field is a **removal** when its last-seen version is older than its endpoint's own
-`lastSeenVersion` — i.e. the endpoint is still in the newest analysed spec, but the field
-is not. This is deliberately *not* the same rule as `readOnly`/`deprecated`, which are
-**last-seen-wins** (see item 2 above): `readOnly` is an attribute that flips back and forth
+`lastSeenVersion` — i.e. the field is absent from the newest analysed spec *in which its
+endpoint still appears*. Note the comparison is against the endpoint's **own** last-seen
+version, which is not necessarily the newest analysed version overall: a retired endpoint,
+last seen at some older version, would still have its own field removals reported. Today
+that distinction is invisible — all 496 endpoints have `lastSeenVersion` 2.28, so the two
+coincide — but it is the rule as implemented, and "the endpoint is still in the newest
+analysed spec" is not part of it. This is deliberately *not* the same rule as
+`readOnly`/`deprecated`, which are **last-seen-wins** (see item 2 above): `readOnly` is an attribute that flips back and forth
 and only its *current* value is meaningful, whereas presence is a monotonic timeline whose
 endpoints are both meaningful — when a field first appeared and whether it is still there.
 Applying last-seen-wins to presence would lose the introduction history; applying

--- a/tools/README.md
+++ b/tools/README.md
@@ -665,14 +665,22 @@ pull requests. The `SSOT_API_KEY`/`SSOT_BASE_URI`/`SSOT_TOPIC_ID` secrets are op
 when any are absent, the version-map step is skipped gracefully and only the capability
 map updates (see item 3 above).
 
-`Build-PfbValueEnumMap.ps1`, `Build-PfbFieldCmdletMap.ps1`, and `Build-PfbApiDriftReport.ps1`
-all run as part of the same weekly/dispatch job, right after the capability map is rebuilt,
-so `Reports/PfbValueEnumMap.json`, `Reports/PfbFieldCmdletMap.json`, and
-`Reports/PfbApiDriftReport.json` (+ their Markdown companions) stay fresh alongside
+`Build-PfbValueEnumMap.ps1`, `Build-PfbFieldCmdletMap.ps1`, `Build-PfbResponseShapeMap.ps1`,
+and `Build-PfbApiDriftReport.ps1` all run as part of the same weekly/dispatch job, right
+after the capability map is rebuilt, so `Reports/PfbValueEnumMap.json`,
+`Reports/PfbFieldCmdletMap.json`, `Reports/PfbApiDriftReport.json` (+ their Markdown
+companions) and `Data/PfbResponseShapeMap.json` stay fresh alongside
 `Data/PfbCapabilityMap.json`.
 
-`Build-PfbResponseShapeMap.ps1` is **not** in that workflow yet, so a CI-generated drift
-report currently reuses the committed `Data/PfbResponseShapeMap.json` rather than
-regenerating it (and would emit the explicit "Not analysed" banner rather than a silent
-empty section if the file were ever absent). Adding it to the workflow — before the
-drift-report step, since the report reads its output — is a follow-on decision.
+`Build-PfbResponseShapeMap.ps1` sits between `Build-PfbFieldCmdletMap.ps1` and
+`Build-PfbApiDriftReport.ps1`, and that position is required in both directions. It must
+come **after** the spec-fetch step, because the generator only walks `tools/specs/` and
+never fetches anything itself — run before the fetch, it would build the map from whatever
+the restored cache happened to hold. It must come **before** the drift-report step, because
+the report reads `Data/PfbResponseShapeMap.json`; run after, CI would emit a report derived
+from the stale committed map and then overwrite that map, leaving a report and a map that
+disagree with no error to signal it. (If the file were ever absent entirely the report emits
+an explicit "Not analysed" banner rather than a silently empty section, so a missing map is
+at least visible — but a *stale* one is not, which is why the ordering rather than the
+presence check is what protects the report.) The drift report's three response-shape counts
+are also surfaced in the workflow's PR body via the `drift_summary` output.

--- a/tools/lib/PfbApiDriftTools.ps1
+++ b/tools/lib/PfbApiDriftTools.ps1
@@ -1423,3 +1423,124 @@ function Get-PfbNonActionableParameters {
 
     return @($script:PfbNonActionableParameters + $derivedNames | Select-Object -Unique | Sort-Object)
 }
+
+function Get-PfbResponseShapeFindings {
+    <#
+    .SYNOPSIS
+        Derives response-side drift findings from Data/PfbResponseShapeMap.json.
+    .DESCRIPTION
+        Three categories, deliberately asymmetric with the request side:
+
+          Removals -- a response field that existed in some analysed version and is absent
+            from the newest analysed version in which its endpoint still exists. This is the
+            genuinely dangerous case and the one thing this axis catches that nothing else
+            can: cmdlets pass responses through raw (508 of 523 emit Invoke-PfbApiRequest
+            directly, with no projection anywhere), so the module holds no schema of its own
+            and a user script binding a removed field silently receives $null.
+
+          RenameCandidates -- a removal and a still-present field on the same endpoint and
+            in the same location, where the new field appears in the version immediately
+            after the old one vanished. Reported as a CANDIDATE and never asserted: adjacency
+            is suggestive, not proof.
+
+          UnhandledEnvelopeFields -- envelope field names no `$response.<name>` reference in
+            Private/Invoke-PfbApiRequest.ps1 ever reads. Informational: many envelope keys
+            legitimately need no handling in that function. This is a COVERAGE observation,
+            not a correctness claim -- it cannot tell whether a field is handled correctly,
+            only whether it is mentioned at all.
+
+        ADDITIONS ARE DELIBERATELY NOT A FINDING. Because responses pass through raw, a new
+        response field reaches the caller with no module change required, so an "added field"
+        row would be pure noise. This inverts the request side's emphasis, and the inversion
+        is the point.
+    .OUTPUTS
+        [PSCustomObject]@{ Removals; RenameCandidates; UnhandledEnvelopeFields }
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        $ResponseShapeMap,
+
+        [string]$RequestHandlerPath
+    )
+
+    $removals = [System.Collections.Generic.List[object]]::new()
+    $renameCandidates = [System.Collections.Generic.List[object]]::new()
+    $envelopeEndpointCounts = [System.Collections.Generic.Dictionary[string, int]]::new()
+
+    $orderedVersions = @($ResponseShapeMap.generatedFrom)
+
+    function Get-NextVersion {
+        param([string]$Version, [string[]]$Ordered)
+        $index = [Array]::IndexOf($Ordered, $Version)
+        if ($index -lt 0 -or $index -ge ($Ordered.Count - 1)) { return $null }
+        return $Ordered[$index + 1]
+    }
+
+    $endpointNames = @($ResponseShapeMap.endpoints.PSObject.Properties.Name | Sort-Object)
+
+    foreach ($epKey in $endpointNames) {
+        $endpoint = $ResponseShapeMap.endpoints.$epKey
+
+        foreach ($name in @($endpoint.responseEnvelope.PSObject.Properties.Name)) {
+            if (-not $envelopeEndpointCounts.ContainsKey($name)) { $envelopeEndpointCounts[$name] = 0 }
+            $envelopeEndpointCounts[$name]++
+        }
+
+        if ($endpoint.PSObject.Properties.Name -notcontains 'removedResponseFields') { continue }
+
+        foreach ($removed in @($endpoint.removedResponseFields)) {
+            $removals.Add([PSCustomObject]@{
+                    Endpoint          = $epKey
+                    Field             = $removed.field
+                    Location          = $removed.location
+                    IntroducedVersion = $removed.introducedVersion
+                    LastSeenVersion   = $removed.lastSeenVersion
+                })
+
+            $successorVersion = Get-NextVersion -Version $removed.lastSeenVersion -Ordered $orderedVersions
+            if (-not $successorVersion) { continue }
+
+            $bag = if ($removed.location -eq 'envelope') {
+                $endpoint.responseEnvelope
+            }
+            else {
+                $endpoint.responseItemProperties
+            }
+
+            foreach ($candidateName in @($bag.PSObject.Properties.Name | Sort-Object)) {
+                if ($bag.$candidateName -ne $successorVersion) { continue }
+                $renameCandidates.Add([PSCustomObject]@{
+                        Endpoint = $epKey
+                        Location = $removed.location
+                        From     = $removed.field
+                        To       = $candidateName
+                        Version  = $successorVersion
+                    })
+            }
+        }
+    }
+
+    $unhandled = [System.Collections.Generic.List[object]]::new()
+    if ($RequestHandlerPath -and (Test-Path $RequestHandlerPath)) {
+        $handlerText = Get-Content -Path $RequestHandlerPath -Raw
+        $referenced = [System.Collections.Generic.HashSet[string]]::new()
+        foreach ($m in [regex]::Matches($handlerText, '\$response\.([A-Za-z_][A-Za-z0-9_]*)')) {
+            [void]$referenced.Add($m.Groups[1].Value)
+        }
+
+        foreach ($name in ($envelopeEndpointCounts.get_Keys() | Sort-Object)) {
+            if ($referenced.Contains($name)) { continue }
+            $unhandled.Add([PSCustomObject]@{
+                    Field         = $name
+                    EndpointCount = $envelopeEndpointCounts[$name]
+                })
+        }
+    }
+
+    return [PSCustomObject]@{
+        Removals                = @($removals | Sort-Object Endpoint, Location, Field)
+        RenameCandidates        = @($renameCandidates | Sort-Object Endpoint, Location, From)
+        UnhandledEnvelopeFields = @($unhandled | Sort-Object { -$_.EndpointCount }, { $_.Field })
+    }
+}

--- a/tools/lib/PfbApiDriftTools.ps1
+++ b/tools/lib/PfbApiDriftTools.ps1
@@ -1434,8 +1434,10 @@ function Get-PfbResponseShapeFindings {
           Removals -- a response field that existed in some analysed version and is absent
             from the newest analysed version in which its endpoint still exists. This is the
             genuinely dangerous case and the one thing this axis catches that nothing else
-            can: cmdlets pass responses through raw (508 of 523 emit Invoke-PfbApiRequest
-            directly, with no projection anywhere), so the module holds no schema of its own
+            can: cmdlets pass responses through raw (measured 2026-08-01 over Public/'s 542
+            functions -- 533 call Invoke-PfbApiRequest at all, and in 526 of those every call
+            is a statement-level pipeline whose result is emitted directly, never captured or
+            projected), so the module holds no schema of its own
             and a user script binding a removed field silently receives $null.
 
           RenameCandidates -- a removal and a still-present field on the same endpoint and

--- a/tools/lib/PfbApiDriftTools.ps1
+++ b/tools/lib/PfbApiDriftTools.ps1
@@ -1482,7 +1482,7 @@ function Get-PfbResponseShapeFindings {
     foreach ($epKey in $endpointNames) {
         $endpoint = $ResponseShapeMap.endpoints.$epKey
 
-        foreach ($name in @($endpoint.responseEnvelope.PSObject.Properties.Name)) {
+        foreach ($name in @($endpoint.responseEnvelope.PSObject.Properties | ForEach-Object { $_.Name })) {
             if (-not $envelopeEndpointCounts.ContainsKey($name)) { $envelopeEndpointCounts[$name] = 0 }
             $envelopeEndpointCounts[$name]++
         }
@@ -1508,7 +1508,7 @@ function Get-PfbResponseShapeFindings {
                 $endpoint.responseItemProperties
             }
 
-            foreach ($candidateName in @($bag.PSObject.Properties.Name | Sort-Object)) {
+            foreach ($candidateName in @($bag.PSObject.Properties | ForEach-Object { $_.Name } | Sort-Object)) {
                 if ($bag.$candidateName -ne $successorVersion) { continue }
                 $renameCandidates.Add([PSCustomObject]@{
                         Endpoint = $epKey

--- a/tools/lib/PfbSpecTools.ps1
+++ b/tools/lib/PfbSpecTools.ps1
@@ -653,6 +653,126 @@ function Get-PfbSpecCapabilities {
     return $results
 }
 
+function Get-PfbResponseSchema {
+    <#
+    .SYNOPSIS
+        Returns the schema node of an operation's first 2xx response that carries a JSON
+        media type, or $null if it has none.
+    .DESCRIPTION
+        Response codes are examined in ascending string order ('200' before '204'), so a
+        200 wins over a 201/204 when an operation declares several. 'application/json' is
+        preferred; if absent, the first declared media type is used, matching the request-side
+        behaviour in Get-PfbSpecCapabilities.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [AllowNull()]
+        $Operation,
+
+        [Parameter(Mandatory)]
+        $Spec
+    )
+
+    if ($null -eq $Operation -or -not $Operation.responses) { return $null }
+
+    $codes = @($Operation.responses.PSObject.Properties.Name |
+            Where-Object { $_ -match '^2\d\d$' } | Sort-Object)
+
+    foreach ($code in $codes) {
+        $response = Resolve-PfbRef -Node $Operation.responses.$code -Spec $Spec
+        if ($null -eq $response -or -not $response.content) { continue }
+
+        $mediaTypes = $response.content.PSObject.Properties.Name
+        $mediaKey = if ($mediaTypes -contains 'application/json') {
+            'application/json'
+        }
+        else {
+            $mediaTypes | Select-Object -First 1
+        }
+        if (-not $mediaKey) { continue }
+
+        if ($response.content.$mediaKey.schema) { return $response.content.$mediaKey.schema }
+    }
+
+    return $null
+}
+
+function Get-PfbSpecResponseShapes {
+    <#
+    .SYNOPSIS
+        Flattens a FlashBlade OpenAPI document into one response-shape record per
+        (HTTP method, normalized path): the 2xx envelope's top-level property names, and the
+        property names of the items[] array's element schema one level deep.
+    .DESCRIPTION
+        Granularity is deliberately TWO levels and no more -- the envelope, and items[]
+        element properties. Depth 3 was measured and rejected: of 13 depth-3 disappearances
+        across all 29 cached specs, 11 are children of a parent already caught at level 1
+        (duplicates needing rollup suppression) and the other 2 are a confirmed spec-authoring
+        false positive (items[].local_snapshot.resource_type, dropped from the inline schema
+        text at fb2.11, not from the API). It costs 2.2x the artifact for zero true findings.
+        See docs/superpowers/specs/2026-08-01-response-shape-drift-design.md.
+
+        MaxDepth defaults to 32, NOT to the 8 used elsewhere in this file. This is
+        load-bearing, not incidental: several fb2.12-2.16 schemas nest allOf more deeply
+        than 8, and reading them truncated makes real fields look absent -- which an
+        accumulator across versions then records as a REMOVAL. Measured: 184 false removals
+        at depth 8 versus a true total of 11 at depth 32. Do not "simplify" this to match
+        the other defaults in this file.
+
+        Reuses Get-PfbSchemaPropertyWalkAccumulators (and therefore
+        Add-PfbSchemaPropertyNodes) rather than introducing a second allOf/$ref walker --
+        one walker, per the toolchain's standing decision.
+    .OUTPUTS
+        [PSCustomObject]@{ Method; Path; EnvelopeProperties = string[]; ItemProperties = string[] }
+        Both collections are sorted for deterministic output.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        $Spec,
+
+        [int]$MaxDepth = 32
+    )
+
+    $results = [System.Collections.Generic.List[object]]::new()
+    if (-not $Spec.paths) { return $results }
+
+    foreach ($rawPath in $Spec.paths.PSObject.Properties.Name) {
+        $pathItem = $Spec.paths.$rawPath
+        $normalizedPath = ConvertTo-PfbNormalizedPath -Path $rawPath
+
+        foreach ($methodName in $pathItem.PSObject.Properties.Name) {
+            if ($script:PfbHttpMethods -notcontains $methodName) { continue }
+
+            $schema = Get-PfbResponseSchema -Operation $pathItem.$methodName -Spec $Spec
+            if ($null -eq $schema) { continue }
+
+            $envelopeProperties = @(Get-PfbSchemaPropertyNames -Schema $schema -Spec $Spec -MaxDepth $MaxDepth)
+
+            # Reach items[]'s element schema through the SAME walk, so an envelope that
+            # declares items behind an allOf/$ref chain is handled identically to an inline one.
+            $itemProperties = @()
+            $walk = Get-PfbSchemaPropertyWalkAccumulators -Schema $schema -Spec $Spec -MaxDepth $MaxDepth
+            if ($walk.PropertyNodesByName.ContainsKey('items')) {
+                $itemsResolved = Resolve-PfbRef -Node $walk.PropertyNodesByName['items'][0] -Spec $Spec
+                if ($null -ne $itemsResolved -and $itemsResolved.type -eq 'array' -and $itemsResolved.items) {
+                    $itemProperties = @(Get-PfbSchemaPropertyNames -Schema $itemsResolved.items -Spec $Spec -MaxDepth $MaxDepth)
+                }
+            }
+
+            $results.Add([PSCustomObject]@{
+                    Method             = $methodName.ToUpper()
+                    Path               = $normalizedPath
+                    EnvelopeProperties = @($envelopeProperties | Sort-Object)
+                    ItemProperties     = @($itemProperties | Sort-Object)
+                })
+        }
+    }
+
+    return $results
+}
+
 function Get-PfbSwaggerIndexVersions {
     <#
     .SYNOPSIS

--- a/tools/lib/PfbSpecTools.ps1
+++ b/tools/lib/PfbSpecTools.ps1
@@ -717,8 +717,11 @@ function Get-PfbSpecResponseShapes {
         load-bearing, not incidental: several fb2.12-2.16 schemas nest allOf more deeply
         than 8, and reading them truncated makes real fields look absent -- which an
         accumulator across versions then records as a REMOVAL. Measured: 184 false removals
-        at depth 8 versus a true total of 11 at depth 32. Do not "simplify" this to match
-        the other defaults in this file.
+        at depth 8 versus a true total of 7 at depth 32. (7, not 11: there are 11 removal
+        TRANSITION EVENTS in the history, but four of them are fields that vanish for one
+        release and return, so they are present in their endpoint's newest analysed version
+        and are correctly not removals. See tools/README.md, "Known blind spot: transient
+        fields".) Do not "simplify" this to match the other defaults in this file.
 
         Reuses Get-PfbSchemaPropertyWalkAccumulators (and therefore
         Add-PfbSchemaPropertyNodes) rather than introducing a second allOf/$ref walker --


### PR DESCRIPTION
## What this adds

The maintainer toolchain only ever analysed the **request** side of the FlashBlade REST API — which parameters and body fields cmdlets fail to expose. A response field being removed or renamed produced no finding at all; it just silently broke user scripts that read it.

This adds a **response-shape drift axis** covering that gap:

```
tools/lib/PfbSpecTools.ps1          extract response envelope + items[] shapes from cached specs
tools/Build-PfbResponseShapeMap.ps1 build Data/PfbResponseShapeMap.json across all 29 spec versions
tools/lib/PfbApiDriftTools.ps1      derive removals, rename candidates, unhandled envelope fields
tools/Build-PfbApiDriftReport.ps1   emit them into the drift report (JSON + Markdown)
.github/workflows/…                 regenerate the map weekly, in the right step order
```

Current findings on the real spec history: **7 removed response fields**, **3 rename candidates**, **11 unhandled envelope fields**.

The last of those closes the loop on the `$response.errors` gap — 140 endpoints have carried an `errors` envelope field since 2.17 that `Invoke-PfbApiRequest` never reads. This branch only makes that **visible**; fixing it belongs elsewhere.

## Design decisions worth knowing

**The map is deliberately NOT merged into `Data/PfbCapabilityMap.json`.** It has no runtime consumer, and merging would add 242,917 bytes (**+81%**) to a file `Private/Get-PfbCapabilityMap.ps1` loads into every user session. Nothing may gate an API call on response data — `Assert-PfbApiCapability` guards request construction only, and a missing response field is never a reason to refuse a call.

**Monotonicity rule: first-seen for introduction, last-seen for presence.** A field last seen before its endpoint's own `lastSeenVersion` has been removed. This deliberately differs from `readOnly`'s last-seen-wins, because what's tracked here is *presence*, not an attribute whose value flips.

**Additions are not findings.** Responses pass through raw (526 of 542 `Public/` functions emit `Invoke-PfbApiRequest`'s result directly), so new response fields surface to users automatically. Only disappearances need reporting.

**Granularity is envelope + `items[]` one level deep.** Depth 3 was measured and rejected: 11 of 13 extra findings were duplicates of level-1 parents, the remaining 2 were a spec-authoring false positive, at 2.2× the artifact size.

**`MaxDepth 32`, not the `8` used elsewhere in `PfbSpecTools.ps1`.** This is load-bearing. At depth 8, fb2.12–2.16's deep `allOf` chains truncate and the accumulator fabricates **184 false removals** against a true 7. It is invisible on the newest spec — every depth from 8 to 32 gives identical results there — so a check against current data looks correct. Documented prominently in `tools/README.md`.

**7 currently-absent removals vs 11 transition events** is an accepted, documented blind spot. The 4-field gap is blip-and-return caused by upstream spec-authoring defects: fb2.12 drops an `allOf`; fb2.20 drops the `BucketPerformanceItems` component from the document entirely (0 mentions, verified against 2.19/2.20/2.21).

**Workflow step order is load-bearing.** The generator runs after the spec fetch (it walks `tools/specs/` and does not fetch) and before the drift report (which consumes its output). In any other position CI would build the report against a stale map and then overwrite it — producing a report and map that disagree, with no error. The constraint is recorded in a comment beside the step.

## Verification

- **Determinism:** all three artifacts — `Data/PfbResponseShapeMap.json`, `Reports/PfbApiDriftReport.json`, `Reports/PfbApiDriftReport.md` — regenerate **byte-identically** (SHA256-confirmed) from the 29 on-disk specs. This matters because the weekly job opens a PR on any diff, so non-determinism means spurious PRs forever.
- **No request-side regression:** 0 request-side fields lost vs `origin/main`; uncovered endpoints identical at 98/98.
- **Scoped Pester, PowerShell 7.6.4:** `PfbSpecTools` 49/0, `Build-PfbResponseShapeMap` 9/0, `PfbApiDriftTools` 114/0, `Build-PfbApiDriftReport` 65/0, `Build-PfbCapabilityMap` 39/0, `Get-PfbCapabilityMap` 3/0.
- **Scoped Pester, Windows PowerShell 5.1:** zero container failures — PS7-only work correctly skips, the rest passes (43/0 and 106/0).
- **Mutation-tested**, not just green. Confirmed killed: `MaxDepth` 32→8; removing both output `Sort-Object` calls; the removal rule's version comparison; rename pairing adjacency→co-occurrence; dropping and inventing removal records.

### Live-array testing: not applicable — and this is derived, not assumed

No `Public/` or `Private/` file is modified (`git diff --stat origin/main -- Public Private` is empty), and `Data/PfbResponseShapeMap.json` has no runtime loader — `Private/Get-PfbCapabilityMap.ps1` reads only `PfbCapabilityMap.json`, which this branch does not touch. Keeping the two maps separate is exactly what makes this exemption genuine; had the axis been merged into the capability map, live verification **would** have been mandatory. The equivalent evidence is the real-spec generator runs plus the determinism and no-regression checks above.

## Review history

Six tasks, each independently reviewed, then a whole-branch review that returned CHANGES REQUESTED and caught two things the per-task reviews structurally could not:

- **CI was red on Windows PowerShell 5.1**, two ways. Every scoped test run during development was PowerShell 7, so nobody saw it. A new `Describe` was missing the `-Skip:` guard its siblings carry, which dragged the file's top-level `BeforeAll` into running a `#Requires -Version 7.0` script and killed the entire container (0 passed / 64 failed). Separately, the new generator uses `ConvertFrom-Json -Depth` (PS 6.2+) but lacked a `#Requires` line.
- **A hardcoded test count would have frozen the pipeline on the axis's first real success.** `Should -Be 7` was harmless as an artifact check — until the generator was wired into CI, where the map is regenerated from freshly-fetched specs *before* the test step runs. A genuine 8th removal would have failed the suite, so the PR steps would never run and every map and report would silently stop updating. Now derived from the committed map instead, and re-proven by mutation to still catch a report that drops or invents a record while correctly tolerating a real new removal.

## Not included, deliberately

No version bump and no CHANGELOG entry — those are maintainer decisions.

One pre-existing observation, not introduced here and not touched: the top-10 aggregation ratio now reads 54.59% against an existing `-BeLessThan 0.55` assertion. Adjusting that threshold would mean this branch silently absorbing an unrelated problem, so it's flagged rather than fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
