### PR TITLE
fix(presets): support PUT in Invoke-PfbApiRequest and fold Set-PfbPresetWorkload onto it

### DIFF
--- a/Private/Invoke-PfbApiRequest.ps1
+++ b/Private/Invoke-PfbApiRequest.ps1
@@ -13,7 +13,7 @@ function Invoke-PfbApiRequest {
         [PSCustomObject]$Array,
 
         [Parameter(Mandatory)]
-        [ValidateSet('GET', 'POST', 'PATCH', 'DELETE')]
+        [ValidateSet('GET', 'POST', 'PATCH', 'PUT', 'DELETE')]
         [string]$Method,
 
         [Parameter(Mandatory)]
@@ -97,7 +97,9 @@ function Invoke-PfbApiRequest {
         Headers = $headers
     }
 
-    if ($Body -and ($Method -eq 'POST' -or $Method -eq 'PATCH')) {
+    # GET/DELETE never carry a body: the guard is a whitelist, not a "not GET" test, so a new
+    # verb has to be added here deliberately rather than inheriting body serialisation.
+    if ($Body -and ($Method -eq 'POST' -or $Method -eq 'PATCH' -or $Method -eq 'PUT')) {
         $restParams['Body'] = ($Body | ConvertTo-Json -Depth 10 -Compress)
     }
 

--- a/Public/Presets/Set-PfbPresetWorkload.ps1
+++ b/Public/Presets/Set-PfbPresetWorkload.ps1
@@ -44,16 +44,7 @@ function Set-PfbPresetWorkload {
 
     $target = if ($Name) { $Name } else { $Id }
     if ($PSCmdlet.ShouldProcess($target, 'Replace workload preset (PUT)')) {
-        # PUT not supported by Invoke-PfbApiRequest's ValidateSet — call directly.
-        $apiVer = $Array.ApiVersion
-        $qs = ConvertTo-PfbQueryString -Parameters $queryParams
-        $uri = "https://$($Array.Endpoint)/api/${apiVer}/presets/workload${qs}"
-        $headers = @{ 'Content-Type' = 'application/json'; 'x-auth-token' = $Array.AuthToken }
-        $restParams = @{ Method = 'PUT'; Uri = $uri; Headers = $headers; Body = ($Attributes | ConvertTo-Json -Depth 15) }
-        if ($Array.SkipCertificateCheck -and $PSVersionTable.PSVersion.Major -ge 6) {
-            $restParams['SkipCertificateCheck'] = $true
-        }
-        Write-Verbose "FlashBlade API: PUT $uri"
-        Invoke-RestMethod @restParams
+        Invoke-PfbApiRequest -Array $Array -Method PUT -Endpoint 'presets/workload' `
+            -Body $Attributes -QueryParams $queryParams
     }
 }

--- a/Tests/Invoke-PfbApiRequest.Tests.ps1
+++ b/Tests/Invoke-PfbApiRequest.Tests.ps1
@@ -64,6 +64,79 @@ Describe 'Invoke-PfbApiRequest - HttpTimeoutMs is applied' {
     }
 }
 
+Describe 'Invoke-PfbApiRequest - PUT support' {
+    It 'sends Method PUT with a serialised JSON body' {
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
+            [PSCustomObject]@{ items = @() }
+        } -ParameterFilter { $Uri -like '*presets/workload*' }
+
+        InModuleScope PureStorageFlashBladePowerShell {
+            $array = [PSCustomObject]@{
+                Endpoint = 'fb.test'; ApiVersion = '2.26'; AuthToken = 'tok'
+                ApiToken = $null; AuthMethod = 'ApiToken'; SkipCertificateCheck = $false
+            }
+            Invoke-PfbApiRequest -Array $array -Method PUT -Endpoint 'presets/workload' -Body @{ name = 'p1' } | Out-Null
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'PUT' -and $Body -eq '{"name":"p1"}'
+        }
+    }
+
+    It 'sends no Body key on a PUT with no -Body' {
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
+            [PSCustomObject]@{ items = @() }
+        } -ParameterFilter { $Uri -like '*presets/workload*' }
+
+        InModuleScope PureStorageFlashBladePowerShell {
+            $array = [PSCustomObject]@{
+                Endpoint = 'fb.test'; ApiVersion = '2.26'; AuthToken = 'tok'
+                ApiToken = $null; AuthMethod = 'ApiToken'; SkipCertificateCheck = $false
+            }
+            Invoke-PfbApiRequest -Array $array -Method PUT -Endpoint 'presets/workload' | Out-Null
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'PUT' -and $null -eq $Body
+        }
+    }
+
+    # Guards against widening the :100 body guard too far -- a body handed to a verb that must
+    # not carry one should be dropped, exactly as it was before PUT was added.
+    It 'still sends no Body on GET or DELETE even when -Body is supplied' -ForEach @(
+        @{ Verb = 'GET' }
+        @{ Verb = 'DELETE' }
+    ) {
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
+            [PSCustomObject]@{ items = @() }
+        } -ParameterFilter { $Uri -like '*file-systems*' }
+
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ Verb = $Verb } {
+            param($Verb)
+            $array = [PSCustomObject]@{
+                Endpoint = 'fb.test'; ApiVersion = '2.26'; AuthToken = 'tok'
+                ApiToken = $null; AuthMethod = 'ApiToken'; SkipCertificateCheck = $false
+            }
+            Invoke-PfbApiRequest -Array $array -Method $Verb -Endpoint 'file-systems' -Body @{ name = 'x' } | Out-Null
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod -Times 1 -Exactly -ParameterFilter {
+            $null -eq $Body
+        }
+    }
+
+    It 'still rejects a verb outside the ValidateSet' {
+        InModuleScope PureStorageFlashBladePowerShell {
+            $array = [PSCustomObject]@{
+                Endpoint = 'fb.test'; ApiVersion = '2.26'; AuthToken = 'tok'
+                ApiToken = $null; AuthMethod = 'ApiToken'; SkipCertificateCheck = $false
+            }
+            { Invoke-PfbApiRequest -Array $array -Method 'TRACE' -Endpoint 'file-systems' } |
+                Should -Throw
+        }
+    }
+}
+
 Describe 'Invoke-PfbApiRequest - AutoPaginate honors -Limit' {
     It 'stops paginating and trims results once the running total reaches the requested limit' {
         $script:pageCallCount = 0

--- a/Tests/Set-PfbPresetWorkload.Tests.ps1
+++ b/Tests/Set-PfbPresetWorkload.Tests.ps1
@@ -1,0 +1,92 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    $moduleRoot = Split-Path -Parent $PSScriptRoot
+    $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
+    Import-Module $manifest -Force
+
+    $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.26'; AuthToken = 'x' }
+}
+
+Describe 'Set-PfbPresetWorkload - routed through Invoke-PfbApiRequest (#76)' {
+
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod { }
+    }
+
+    Context 'the shared request path is used' {
+        It 'sends PUT to presets/workload' {
+            Set-PfbPresetWorkload -Name 'analytics' -Attributes @{ name = 'analytics' } -Confirm:$false -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                $Method -eq 'PUT' -and $Endpoint -eq 'presets/workload'
+            }
+        }
+
+        # The whole point of #76: this cmdlet used to call Invoke-RestMethod itself, which
+        # skipped capability gating, error normalisation, and Bearer-token auth. If a direct
+        # call ever comes back, this is the test that says so.
+        It 'makes no direct Invoke-RestMethod call' {
+            Set-PfbPresetWorkload -Name 'analytics' -Attributes @{ name = 'analytics' } -Confirm:$false -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod -Times 0 -Exactly
+        }
+
+        It 'passes -Attributes through as the body, unmodified' {
+            $attrs = @{ name = 'analytics'; description = 'test'; workload_type = 'generic' }
+            Set-PfbPresetWorkload -Name 'analytics' -Attributes $attrs -Confirm:$false -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                $Body.Count -eq 3 -and
+                $Body['name'] -eq 'analytics' -and
+                $Body['description'] -eq 'test' -and
+                $Body['workload_type'] -eq 'generic'
+            }
+        }
+    }
+
+    Context 'query parameters' {
+        It 'targets by name via the names query parameter' {
+            Set-PfbPresetWorkload -Name 'analytics' -Attributes @{ name = 'analytics' } -Confirm:$false -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                $QueryParams['names'] -eq 'analytics' -and -not $QueryParams.ContainsKey('ids')
+            }
+        }
+
+        It 'targets by id via the ids query parameter' {
+            Set-PfbPresetWorkload -Id 'preset-1' -Attributes @{ name = 'analytics' } -Confirm:$false -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                $QueryParams['ids'] -eq 'preset-1' -and -not $QueryParams.ContainsKey('names')
+            }
+        }
+
+        It 'sends skip_verify_deployable only when the switch is supplied' {
+            Set-PfbPresetWorkload -Name 'analytics' -Attributes @{ name = 'analytics' } -SkipVerifyDeployable -Confirm:$false -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                $QueryParams['skip_verify_deployable'] -eq 'true'
+            }
+        }
+
+        It 'omits skip_verify_deployable when the switch is absent' {
+            Set-PfbPresetWorkload -Name 'analytics' -Attributes @{ name = 'analytics' } -Confirm:$false -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                -not $QueryParams.ContainsKey('skip_verify_deployable')
+            }
+        }
+    }
+
+    Context 'ShouldProcess still gates the call' {
+        It 'makes no request under -WhatIf' {
+            Set-PfbPresetWorkload -Name 'analytics' -Attributes @{ name = 'analytics' } -WhatIf -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 0 -Exactly
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod -Times 0 -Exactly
+        }
+    }
+}


### PR DESCRIPTION
Closes #76.

`Set-PfbPresetWorkload` hand-rolled its own `Invoke-RestMethod` call, with a comment
explaining that the shared request path could not express PUT. That was true when the
cmdlet was written. It is no longer true after the first commit here, so the bypass goes
away.

## What changed

**`Invoke-PfbApiRequest` accepts PUT** (`cedf31a`). `PUT` joins the `ValidateSet`, and the
body-serialisation guard stays an explicit whitelist (`POST`/`PATCH`/`PUT`) rather than
becoming a "not GET" test — a future verb has to opt into carrying a body deliberately.

**`Set-PfbPresetWorkload` routes through it** (`b56165c`). Twelve lines of hand-rolled
request construction become one call. `Assert-PfbConnection` and the `ShouldProcess` gate
are unchanged.

Three consequences, none of them silent:

- **Capability gating now runs.** This cmdlet and `Set-PfbWorkloadTag` were the only two
  write cmdlets in the module exempt from it. A call against an array below REST 2.23 now
  throws locally instead of going out on the wire to be rejected.
- **Errors are normalised** through `ConvertTo-PfbApiError`, matching every other write
  cmdlet, instead of surfacing a raw `Invoke-RestMethod` exception.
- **Certificate and OAuth2 sessions work.** The hand-rolled block set `x-auth-token`
  unconditionally and never consulted `$Array.BearerToken`, so the cmdlet was broken for
  bearer-authenticated connections. The comment it carried did not mention this; it is
  fixed here as a side effect of the fold.

Body serialisation moves to the shared path's `-Depth 10`, down from the local `-Depth 15`.
The resolved `PUT /presets/workload` request schema nests 8 levels, so nothing truncates.

## Please read this part before merging

**This cmdlet does not work today, and it does not work after this PR either.** That is not
a regression introduced here — it has never worked. I found this while live-testing, and it
is worth recording because the issue as filed implies the fold makes the cmdlet correct.

Every preset write, and every *name-scoped* preset read, requires `context_names=<fleet>`.
No cmdlet in `Public/Presets/` has ever sent it. Tested against FB-A (Purity//FB 4.8.2,
REST 2.26) as a dynamic-authorization-model admin, against a preset that genuinely existed:

| Cmdlet | Result |
|---|---|
| `Get-PfbPresetWorkload` (unfiltered) | works |
| `Get-PfbPresetWorkload -Name` | `Preset does not exist.` |
| `Set-PfbPresetWorkload -Name` | `Preset does not exist.` |
| `New-PfbPresetWorkload` | `Creating a preset in the array context is not supported.` |
| `Remove-PfbPresetWorkload -Name` | `Preset does not exist.` |
| `Update-PfbPresetWorkload` | untested; expected to fail the same way |

Five of six preset operations are non-functional. What this PR changes is that
`Set-PfbPresetWorkload` is now *fixable in one place*: it was the last preset cmdlet routing
around the shared request path, so whatever adds `context_names` centrally will reach it
without a special case. That is the value here — the rewiring, not a working cmdlet.

One finding for the context work, from the same testing: `/presets/workload` rejects a
member array as context (`context_names=<member>` → `code 13 Invalid context`) and accepts
only the fleet name, on every verb. The shared `Context_names` component description
("an array in the same fleet *or* the name of the fleet itself") is wrong for this endpoint.

## Verification

- `Tests/Set-PfbPresetWorkload.Tests.ps1` is new — the cmdlet had no tests at all. Beyond
  verb/endpoint/body/query coverage it asserts `Invoke-RestMethod -Times 0`, which is the
  regression that would quietly undo this change.
- `Tests/Invoke-PfbApiRequest.Tests.ps1` gains PUT coverage: body serialisation, PUT with no
  body, GET/DELETE still sending no body, and an out-of-set verb failing parameter binding.
- Scoped run, both editions: **18 passed / 0 failed**, containers healthy, under pwsh 7 and
  Windows PowerShell 5.1 (Pester 6.0.1, CI's pin).
- Live-tested on FB-A: full create → PUT (revision 1 → 2) → delete round trip via fleet
  context, plus the matrix above. Lab left clean.

No version or CHANGELOG changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
