### PR TITLE
fix(workloads): send a JSON array when a single tag is supplied, and fold Set-PfbWorkloadTag onto the shared request path

### DIFF
--- a/Private/Assert-PfbApiCapability.ps1
+++ b/Private/Assert-PfbApiCapability.ps1
@@ -24,8 +24,21 @@ function Assert-PfbApiCapability {
         [Parameter(Mandatory)]
         [string]$Endpoint,
 
+        # Hashtable OR array. Invoke-PfbApiRequest forwards its own -Body straight into this
+        # parameter, and a few endpoints declare a top-level JSON array as their request body,
+        # so this must admit both or the forwarding call fails at bind time.
+        #
+        # ICollection, not IEnumerable and not a bare [object]. IEnumerable looks narrower but
+        # is worse: System.String implements it, so PowerShell happily converts -Body 42 into
+        # the string "42" instead of rejecting it. ICollection admits every dictionary and
+        # list shape (Hashtable, Hashtable[], Object[], OrderedDictionary, List<T>) while
+        # still rejecting strings, numbers, booleans and PSCustomObjects exactly as
+        # [hashtable] did, and -- unlike a ValidateScript, which rejects an explicit $null
+        # even under [AllowNull()] -- it still accepts the $null this function is handed on
+        # every bodyless call. Verified under both PowerShell 5.1 and 7.
+        # See the array-body note on the body-field loop below for how each shape is treated.
         [Parameter()]
-        [hashtable]$Body,
+        [System.Collections.ICollection]$Body,
 
         [Parameter()]
         [hashtable]$QueryParams,
@@ -72,7 +85,21 @@ function Assert-PfbApiCapability {
         }
     }
 
-    if ($Body) {
+    # Dictionary bodies only, and deliberately so. An array body's per-element fields are NOT
+    # checked, because the capability map records nothing to check them against:
+    # tools/Build-PfbCapabilityMap.ps1 fills bodyProperties from Get-PfbSchemaPropertyNames,
+    # whose schema walk resolves $ref and allOf but never descends through an array schema's
+    # "items". Every array-bodied endpoint in the spec -- PUT /workloads/tags/batch,
+    # POST /nodes/batch, POST /resource-accesses/batch -- therefore carries
+    # "bodyProperties": {} in Data/PfbCapabilityMap.json, so a union-of-element-fields check
+    # would compare every field against an empty map and could never fire. Skipping is an
+    # honest no-op; the alternative is a gate that only looks like one. Teaching the map to
+    # record per-element fields is its own change, and this loop picks it up for free if a
+    # future map representation ever lands.
+    #
+    # Endpoint minVersion and query-parameter checks above still run for array-bodied calls,
+    # which is gating those endpoints previously had none of.
+    if ($Body -is [System.Collections.IDictionary]) {
         foreach ($propName in $Body.Keys) {
             $introducedIn = $entry.bodyProperties.$propName
             if ($introducedIn -and -not (Test-PfbVersionAtLeast -Have $effectiveVersion -Need $introducedIn)) {

--- a/Private/Invoke-PfbApiRequest.ps1
+++ b/Private/Invoke-PfbApiRequest.ps1
@@ -19,8 +19,13 @@ function Invoke-PfbApiRequest {
         [Parameter(Mandatory)]
         [string]$Endpoint,
 
+        # Hashtable OR array: a few endpoints (PUT /workloads/tags/batch, POST /nodes/batch,
+        # POST /resource-accesses/batch) declare a top-level JSON array as their request body.
+        # Matches Assert-PfbApiCapability's -Body, which this is forwarded into unmodified --
+        # see the type note there for why ICollection rather than IEnumerable or [object].
+        # Every existing caller passes a [hashtable] (or $null), all of which bind unchanged.
         [Parameter()]
-        [hashtable]$Body,
+        [System.Collections.ICollection]$Body,
 
         [Parameter()]
         [hashtable]$QueryParams,
@@ -99,8 +104,13 @@ function Invoke-PfbApiRequest {
 
     # GET/DELETE never carry a body: the guard is a whitelist, not a "not GET" test, so a new
     # verb has to be added here deliberately rather than inheriting body serialisation.
+    #
+    # -InputObject, NOT the pipeline: the pipeline unrolls a collection, so a one-element
+    # array body would arrive at ConvertTo-Json as its bare element and serialise to a JSON
+    # object instead of a one-element array. A hashtable is never unrolled by the pipeline,
+    # so the hashtable path's output is byte-identical either way.
     if ($Body -and ($Method -eq 'POST' -or $Method -eq 'PATCH' -or $Method -eq 'PUT')) {
-        $restParams['Body'] = ($Body | ConvertTo-Json -Depth 10 -Compress)
+        $restParams['Body'] = (ConvertTo-Json -InputObject $Body -Depth 10 -Compress)
     }
 
     # SSL handling

--- a/Public/Workloads/Set-PfbWorkloadTag.ps1
+++ b/Public/Workloads/Set-PfbWorkloadTag.ps1
@@ -40,10 +40,12 @@ function Set-PfbWorkloadTag {
     if ($ResourceName) { $queryParams['resource_names'] = $ResourceName -join ',' }
     if ($ResourceId)   { $queryParams['resource_ids']   = $ResourceId -join ',' }
 
-    # The batch endpoint takes a raw array of tag objects as the body — Invoke-PfbApiRequest
-    # expects a hashtable, so wrap the array in a dummy key and unwrap below via $Raw.
-    # The FB tag-batch endpoint actually receives the array directly.
-    $jsonBody = $Tags | ConvertTo-Json -Depth 5
+    # -InputObject, NOT the pipeline. The pipeline unrolls $Tags, so a one-element
+    # [hashtable[]] -- which [ValidateCount(1, 30)] explicitly permits -- reaches
+    # ConvertTo-Json as a bare hashtable and serialises to a JSON object instead of a
+    # one-element array. The endpoint requires an array (minItems 1), so the single-tag
+    # case was rejected on the wire. -InputObject serialises the collection as a whole.
+    $jsonBody = ConvertTo-Json -InputObject $Tags -Depth 5
 
     if ($PSCmdlet.ShouldProcess(($ResourceName + $ResourceId -join ', '), "Apply $($Tags.Count) tag(s)")) {
         # Direct REST call bypassing the hashtable-only -Body parameter on Invoke-PfbApiRequest.

--- a/Public/Workloads/Set-PfbWorkloadTag.ps1
+++ b/Public/Workloads/Set-PfbWorkloadTag.ps1
@@ -40,24 +40,13 @@ function Set-PfbWorkloadTag {
     if ($ResourceName) { $queryParams['resource_names'] = $ResourceName -join ',' }
     if ($ResourceId)   { $queryParams['resource_ids']   = $ResourceId -join ',' }
 
-    # -InputObject, NOT the pipeline. The pipeline unrolls $Tags, so a one-element
-    # [hashtable[]] -- which [ValidateCount(1, 30)] explicitly permits -- reaches
-    # ConvertTo-Json as a bare hashtable and serialises to a JSON object instead of a
-    # one-element array. The endpoint requires an array (minItems 1), so the single-tag
-    # case was rejected on the wire. -InputObject serialises the collection as a whole.
-    $jsonBody = ConvertTo-Json -InputObject $Tags -Depth 5
-
     if ($PSCmdlet.ShouldProcess(($ResourceName + $ResourceId -join ', '), "Apply $($Tags.Count) tag(s)")) {
-        # Direct REST call bypassing the hashtable-only -Body parameter on Invoke-PfbApiRequest.
-        $apiVer = $Array.ApiVersion
-        $qs = ConvertTo-PfbQueryString -Parameters $queryParams
-        $uri = "https://$($Array.Endpoint)/api/${apiVer}/workloads/tags/batch${qs}"
-        $headers = @{ 'Content-Type' = 'application/json'; 'x-auth-token' = $Array.AuthToken }
-        $restParams = @{ Method = 'PUT'; Uri = $uri; Headers = $headers; Body = $jsonBody }
-        if ($Array.SkipCertificateCheck -and $PSVersionTable.PSVersion.Major -ge 6) {
-            $restParams['SkipCertificateCheck'] = $true
-        }
-        Write-Verbose "FlashBlade API: PUT $uri"
-        Invoke-RestMethod @restParams
+        # $Tags goes over as the body unmodified: this endpoint's body IS the tag array, not
+        # an object wrapping one. Serialisation happens in the shared path, which uses
+        # ConvertTo-Json -InputObject -- so the one-element array stays an array. That is the
+        # same guarantee the local ConvertTo-Json deleted here used to provide; the
+        # single-tag test asserting it is unchanged and still passes through this path.
+        Invoke-PfbApiRequest -Array $Array -Method PUT -Endpoint 'workloads/tags/batch' `
+            -Body $Tags -QueryParams $queryParams
     }
 }

--- a/Tests/Assert-PfbApiCapability.Tests.ps1
+++ b/Tests/Assert-PfbApiCapability.Tests.ps1
@@ -131,3 +131,121 @@ Describe 'Assert-PfbApiCapability' {
         }
     }
 }
+
+# Kept in its own Describe with its own fixture so the hashtable-path expectations above --
+# the regression gate for widening -Body -- stay untouched.
+Describe 'Assert-PfbApiCapability - array request bodies' {
+    BeforeEach {
+        InModuleScope PureStorageFlashBladePowerShell {
+            $script:PfbCapabilityMap = [PSCustomObject]@{
+                endpoints = [PSCustomObject]@{
+                    'PUT /widgets/batch' = [PSCustomObject]@{
+                        minVersion     = '9.1'
+                        parameters     = [PSCustomObject]@{ resource_names = '9.2' }
+                        # Mirrors the real map: every array-bodied endpoint in
+                        # Data/PfbCapabilityMap.json has an empty bodyProperties, because the
+                        # spec walk never descends into an array schema's "items".
+                        bodyProperties = [PSCustomObject]@{}
+                    }
+                    # Contrived: a bodyProperties entry on an array-bodied endpoint, which the
+                    # real map cannot currently produce. Pins the deliberate decision that an
+                    # array body's elements are not checked against it.
+                    'PUT /gadgets/batch' = [PSCustomObject]@{
+                        minVersion     = '9.0'
+                        parameters     = [PSCustomObject]@{}
+                        bodyProperties = [PSCustomObject]@{ color = '9.9' }
+                    }
+                }
+            }
+            $script:PfbVersionMap = [PSCustomObject]@{
+                '9.0' = [PSCustomObject]@{ purity = '5.0.0' }
+                '9.1' = [PSCustomObject]@{ purity = '5.1.0' }
+            }
+        }
+    }
+
+    AfterEach {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ root = $script:originalModuleRoot } {
+            $script:PfbCapabilityMap = $null
+            $script:PfbVersionMap = $null
+            $script:PfbModuleRoot = $root
+        }
+    }
+
+    It 'accepts an array body without throwing when the endpoint is supported' {
+        $array = New-TestArray -ApiVersion '9.1'
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ array = $array } {
+            $tags = [hashtable[]]@(@{ key = 'team'; value = 'analytics' })
+            { Assert-PfbApiCapability -Array $array -Method PUT -Endpoint 'widgets/batch' -Body $tags } |
+                Should -Not -Throw
+        }
+    }
+
+    It 'still enforces the endpoint minVersion for an array body' {
+        $array = New-TestArray -ApiVersion '9.0'
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ array = $array } {
+            $tags = [hashtable[]]@(@{ key = 'team'; value = 'analytics' })
+            { Assert-PfbApiCapability -Array $array -Method PUT -Endpoint 'widgets/batch' -Body $tags } |
+                Should -Throw -ExpectedMessage '*PUT /widgets/batch requires REST 9.1*'
+        }
+    }
+
+    It 'still enforces query-parameter gating for an array body' {
+        $array = New-TestArray -ApiVersion '9.1'
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ array = $array } {
+            $tags = [hashtable[]]@(@{ key = 'team'; value = 'analytics' })
+            { Assert-PfbApiCapability -Array $array -Method PUT -Endpoint 'widgets/batch' -Body $tags -QueryParams @{ resource_names = 'wl1' } } |
+                Should -Throw -ExpectedMessage "*parameter 'resource_names'*requires REST 9.2*"
+        }
+    }
+
+    It 'does not check an array element field against bodyProperties' {
+        $array = New-TestArray -ApiVersion '9.0'
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ array = $array } {
+            $elements = [hashtable[]]@(@{ color = 'red' })
+            { Assert-PfbApiCapability -Array $array -Method PUT -Endpoint 'gadgets/batch' -Body $elements } |
+                Should -Not -Throw
+        }
+    }
+
+    It 'still checks a hashtable body against the same bodyProperties entry' {
+        $array = New-TestArray -ApiVersion '9.0'
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ array = $array } {
+            { Assert-PfbApiCapability -Array $array -Method PUT -Endpoint 'gadgets/batch' -Body @{ color = 'red' } } |
+                Should -Throw -ExpectedMessage "*request-body field 'color'*requires REST 9.9*"
+        }
+    }
+
+    It 'does not throw on an empty array body' {
+        $array = New-TestArray -ApiVersion '9.1'
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ array = $array } {
+            { Assert-PfbApiCapability -Array $array -Method PUT -Endpoint 'widgets/batch' -Body @() } |
+                Should -Not -Throw
+        }
+    }
+
+    # -Body was widened to [System.Collections.ICollection], not to [object]: the shapes
+    # [hashtable] used to reject must still be rejected at bind time. IEnumerable would have
+    # silently converted 42 and $true into the strings "42"/"True".
+    It 'still rejects a non-collection body at bind time' -ForEach @(
+        @{ Label = 'int'; Value = 42 }
+        @{ Label = 'string'; Value = 'not-a-body' }
+        @{ Label = 'PSCustomObject'; Value = [PSCustomObject]@{ color = 'red' } }
+    ) {
+        $array = New-TestArray -ApiVersion '9.1'
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ array = $array; value = $Value } {
+            { Assert-PfbApiCapability -Array $array -Method PUT -Endpoint 'widgets/batch' -Body $value } |
+                Should -Throw
+        }
+    }
+
+    # Every bodyless call reaches this function as -Body $null (Invoke-PfbApiRequest forwards
+    # its own unbound $Body unconditionally), so the widened type must still accept it.
+    It 'still accepts an explicit $null body' {
+        $array = New-TestArray -ApiVersion '9.1'
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ array = $array } {
+            { Assert-PfbApiCapability -Array $array -Method PUT -Endpoint 'widgets/batch' -Body $null } |
+                Should -Not -Throw
+        }
+    }
+}

--- a/Tests/Invoke-PfbApiRequest.Tests.ps1
+++ b/Tests/Invoke-PfbApiRequest.Tests.ps1
@@ -137,6 +137,105 @@ Describe 'Invoke-PfbApiRequest - PUT support' {
     }
 }
 
+Describe 'Invoke-PfbApiRequest - array request bodies' {
+
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
+            [PSCustomObject]@{ items = @() }
+        }
+    }
+
+    # Key order inside each serialised object is not asserted anywhere below: PowerShell
+    # randomises hashtable enumeration order per process, so both orderings are correct.
+
+    It 'serialises an array body as a top-level JSON array' {
+        InModuleScope PureStorageFlashBladePowerShell {
+            $array = [PSCustomObject]@{
+                Endpoint = 'fb.test'; ApiVersion = '2.26'; AuthToken = 'tok'
+                ApiToken = $null; AuthMethod = 'ApiToken'; SkipCertificateCheck = $false
+            }
+            $tags = [hashtable[]]@(
+                @{ key = 'team'; value = 'analytics' }
+                @{ key = 'env'; value = 'prod' }
+            )
+            Invoke-PfbApiRequest -Array $array -Method PUT -Endpoint 'workloads/tags/batch' -Body $tags | Out-Null
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod -Times 1 -Exactly -ParameterFilter {
+            $Body.StartsWith('[') -and $Body.EndsWith(']') -and
+            $Body -match '"analytics"' -and $Body -match '"prod"'
+        }
+    }
+
+    # The single-element case is the one that regresses silently: piping a one-element
+    # collection into ConvertTo-Json unrolls it into a bare object.
+    It 'keeps a SINGLE-element array body an array rather than collapsing it to an object' {
+        InModuleScope PureStorageFlashBladePowerShell {
+            $array = [PSCustomObject]@{
+                Endpoint = 'fb.test'; ApiVersion = '2.26'; AuthToken = 'tok'
+                ApiToken = $null; AuthMethod = 'ApiToken'; SkipCertificateCheck = $false
+            }
+            $tags = [hashtable[]]@(@{ key = 'team'; value = 'analytics' })
+            Invoke-PfbApiRequest -Array $array -Method PUT -Endpoint 'workloads/tags/batch' -Body $tags | Out-Null
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod -Times 1 -Exactly -ParameterFilter {
+            $Body.StartsWith('[') -and $Body.EndsWith(']') -and $Body -match '"analytics"'
+        }
+    }
+
+    # Regression gate on the widened -Body: a hashtable must still serialise to a JSON
+    # object, unchanged by the move from the pipeline to -InputObject.
+    It 'still serialises a hashtable body as a JSON object' {
+        InModuleScope PureStorageFlashBladePowerShell {
+            $array = [PSCustomObject]@{
+                Endpoint = 'fb.test'; ApiVersion = '2.26'; AuthToken = 'tok'
+                ApiToken = $null; AuthMethod = 'ApiToken'; SkipCertificateCheck = $false
+            }
+            Invoke-PfbApiRequest -Array $array -Method POST -Endpoint 'buckets' -Body @{ name = 'b1' } | Out-Null
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod -Times 1 -Exactly -ParameterFilter {
+            $Body -eq '{"name":"b1"}'
+        }
+    }
+
+    # -Body was widened from [hashtable] to [System.Collections.ICollection], not to
+    # [object]: the shapes [hashtable] rejected must still be rejected at bind time.
+    It 'still rejects a non-collection -Body' -ForEach @(
+        @{ Label = 'int'; Value = 42 }
+        @{ Label = 'string'; Value = 'not-a-body' }
+        @{ Label = 'PSCustomObject'; Value = [PSCustomObject]@{ name = 'b1' } }
+    ) {
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{ value = $Value } {
+            param($value)
+            $array = [PSCustomObject]@{
+                Endpoint = 'fb.test'; ApiVersion = '2.26'; AuthToken = 'tok'
+                ApiToken = $null; AuthMethod = 'ApiToken'; SkipCertificateCheck = $false
+            }
+            { Invoke-PfbApiRequest -Array $array -Method POST -Endpoint 'buckets' -Body $value } |
+                Should -Throw
+        }
+    }
+
+    # New-PfbFileSystemSnapshot builds $body = $null and passes it unconditionally, so the
+    # widened type must still bind an explicit $null, not only an omitted -Body.
+    It 'still accepts an explicit $null -Body and sends no body' {
+        InModuleScope PureStorageFlashBladePowerShell {
+            $array = [PSCustomObject]@{
+                Endpoint = 'fb.test'; ApiVersion = '2.26'; AuthToken = 'tok'
+                ApiToken = $null; AuthMethod = 'ApiToken'; SkipCertificateCheck = $false
+            }
+            $nothing = $null
+            Invoke-PfbApiRequest -Array $array -Method POST -Endpoint 'buckets' -Body $nothing | Out-Null
+        }
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod -Times 1 -Exactly -ParameterFilter {
+            $null -eq $Body
+        }
+    }
+}
+
 Describe 'Invoke-PfbApiRequest - AutoPaginate honors -Limit' {
     It 'stops paginating and trims results once the running total reaches the requested limit' {
         $script:pageCallCount = 0

--- a/Tests/Set-PfbWorkloadTag.Tests.ps1
+++ b/Tests/Set-PfbWorkloadTag.Tests.ps1
@@ -1,0 +1,85 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+<#
+.SYNOPSIS
+    Unit tests for Set-PfbWorkloadTag.
+.DESCRIPTION
+    The cmdlet had no tests. These assert the shape that actually reaches the wire, so they
+    survive the cmdlet being refolded onto Invoke-PfbApiRequest: Invoke-RestMethod is the
+    mock boundary, not Invoke-PfbApiRequest.
+#>
+
+BeforeAll {
+    $moduleRoot = Split-Path -Parent $PSScriptRoot
+    $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
+    Import-Module $manifest -Force
+
+    $script:fakeArray = [PSCustomObject]@{
+        Endpoint             = 'fb.example.test'
+        ApiVersion           = '2.26'
+        AuthToken            = 'x'
+        ApiToken             = $null
+        AuthMethod           = 'ApiToken'
+        SkipCertificateCheck = $false
+    }
+}
+
+Describe 'Set-PfbWorkloadTag - wire body shape' {
+
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod { [PSCustomObject]@{ items = @() } }
+    }
+
+    # The #77 regression. PUT /workloads/tags/batch declares minItems 1 on a top-level array,
+    # and [ValidateCount(1, 30)] explicitly permits one tag -- but a one-element collection
+    # piped into ConvertTo-Json unrolls and serialises as a bare object, which the array
+    # rejects. A two-tag call passes either way, so ONE tag is the assertion that matters.
+    #
+    # Key order inside each tag object is deliberately not asserted: PowerShell randomises
+    # hashtable enumeration order per process, so {"key":..,"value":..} and the reverse are
+    # both correct output.
+    It 'serialises a SINGLE tag as a one-element JSON array, not a bare object' {
+        Set-PfbWorkloadTag -ResourceName 'wl1' -Tags @(@{ key = 'team'; value = 'analytics' }) -Confirm:$false -Array $fakeArray
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod -Times 1 -Exactly -ParameterFilter {
+            $Body.Trim().StartsWith('[') -and
+            $Body.Trim().EndsWith(']') -and
+            $Body -match '"analytics"'
+        }
+    }
+
+    It 'serialises multiple tags as a JSON array' {
+        Set-PfbWorkloadTag -ResourceName 'wl1' -Tags @(
+            @{ key = 'team'; value = 'analytics' }
+            @{ key = 'env'; value = 'prod' }
+        ) -Confirm:$false -Array $fakeArray
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod -Times 1 -Exactly -ParameterFilter {
+            $Body.Trim().StartsWith('[') -and
+            $Body -match '"analytics"' -and
+            $Body -match '"prod"'
+        }
+    }
+
+    It 'sends PUT to the workloads/tags/batch endpoint' {
+        Set-PfbWorkloadTag -ResourceName 'wl1' -Tags @(@{ key = 'team'; value = 'analytics' }) -Confirm:$false -Array $fakeArray
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'PUT' -and $Uri -like '*/workloads/tags/batch*'
+        }
+    }
+}
+
+Describe 'Set-PfbWorkloadTag - ShouldProcess gates the call' {
+
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod { [PSCustomObject]@{ items = @() } }
+    }
+
+    It 'makes no request under -WhatIf' {
+        Set-PfbWorkloadTag -ResourceName 'wl1' -Tags @(@{ key = 'team'; value = 'analytics' }) -WhatIf -Array $fakeArray
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod -Times 0 -Exactly
+    }
+}

--- a/Tests/Set-PfbWorkloadTag.Tests.ps1
+++ b/Tests/Set-PfbWorkloadTag.Tests.ps1
@@ -70,6 +70,30 @@ Describe 'Set-PfbWorkloadTag - wire body shape' {
     }
 }
 
+Describe 'Set-PfbWorkloadTag - query parameters reach the wire' {
+
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod { [PSCustomObject]@{ items = @() } }
+    }
+
+    It 'targets by name via resource_names' {
+        Set-PfbWorkloadTag -ResourceName 'wl1', 'wl2' -Tags @(@{ key = 'team'; value = 'analytics' }) -Confirm:$false -Array $fakeArray
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod -Times 1 -Exactly -ParameterFilter {
+            $Uri -like '*resource_names=wl1*wl2*' -and $Uri -notlike '*resource_ids*'
+        }
+    }
+
+    It 'targets by id via resource_ids' {
+        Set-PfbWorkloadTag -ResourceId 'wl-1' -Tags @(@{ key = 'team'; value = 'analytics' }) -Confirm:$false -Array $fakeArray
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod -Times 1 -Exactly -ParameterFilter {
+            $Uri -like '*resource_ids=wl-1*' -and $Uri -notlike '*resource_names*'
+        }
+    }
+}
+
 Describe 'Set-PfbWorkloadTag - ShouldProcess gates the call' {
 
     BeforeEach {
@@ -79,6 +103,96 @@ Describe 'Set-PfbWorkloadTag - ShouldProcess gates the call' {
 
     It 'makes no request under -WhatIf' {
         Set-PfbWorkloadTag -ResourceName 'wl1' -Tags @(@{ key = 'team'; value = 'analytics' }) -WhatIf -Array $fakeArray
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod -Times 0 -Exactly
+    }
+}
+
+Describe 'Set-PfbWorkloadTag - routed through Invoke-PfbApiRequest (#77)' {
+
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod { }
+    }
+
+    It 'sends PUT to workloads/tags/batch' {
+        Set-PfbWorkloadTag -ResourceName 'wl1' -Tags @(@{ key = 'team'; value = 'analytics' }) -Confirm:$false -Array $fakeArray
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'PUT' -and $Endpoint -eq 'workloads/tags/batch'
+        }
+    }
+
+    # The point of the refactor: the hand-rolled call skipped capability gating, error
+    # normalisation and Bearer-token auth. If a direct call ever comes back, this says so.
+    It 'makes no direct Invoke-RestMethod call' {
+        Set-PfbWorkloadTag -ResourceName 'wl1' -Tags @(@{ key = 'team'; value = 'analytics' }) -Confirm:$false -Array $fakeArray
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod -Times 0 -Exactly
+    }
+
+    It 'passes -Tags through as the body, unmodified and still a collection' {
+        Set-PfbWorkloadTag -ResourceName 'wl1' -Tags @(
+            @{ key = 'team'; value = 'analytics'; namespace = 'default' }
+            @{ key = 'env'; value = 'prod' }
+        ) -Confirm:$false -Array $fakeArray
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $Body.Count -eq 2 -and
+            $Body[0]['key'] -eq 'team' -and $Body[0]['namespace'] -eq 'default' -and
+            $Body[1]['value'] -eq 'prod'
+        }
+    }
+
+    # A one-element [hashtable[]] must not be unwrapped into a bare hashtable by parameter
+    # binding on the way into the shared path -- that would put the #77 defect back.
+    It 'passes a SINGLE tag through as a one-element collection, not a bare hashtable' {
+        Set-PfbWorkloadTag -ResourceName 'wl1' -Tags @(@{ key = 'team'; value = 'analytics' }) -Confirm:$false -Array $fakeArray
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $Body -is [array] -and $Body.Count -eq 1 -and $Body[0]['key'] -eq 'team'
+        }
+    }
+
+    It 'puts the targeting selectors in QueryParams' {
+        Set-PfbWorkloadTag -ResourceName 'wl1', 'wl2' -Tags @(@{ key = 'team'; value = 'analytics' }) -Confirm:$false -Array $fakeArray
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['resource_names'] -eq 'wl1,wl2' -and -not $QueryParams.ContainsKey('resource_ids')
+        }
+    }
+
+    It 'makes no request under -WhatIf' {
+        Set-PfbWorkloadTag -ResourceName 'wl1' -Tags @(@{ key = 'team'; value = 'analytics' }) -WhatIf -Array $fakeArray
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 0 -Exactly
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod -Times 0 -Exactly
+    }
+}
+
+Describe 'Set-PfbWorkloadTag - capability gating now applies' {
+
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod { [PSCustomObject]@{ items = @() } }
+    }
+
+    # PUT /workloads/tags/batch is minVersion 2.23 in Data/PfbCapabilityMap.json. Before the
+    # refactor the hand-rolled call bypassed Assert-PfbApiCapability entirely and this went
+    # out on the wire to be rejected by the array.
+    It 'throws locally, with no network call, against an array below the endpoint minVersion' {
+        $oldArray = [PSCustomObject]@{
+            Endpoint             = 'fb.example.test'
+            ApiVersion           = '2.22'
+            AuthToken            = 'x'
+            ApiToken             = $null
+            AuthMethod           = 'ApiToken'
+            SkipCertificateCheck = $false
+        }
+
+        { Set-PfbWorkloadTag -ResourceName 'wl1' -Tags @(@{ key = 'team'; value = 'analytics' }) -Confirm:$false -Array $oldArray } |
+            Should -Throw -ExpectedMessage '*PUT /workloads/tags/batch requires REST 2.23*'
 
         Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod -Times 0 -Exactly
     }


### PR DESCRIPTION
Fixes #77.

`Set-PfbWorkloadTag` was the last write cmdlet hand-rolling its own `Invoke-RestMethod`, and it serialised its body with `$Tags | ConvertTo-Json`. The pipeline unrolls a collection, so a **single** tag arrived at `ConvertTo-Json` as a bare hashtable and went over the wire as a JSON object where the endpoint requires an array.

The array names the defect precisely. Against FB-A (Purity//FB 4.8.2, REST 2.26), one tag, before this change:

```
{"code":3,"message":"Cannot deserialize value of type `java.util.ArrayList` from Object value (token `JsonToken.START_OBJECT`)"}
```

Two tags never hit it — the pipeline emits a real array at N≥2 — which is why this survived.

## Commits

| SHA | Subject |
|---|---|
| `e356a5f` | `fix(workloads): send a JSON array when a single tag is supplied` |
| `41dab21` | `feat(core): accept array request bodies in Assert-PfbApiCapability` |
| `9f527dd` | `feat(core): allow array request bodies through Invoke-PfbApiRequest` |
| `39bd09f` | `fix(workloads): route Set-PfbWorkloadTag through Invoke-PfbApiRequest` |

`e356a5f` is the minimal standalone fix and is independently revertable — verified by both `git revert` at its own tip and `git cherry-pick` onto `main`. The remaining three fold the cmdlet onto the shared request path, which is what the endpoint needed anyway and what makes the cmdlet reachable by any future central query-parameter injection.

## Design decision: array bodies are not field-validated

`Assert-PfbApiCapability` iterated `$Body.Keys`, which an array does not have. The obvious fix is to validate the union of element field names — but the capability map records nothing to validate against. `PUT /workloads/tags/batch` carries `"bodyProperties": {}`, as do the only other three array-bodied endpoints in the spec (`POST /nodes/batch`, `POST /resource-accesses/batch`, `POST /fleets/members/batch`).

Root cause: `Build-PfbCapabilityMap.ps1` fills `bodyProperties` via `Get-PfbSchemaPropertyNames`, whose schema walk resolves `$ref` and `allOf` but never descends through an array schema's `items`. Filed as #82; tracked with the other pending capability-map changes in #84.

So a union check would compare every field against an empty map and could never fire — a gate that only looks like one. The loop is now guarded on `-is [IDictionary]`, which picks up per-element data for free if the map ever learns to record it. Endpoint `minVersion` and query-parameter gating **do** still run for array bodies, which is gating these endpoints previously had none of.

Confirmed against the live array that this loses nothing today: a bogus element field is rejected on the wire with `Unrecognized field "bogus_field"`.

## Notes on the implementation

**`-Body` is typed `[System.Collections.ICollection]`.** `IEnumerable` looks narrower but is worse — `System.String` implements it, so `-Body 42` would silently bind as the string `"42"` instead of being rejected. `ValidateScript` is unusable because PowerShell rejects an explicit `$null` argument against one even under `[AllowNull()]`, and several callers pass `-Body $null`. `ICollection` admits Hashtable / Hashtable[] / Object[] / OrderedDictionary / List<T> and `$null`, and rejects int, string, bool and PSCustomObject — matching `[hashtable]`'s rejections exactly. Verified identical under 5.1 and 7.

**The shared serialisation line changed** to `ConvertTo-Json -InputObject $Body`. The previous `($Body | ConvertTo-Json)` would have reintroduced the exact single-element defect inside the shared path the moment the cmdlet was folded onto it. Hashtable output is byte-identical, and there is a test pinning that.

## Verification

Scoped Pester, 12 files (this change's tests plus every file exercising the real request path), both editions:

```
Edition    Pester  Status  Passed  Failed  Skipped  Container
pwsh 7     6.0.1   Passed     311       0        0  ok
WinPS 5.1  6.0.1   Passed     287       0       24  ok
```

The 24 WinPS 5.1 skips are pre-existing `-Skip:($PSVersionTable.PSVersion.Major -lt 7)` guards. `Tests/Assert-PfbApiCapability.Tests.ps1` is +118/-0 and `Tests/Invoke-PfbApiRequest.Tests.ps1` is +99/-0 — no existing expectation was modified to accommodate this change.

One pre-existing pwsh-7 failure in `Tests/Build-PfbApiDriftReport.Tests.ps1` ("Nothing vanishes" vs the committed report on disk) reproduces identically on untouched `main` and is excluded from the counts above.

Live-verified against FB-A (REST 2.26):

| Case | Result |
|---|---|
| One tag | fails on `main` with `code 3` deserialize error; reaches `code 6` here |
| Two tags | `code 6` before and after — no regression |
| Capability gating | throws locally at 2.22 with the correct 2.23 / Purity 4.6.7 message; reaches the wire at 2.26 |
| Error shape | was an opaque `400 ()`; now `FlashBlade API error: Workload does not exist.` |
| Bogus element field | rejected by the array — local skip loses nothing |

The error-shape improvement is a side effect of folding onto the shared path: the old raw `Invoke-RestMethod` discarded the response body, so every failure surfaced as a bare 400. The cmdlet also inherits the 401/403 reconnect-and-retry path, which is safe here since this PUT is idempotent.

## Not in scope

`PUT /workloads/tags/batch` declares `context_names` (2.23), so this cmdlet will need fleet-context handling — that belongs to the Fusion work in #72, and this PR is the prerequisite that makes the cmdlet reachable by it. Live testing separately confirmed the endpoint is array-scoped: it accepts array names and `<fleet>.arrays`, and rejects a bare fleet name.

No version bump or CHANGELOG edit, per the maintainer's call on those.


