### PR TITLE
fix(replication): select array connections by remote_names, not the dead names query key

### DIFF
--- a/Private/Assert-PfbRemoteNameNotCoerced.ps1
+++ b/Private/Assert-PfbRemoteNameNotCoerced.ps1
@@ -6,11 +6,15 @@ function Assert-PfbRemoteNameNotCoerced {
         PowerShell resolves pipeline binding in three passes: ByValue-without-coercion,
         then ByPropertyName-without-coercion, then ByValue-WITH-coercion.
 
-        Array-connection cmdlets that expose an -Id parameter (Get-/Remove-/Update-PfbArrayConnection)
-        bind a piped connection object at pass 2, on id. Get-PfbArrayConnectionPath and
-        Get-PfbArrayConnectionPerformanceReplication have no -Id parameter at all, so a piped
-        connection object falls through to pass 3 and the entire PSCustomObject is ToString()-ed
-        into [string[]]$RemoteName, producing a garbage filter such as
+        Get-PfbArrayConnectionPath and Get-PfbArrayConnectionPerformanceReplication have no -Id
+        parameter at all, so a piped connection object falls through to pass 3 and the entire
+        PSCustomObject is ToString()-ed into [string[]]$RemoteName. Get-/Remove-PfbArrayConnection
+        do expose -Id and usually bind at pass 2 on it, but that is a property of the piped
+        OBJECT, not of the cmdlet: pipe anything lacking id/name/remoteName and pass 3 fires
+        there too. (Update-PfbArrayConnection is genuinely immune -- neither of its parameters
+        declares ValueFromPipeline, so pass 3 is unreachable and the guard would be dead code.)
+
+        Either way the result is a garbage filter such as
 
             remote_names=@{id=10314f42-aaaa; status=connected; remote=}
 
@@ -21,14 +25,22 @@ function Assert-PfbRemoteNameNotCoerced {
 
         -RemoteName by value with plain strings ('FB-B','FB-C' | Get-PfbArrayConnectionPath) is
         unaffected, as is binding by property name.
+
+        Deliberately called imperatively from each cmdlet's process block rather than wired as
+        [ValidateScript({ Assert-PfbRemoteNameNotCoerced $_ })] like Assert-PfbSafeName. That was
+        tried and reverted: a ValidateScript failure on a PIPELINE-bound argument is a
+        NON-terminating per-item binding error, so the cmdlet's end block still runs and still
+        issues the request -- with no remote_names key at all, i.e. the silently-unfiltered
+        result that issue #64 exists to eliminate. Verified on both editions. The imperative
+        throw terminates the pipeline, which is the required behaviour.
     #>
     param([Parameter(Mandatory)] [object]$Value)
 
     foreach ($v in @($Value)) {
         if ($v -is [string] -and $v -like '*@{*') {
             throw ("-RemoteName received a stringified object ('{0}') instead of a remote array name. " -f $v) +
-                  'This cmdlet has no -Id parameter, so piping an array-connection object coerces the ' +
-                  'whole object into -RemoteName. Pipe the remote name instead, e.g. ' +
+                  'A piped object that binds to neither -Id nor a name property is coerced whole into ' +
+                  '-RemoteName. Pipe the remote name instead, e.g. ' +
                   'Get-PfbArrayConnection | Select-Object -ExpandProperty remote | ' +
                   'Select-Object -ExpandProperty name | Get-PfbArrayConnectionPath, or pass -RemoteName explicitly.'
         }

--- a/Private/Assert-PfbRemoteNameNotCoerced.ps1
+++ b/Private/Assert-PfbRemoteNameNotCoerced.ps1
@@ -1,0 +1,37 @@
+function Assert-PfbRemoteNameNotCoerced {
+    <#
+    .SYNOPSIS
+        Reject a -RemoteName value that is the ToString() of a whole piped object.
+    .DESCRIPTION
+        PowerShell resolves pipeline binding in three passes: ByValue-without-coercion,
+        then ByPropertyName-without-coercion, then ByValue-WITH-coercion.
+
+        Array-connection cmdlets that expose an -Id parameter (Get-/Remove-/Update-PfbArrayConnection)
+        bind a piped connection object at pass 2, on id. Get-PfbArrayConnectionPath and
+        Get-PfbArrayConnectionPerformanceReplication have no -Id parameter at all, so a piped
+        connection object falls through to pass 3 and the entire PSCustomObject is ToString()-ed
+        into [string[]]$RemoteName, producing a garbage filter such as
+
+            remote_names=@{id=10314f42-aaaa; status=connected; remote=}
+
+        Before issue #64 the key was the unrecognised (and therefore silently ignored) names=, so
+        this returned every record unfiltered. Now that remote_names= is live, the array rejects
+        it with "Array connection does not exist." This helper turns that into an actionable,
+        module-level failure instead of a confusing server-side one.
+
+        -RemoteName by value with plain strings ('FB-B','FB-C' | Get-PfbArrayConnectionPath) is
+        unaffected, as is binding by property name.
+    #>
+    param([Parameter(Mandatory)] [object]$Value)
+
+    foreach ($v in @($Value)) {
+        if ($v -is [string] -and $v -like '*@{*') {
+            throw ("-RemoteName received a stringified object ('{0}') instead of a remote array name. " -f $v) +
+                  'This cmdlet has no -Id parameter, so piping an array-connection object coerces the ' +
+                  'whole object into -RemoteName. Pipe the remote name instead, e.g. ' +
+                  'Get-PfbArrayConnection | Select-Object -ExpandProperty remote | ' +
+                  'Select-Object -ExpandProperty name | Get-PfbArrayConnectionPath, or pass -RemoteName explicitly.'
+        }
+    }
+    return $true
+}

--- a/Public/Monitoring/Update-PfbAsyncLog.ps1
+++ b/Public/Monitoring/Update-PfbAsyncLog.ps1
@@ -3,18 +3,18 @@ function Update-PfbAsyncLog {
     .SYNOPSIS
         Updates an asynchronous log collection job on the FlashBlade.
     .DESCRIPTION
-        The Update-PfbAsyncLog cmdlet modifies an asynchronous log collection job on the
-        connected Everpure FlashBlade. Identify the job by name or ID and supply the
-        changed properties via Attributes or individual parameters.
+        The Update-PfbAsyncLog cmdlet modifies the asynchronous log collection job on the
+        connected Everpure FlashBlade. Supply the changed properties via Attributes or the
+        individual parameters.
+
+        PATCH /logs-async takes no query parameters and no selector: the array has one async
+        log collection to configure, not a collection of named jobs. The endpoint requires
+        start_time on every request, even though the spec marks no field as required.
 
         The individual typed parameters and the raw -Attributes hashtable are mutually
         exclusive: they live in separate parameter sets, so PowerShell rejects a mixed
         invocation at bind time rather than letting -Attributes silently override an
         explicitly supplied value.
-    .PARAMETER Name
-        The name of the async log job to update. Accepts pipeline input by property name.
-    .PARAMETER Id
-        The ID of the async log job to update.
     .PARAMETER EndTime
         When the time window ends (in milliseconds since epoch).
     .PARAMETER HardwareComponents
@@ -27,44 +27,31 @@ function Update-PfbAsyncLog {
     .PARAMETER Array
         The FlashBlade connection object. If not specified, the default connection is used.
     .EXAMPLE
-        Update-PfbAsyncLog -Name "log-job-1" -StartTime 1700000000000 -EndTime 1700003600000
+        Update-PfbAsyncLog -StartTime 1700000000000 -EndTime 1700003600000
 
-        Sets the processing time window for the async log job named "log-job-1" using typed
-        parameters.
+        Sets the processing time window using typed parameters.
     .EXAMPLE
-        Update-PfbAsyncLog -Id "12345" -Attributes @{ status = 'cancelled' }
+        Update-PfbAsyncLog -StartTime 1700000000000 -HardwareComponents 'CH1.FB1','CH1.FB2'
 
-        Cancels the async log job identified by ID.
+        Restricts log processing to two hardware components over the given window.
     .EXAMPLE
-        Update-PfbAsyncLog -Name "log-job-1" -Attributes @{ keep_until = 1700000000000 }
+        Update-PfbAsyncLog -Attributes @{ start_time = 1700000000000; end_time = 1700003600000 }
 
-        Updates the retention time for the specified async log job.
+        Equivalent to the first example, using the raw attributes hashtable.
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium',
-                   DefaultParameterSetName = 'ByNameIndividual')]
+                   DefaultParameterSetName = 'Individual')]
     param(
-        [Parameter(ParameterSetName = 'ByNameIndividual', Mandatory, ValueFromPipelineByPropertyName)]
-        [Parameter(ParameterSetName = 'ByNameAttributes',  Mandatory, ValueFromPipelineByPropertyName)]
-        [string]$Name,
-
-        [Parameter(ParameterSetName = 'ByIdIndividual', Mandatory)]
-        [Parameter(ParameterSetName = 'ByIdAttributes',  Mandatory)]
-        [string]$Id,
-
-        [Parameter(ParameterSetName = 'ByNameIndividual')]
-        [Parameter(ParameterSetName = 'ByIdIndividual')]
+        [Parameter(ParameterSetName = 'Individual')]
         [long]$EndTime,
 
-        [Parameter(ParameterSetName = 'ByNameIndividual')]
-        [Parameter(ParameterSetName = 'ByIdIndividual')]
+        [Parameter(ParameterSetName = 'Individual')]
         [string[]]$HardwareComponents,
 
-        [Parameter(ParameterSetName = 'ByNameIndividual')]
-        [Parameter(ParameterSetName = 'ByIdIndividual')]
+        [Parameter(ParameterSetName = 'Individual')]
         [long]$StartTime,
 
-        [Parameter(ParameterSetName = 'ByNameAttributes', Mandatory)]
-        [Parameter(ParameterSetName = 'ByIdAttributes',   Mandatory)]
+        [Parameter(ParameterSetName = 'Attributes', Mandatory)]
         [hashtable]$Attributes,
 
         [Parameter()] [PSCustomObject]$Array
@@ -75,11 +62,7 @@ function Update-PfbAsyncLog {
     }
 
     process {
-        $queryParams = @{}
-        if ($Name) { $queryParams['names'] = $Name }
-        if ($Id)   { $queryParams['ids']   = $Id }
-
-        if ($PSCmdlet.ParameterSetName -like '*Attributes') {
+        if ($PSCmdlet.ParameterSetName -eq 'Attributes') {
             $body = $Attributes
         }
         else {
@@ -97,10 +80,11 @@ function Update-PfbAsyncLog {
             }
         }
 
-        $target = if ($Name) { $Name } else { $Id }
-
-        if ($PSCmdlet.ShouldProcess($target, 'Update async log job')) {
-            Invoke-PfbApiRequest -Array $Array -Method PATCH -Endpoint 'logs-async' -Body $body -QueryParams $queryParams
+        # PATCH /logs-async takes no query parameters in any spec version and ignores any that
+        # are sent (issue #64), so there is no per-job target to name here -- the endpoint
+        # operates on the array's async log collection itself.
+        if ($PSCmdlet.ShouldProcess('logs-async', 'Update async log job')) {
+            Invoke-PfbApiRequest -Array $Array -Method PATCH -Endpoint 'logs-async' -Body $body
         }
     }
 }

--- a/Public/Replication/Get-PfbArrayConnection.ps1
+++ b/Public/Replication/Get-PfbArrayConnection.ps1
@@ -19,7 +19,8 @@ function Get-PfbArrayConnection {
     .PARAMETER Filter
         A server-side filter expression to narrow results (e.g., "status='connected'").
     .PARAMETER Sort
-        Sort field and direction (e.g., "name" or "name-").
+        Sort field and direction (e.g., "id" or "id-"). An array connection has no name field,
+        so "name" is not a valid sort field here -- use "id", "status" or "type".
     .PARAMETER Limit
         Maximum number of array connection entries to return.
     .PARAMETER Array
@@ -38,9 +39,9 @@ function Get-PfbArrayConnection {
         Retrieves only the asynchronous replication connections, excluding the
         system-managed fleet-management ones.
     .EXAMPLE
-        Get-PfbArrayConnection -Filter "status='connected'" -Sort "name" -Limit 10
+        Get-PfbArrayConnection -Filter "status='connected'" -Sort "id" -Limit 10
 
-        Retrieves up to 10 connected array connections sorted by name.
+        Retrieves up to 10 connected array connections sorted by id.
     #>
     [CmdletBinding(DefaultParameterSetName = 'List')]
     param(

--- a/Public/Replication/Get-PfbArrayConnection.ps1
+++ b/Public/Replication/Get-PfbArrayConnection.ps1
@@ -19,8 +19,9 @@ function Get-PfbArrayConnection {
     .PARAMETER Filter
         A server-side filter expression to narrow results (e.g., "status='connected'").
     .PARAMETER Sort
-        Sort field and direction (e.g., "id" or "id-"). An array connection has no name field,
-        so "name" is not a valid sort field here -- use "id", "status" or "type".
+        Sort field and direction (e.g., "id" or "id-"). An array connection has no name field, so
+        "name" cannot sort it. The API publishes no enum of sortable fields -- use a field the
+        resource actually has, such as "id", "status" or "type".
     .PARAMETER Limit
         Maximum number of array connection entries to return.
     .PARAMETER Array

--- a/Public/Replication/Get-PfbArrayConnection.ps1
+++ b/Public/Replication/Get-PfbArrayConnection.ps1
@@ -4,13 +4,18 @@ function Get-PfbArrayConnection {
         Retrieves FlashBlade array connections (replication links between arrays).
     .DESCRIPTION
         The Get-PfbArrayConnection cmdlet returns array connection configurations from the
-        connected Pure Storage FlashBlade. Array connections define replication links between
+        connected Everpure FlashBlade. Array connections define replication links between
         FlashBlade arrays and are required for file system and bucket replication. Supports
         pipeline input, server-side filtering, and automatic pagination.
-    .PARAMETER Name
-        One or more array connection names to retrieve. Accepts pipeline input.
+
+        An array connection has no name of its own -- the API resource carries only an id. Its
+        human-readable identifier is the REMOTE array's name, so -RemoteName (aliased to -Name
+        for compatibility) is how you select one by name.
+    .PARAMETER RemoteName
+        One or more REMOTE array names whose connections to retrieve. Aliased to -Name. Accepts
+        pipeline input.
     .PARAMETER Id
-        One or more array connection IDs to retrieve.
+        One or more array connection IDs to retrieve. Accepts pipeline input by property name.
     .PARAMETER Filter
         A server-side filter expression to narrow results (e.g., "status='connected'").
     .PARAMETER Sort
@@ -24,9 +29,14 @@ function Get-PfbArrayConnection {
 
         Retrieves all array connections from the connected FlashBlade.
     .EXAMPLE
-        Get-PfbArrayConnection -Name "remote-fb-dc2"
+        Get-PfbArrayConnection -RemoteName "FB-B"
 
-        Retrieves the array connection named "remote-fb-dc2".
+        Retrieves the connection to the remote array named "FB-B".
+    .EXAMPLE
+        Get-PfbArrayConnection | Where-Object type -eq 'async-replication'
+
+        Retrieves only the asynchronous replication connections, excluding the
+        system-managed fleet-management ones.
     .EXAMPLE
         Get-PfbArrayConnection -Filter "status='connected'" -Sort "name" -Limit 10
 
@@ -34,25 +44,33 @@ function Get-PfbArrayConnection {
     #>
     [CmdletBinding(DefaultParameterSetName = 'List')]
     param(
-        [Parameter(ParameterSetName = 'ByName', ValueFromPipeline, ValueFromPipelineByPropertyName)] [string[]]$Name,
-        [Parameter(ParameterSetName = 'ById')] [string[]]$Id,
+        [Parameter(ParameterSetName = 'ByRemoteName', ValueFromPipeline, ValueFromPipelineByPropertyName)]
+        [Alias('Name')]
+        [string[]]$RemoteName,
+
+        [Parameter(ParameterSetName = 'ById', ValueFromPipelineByPropertyName)] [string[]]$Id,
         [Parameter()] [string]$Filter, [Parameter()] [string]$Sort, [Parameter()] [int]$Limit,
         [Parameter()] [PSCustomObject]$Array
     )
     begin {
         Assert-PfbConnection -Array ([ref]$Array)
-        $allNames = [System.Collections.Generic.List[string]]::new()
+        $allRemoteNames = [System.Collections.Generic.List[string]]::new()
         $allIds = [System.Collections.Generic.List[string]]::new()
     }
 
     process {
-        if ($Name) { foreach ($n in $Name) { $allNames.Add($n) } }
+        if ($RemoteName) { foreach ($n in $RemoteName) { $allRemoteNames.Add($n) } }
         if ($Id) { foreach ($i in $Id) { $allIds.Add($i) } }
     }
 
     end {
         $queryParams = @{}
-        Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
+        # remote_names is assigned inline rather than added to Add-PfbCommonQueryParams: it is a
+        # replication-family filter on 11 endpoints, not one of the ~148-endpoint common keys the
+        # helper centralizes, and the five other cmdlets in this module that emit it all do it
+        # inline too (issue #64). The comma-join is what the helper used to provide.
+        Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Ids $allIds
+        if ($allRemoteNames.Count) { $queryParams['remote_names'] = $allRemoteNames -join ',' }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'array-connections' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Replication/Get-PfbArrayConnection.ps1
+++ b/Public/Replication/Get-PfbArrayConnection.ps1
@@ -60,7 +60,12 @@ function Get-PfbArrayConnection {
     }
 
     process {
-        if ($RemoteName) { foreach ($n in $RemoteName) { $allRemoteNames.Add($n) } }
+        if ($RemoteName) {
+            foreach ($n in $RemoteName) {
+                Assert-PfbRemoteNameNotCoerced -Value $n
+                $allRemoteNames.Add($n)
+            }
+        }
         if ($Id) { foreach ($i in $Id) { $allIds.Add($i) } }
     }
 

--- a/Public/Replication/Get-PfbArrayConnectionPath.ps1
+++ b/Public/Replication/Get-PfbArrayConnectionPath.ps1
@@ -16,7 +16,8 @@ function Get-PfbArrayConnectionPath {
         A server-side filter expression to narrow results.
     .PARAMETER Sort
         Sort field and direction (e.g., "id" or "id-"). An array connection path has no name
-        field, so "name" is not a valid sort field here -- use "id", "status" or "type".
+        field, so "name" cannot sort it. The API publishes no enum of sortable fields -- use a
+        field the resource actually has, such as "id", "status" or "type".
     .PARAMETER Limit
         Maximum number of entries to return.
     .PARAMETER Array

--- a/Public/Replication/Get-PfbArrayConnectionPath.ps1
+++ b/Public/Replication/Get-PfbArrayConnectionPath.ps1
@@ -48,7 +48,16 @@ function Get-PfbArrayConnectionPath {
     }
 
     process {
-        if ($RemoteName) { foreach ($n in $RemoteName) { $allRemoteNames.Add($n) } }
+        if ($RemoteName) {
+            foreach ($n in $RemoteName) {
+                # This cmdlet has no -Id parameter, so a piped array-connection object falls
+                # through PowerShell's ByValue-with-coercion pass and gets ToString()-ed into
+                # -RemoteName (issue #64 follow-up). Fail here with an actionable message rather
+                # than sending remote_names=@{...} and letting the array reject it.
+                Assert-PfbRemoteNameNotCoerced -Value $n
+                $allRemoteNames.Add($n)
+            }
+        }
     }
 
     end {

--- a/Public/Replication/Get-PfbArrayConnectionPath.ps1
+++ b/Public/Replication/Get-PfbArrayConnectionPath.ps1
@@ -4,9 +4,14 @@ function Get-PfbArrayConnectionPath {
         Retrieves array connection path information from a FlashBlade array.
     .DESCRIPTION
         The Get-PfbArrayConnectionPath cmdlet returns network path information for array
-        connections on the connected Pure Storage FlashBlade.
-    .PARAMETER Name
-        One or more connection names to retrieve paths for. Accepts pipeline input.
+        connections on the connected Everpure FlashBlade.
+
+        An array connection has no name of its own -- the API resource carries only an id. Its
+        human-readable identifier is the REMOTE array's name, so -RemoteName (aliased to -Name
+        for compatibility) is how you select one by name.
+    .PARAMETER RemoteName
+        One or more REMOTE array names whose connection paths to retrieve. Aliased to -Name.
+        Accepts pipeline input.
     .PARAMETER Filter
         A server-side filter expression to narrow results.
     .PARAMETER Sort
@@ -20,9 +25,9 @@ function Get-PfbArrayConnectionPath {
 
         Retrieves all array connection paths from the connected FlashBlade.
     .EXAMPLE
-        Get-PfbArrayConnectionPath -Name "remote-fb-dc2"
+        Get-PfbArrayConnectionPath -RemoteName "FB-B"
 
-        Retrieves connection paths for the specified array connection.
+        Retrieves connection paths for the specified remote array.
     .EXAMPLE
         Get-PfbArrayConnectionPath -Limit 10
 
@@ -30,22 +35,30 @@ function Get-PfbArrayConnectionPath {
     #>
     [CmdletBinding()]
     param(
-        [Parameter(ValueFromPipeline, ValueFromPipelineByPropertyName)] [string[]]$Name,
+        [Parameter(ValueFromPipeline, ValueFromPipelineByPropertyName)]
+        [Alias('Name')]
+        [string[]]$RemoteName,
+
         [Parameter()] [string]$Filter, [Parameter()] [string]$Sort, [Parameter()] [int]$Limit,
         [Parameter()] [PSCustomObject]$Array
     )
     begin {
         Assert-PfbConnection -Array ([ref]$Array)
-        $allNames = [System.Collections.Generic.List[string]]::new()
+        $allRemoteNames = [System.Collections.Generic.List[string]]::new()
     }
 
     process {
-        if ($Name) { foreach ($n in $Name) { $allNames.Add($n) } }
+        if ($RemoteName) { foreach ($n in $RemoteName) { $allRemoteNames.Add($n) } }
     }
 
     end {
         $queryParams = @{}
-        Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames
+        # No -Names argument: GET /array-connections/path documents no names parameter in any
+        # spec version, and an unrecognised key is silently ignored rather than rejected, so the
+        # old call returned every path unfiltered (issue #64). remote_names is assigned inline
+        # for the reason given in Get-PfbArrayConnection.ps1.
+        Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters
+        if ($allRemoteNames.Count) { $queryParams['remote_names'] = $allRemoteNames -join ',' }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'array-connections/path' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Replication/Get-PfbArrayConnectionPath.ps1
+++ b/Public/Replication/Get-PfbArrayConnectionPath.ps1
@@ -15,7 +15,8 @@ function Get-PfbArrayConnectionPath {
     .PARAMETER Filter
         A server-side filter expression to narrow results.
     .PARAMETER Sort
-        Sort field and direction (e.g., "name" or "name-").
+        Sort field and direction (e.g., "id" or "id-"). An array connection path has no name
+        field, so "name" is not a valid sort field here -- use "id", "status" or "type".
     .PARAMETER Limit
         Maximum number of entries to return.
     .PARAMETER Array

--- a/Public/Replication/Get-PfbArrayConnectionPerformanceReplication.ps1
+++ b/Public/Replication/Get-PfbArrayConnectionPerformanceReplication.ps1
@@ -63,7 +63,14 @@ function Get-PfbArrayConnectionPerformanceReplication {
     }
 
     process {
-        if ($RemoteName) { foreach ($n in $RemoteName) { $allRemoteNames.Add($n) } }
+        if ($RemoteName) {
+            foreach ($n in $RemoteName) {
+                # No -Id parameter here either, so a piped object coerces into -RemoteName --
+                # see Get-PfbArrayConnectionPath.ps1 for the binding-pass explanation.
+                Assert-PfbRemoteNameNotCoerced -Value $n
+                $allRemoteNames.Add($n)
+            }
+        }
     }
 
     end {

--- a/Public/Replication/Get-PfbArrayConnectionPerformanceReplication.ps1
+++ b/Public/Replication/Get-PfbArrayConnectionPerformanceReplication.ps1
@@ -5,8 +5,13 @@ function Get-PfbArrayConnectionPerformanceReplication {
     .DESCRIPTION
         The Get-PfbArrayConnectionPerformanceReplication cmdlet returns replication performance
         metrics per array connection, including bytes sent/received and throughput.
-    .PARAMETER Name
-        One or more connection names to retrieve performance for. Accepts pipeline input.
+
+        An array connection has no name of its own -- the API resource carries only an id. Its
+        human-readable identifier is the REMOTE array's name, so -RemoteName (aliased to -Name
+        for compatibility) is how you select one by name.
+    .PARAMETER RemoteName
+        One or more REMOTE array names whose connection performance to retrieve. Aliased to -Name.
+        Accepts pipeline input.
     .PARAMETER Filter
         A server-side filter expression to narrow results.
     .PARAMETER Sort
@@ -29,9 +34,9 @@ function Get-PfbArrayConnectionPerformanceReplication {
 
         Retrieves current replication performance for all array connections.
     .EXAMPLE
-        Get-PfbArrayConnectionPerformanceReplication -Name "remote-fb-dc2" -Resolution 86400000
+        Get-PfbArrayConnectionPerformanceReplication -RemoteName "FB-B" -Resolution 86400000
 
-        Retrieves daily replication performance for the specified connection.
+        Retrieves daily replication performance for the specified remote array.
     .EXAMPLE
         Get-PfbArrayConnectionPerformanceReplication -StartTime 1609459200000 -EndTime 1609545600000
 
@@ -39,7 +44,10 @@ function Get-PfbArrayConnectionPerformanceReplication {
     #>
     [CmdletBinding()]
     param(
-        [Parameter(ValueFromPipeline, ValueFromPipelineByPropertyName)] [string[]]$Name,
+        [Parameter(ValueFromPipeline, ValueFromPipelineByPropertyName)]
+        [Alias('Name')]
+        [string[]]$RemoteName,
+
         [Parameter()] [string]$Filter, [Parameter()] [string]$Sort, [Parameter()] [int]$Limit,
         [Parameter()] [long]$StartTime,
         [Parameter()] [long]$EndTime,
@@ -51,16 +59,18 @@ function Get-PfbArrayConnectionPerformanceReplication {
     )
     begin {
         Assert-PfbConnection -Array ([ref]$Array)
-        $allNames = [System.Collections.Generic.List[string]]::new()
+        $allRemoteNames = [System.Collections.Generic.List[string]]::new()
     }
 
     process {
-        if ($Name) { foreach ($n in $Name) { $allNames.Add($n) } }
+        if ($RemoteName) { foreach ($n in $RemoteName) { $allRemoteNames.Add($n) } }
     }
 
     end {
         $queryParams = @{}
-        Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames
+        # No -Names argument, and remote_names assigned inline -- see Get-PfbArrayConnectionPath.ps1.
+        Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters
+        if ($allRemoteNames.Count) { $queryParams['remote_names'] = $allRemoteNames -join ',' }
         if ($StartTime) { $queryParams['start_time'] = $StartTime }
         if ($EndTime) { $queryParams['end_time'] = $EndTime }
         if ($Resolution) { $queryParams['resolution'] = $Resolution }

--- a/Public/Replication/Remove-PfbArrayConnection.ps1
+++ b/Public/Replication/Remove-PfbArrayConnection.ps1
@@ -54,6 +54,7 @@ function Remove-PfbArrayConnection {
     }
 
     process {
+        if ($RemoteName) { Assert-PfbRemoteNameNotCoerced -Value $RemoteName }
         $target = if ($RemoteName) { $RemoteName } else { $Id }
         $queryParams = @{}
         if ($RemoteName) { $queryParams['remote_names'] = $RemoteName }

--- a/Public/Replication/Remove-PfbArrayConnection.ps1
+++ b/Public/Replication/Remove-PfbArrayConnection.ps1
@@ -1,35 +1,52 @@
-function Remove-PfbArrayConnection {
+﻿function Remove-PfbArrayConnection {
     <#
     .SYNOPSIS
         Removes an array connection from a FlashBlade array.
     .DESCRIPTION
         The Remove-PfbArrayConnection cmdlet deletes a replication connection from the connected
-        Pure Storage FlashBlade. The target connection can be identified by name or ID. This
-        cmdlet has a high confirm impact and will prompt for confirmation by default. Removing
-        an array connection will prevent any associated replication from continuing.
-    .PARAMETER Name
-        The name of the array connection to remove. Accepts pipeline input.
+        Everpure FlashBlade. This cmdlet has a high confirm impact and will prompt for
+        confirmation by default. Removing an array connection will prevent any associated
+        replication from continuing.
+
+        An array connection has no name of its own -- the API resource carries only an id. Its
+        human-readable identifier is the REMOTE array's name, so -RemoteName (aliased to -Name
+        for compatibility) is how you select one by name.
+    .PARAMETER RemoteName
+        The name of the REMOTE array whose connection to remove. Aliased to -Name. Accepts
+        pipeline input.
     .PARAMETER Id
-        The ID of the array connection to remove.
+        The ID of the array connection to remove. Accepts pipeline input by property name.
     .PARAMETER Array
         The FlashBlade connection object. If not specified, the default connection is used.
     .EXAMPLE
-        Remove-PfbArrayConnection -Name "remote-fb-old"
+        Remove-PfbArrayConnection -RemoteName "FB-B"
 
-        Removes the array connection named "remote-fb-old" after prompting for confirmation.
+        Removes the connection to the remote array named "FB-B" after prompting for confirmation.
     .EXAMPLE
-        Remove-PfbArrayConnection -Name "remote-fb-test" -Confirm:$false
+        Remove-PfbArrayConnection -RemoteName "FB-B" -Confirm:$false
 
-        Removes the array connection named "remote-fb-test" without prompting.
+        Removes the connection without prompting.
     .EXAMPLE
-        Get-PfbArrayConnection -Filter "status='disconnected'" | Remove-PfbArrayConnection
+        Get-PfbArrayConnection | Where-Object status -eq 'disconnected' | Remove-PfbArrayConnection
 
-        Removes all disconnected array connections via pipeline input.
+        Removes all disconnected array connections, binding each one by its id through the
+        pipeline.
+    .EXAMPLE
+        Get-PfbArrayConnection |
+            Where-Object { $_.remote.id -eq '10314f42-020d-7080-8013-000133810cd0' } |
+            Remove-PfbArrayConnection
+
+        Selects a connection by the remote array's id. This cmdlet has no -RemoteId parameter,
+        and on the write endpoints remote_ids only narrows an already-scoped request, so filter
+        client-side and let the connection's own id bind through the pipeline.
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
     param(
-        [Parameter(ParameterSetName = 'ByName', Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)] [string]$Name,
-        [Parameter(ParameterSetName = 'ById', Mandatory)] [string]$Id,
+        [Parameter(ParameterSetName = 'ByRemoteName', Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)]
+        [Alias('Name')]
+        [string]$RemoteName,
+
+        [Parameter(ParameterSetName = 'ById', Mandatory, ValueFromPipelineByPropertyName)] [string]$Id,
         [Parameter()] [PSCustomObject]$Array
     )
     begin {
@@ -37,9 +54,9 @@ function Remove-PfbArrayConnection {
     }
 
     process {
-        $target = if ($Name) { $Name } else { $Id }
+        $target = if ($RemoteName) { $RemoteName } else { $Id }
         $queryParams = @{}
-        if ($Name) { $queryParams['names'] = $Name }
+        if ($RemoteName) { $queryParams['remote_names'] = $RemoteName }
         if ($Id) { $queryParams['ids'] = $Id }
         if ($PSCmdlet.ShouldProcess($target, 'Remove array connection')) {
             Invoke-PfbApiRequest -Array $Array -Method DELETE -Endpoint 'array-connections' -QueryParams $queryParams

--- a/Public/Replication/Remove-PfbArrayConnection.ps1
+++ b/Public/Replication/Remove-PfbArrayConnection.ps1
@@ -1,4 +1,4 @@
-﻿function Remove-PfbArrayConnection {
+function Remove-PfbArrayConnection {
     <#
     .SYNOPSIS
         Removes an array connection from a FlashBlade array.

--- a/Public/Replication/Update-PfbArrayConnection.ps1
+++ b/Public/Replication/Update-PfbArrayConnection.ps1
@@ -4,18 +4,24 @@ function Update-PfbArrayConnection {
         Updates an existing array connection on a FlashBlade array.
     .DESCRIPTION
         The Update-PfbArrayConnection cmdlet modifies attributes of an existing replication
-        connection on the connected Pure Storage FlashBlade. The target connection can be
-        identified by name or ID. Common updates include changing replication addresses and
-        connection throttling settings. Supports pipeline input and ShouldProcess.
+        connection on the connected Everpure FlashBlade. Common updates include changing
+        replication addresses and connection throttling settings. Supports pipeline input and
+        ShouldProcess.
+
+        An array connection has no name of its own -- the API resource carries only an id. Its
+        human-readable identifier is the REMOTE array's name, so -RemoteName (aliased to -Name
+        for compatibility) is how you select one by name.
 
         The individual typed parameters and the raw -Attributes hashtable are mutually
         exclusive: they live in separate parameter sets, so PowerShell rejects a mixed
         invocation at bind time rather than letting -Attributes silently override an
         explicitly supplied value.
-    .PARAMETER Name
-        The name of the array connection to update. Accepts pipeline input by property name.
+    .PARAMETER RemoteName
+        The name of the REMOTE array whose connection to update. Aliased to -Name. Accepts
+        pipeline input by property name.
     .PARAMETER Id
-        The ID of the array connection to update.
+        The ID of the array connection to update. Accepts pipeline input by property name, so
+        connection objects from Get-PfbArrayConnection can be piped in directly.
     .PARAMETER ManagementAddress
         Management address of the target array.
     .PARAMETER ReplicationAddresses
@@ -33,76 +39,89 @@ function Update-PfbArrayConnection {
         The bandwidth throttling for the array connection, as a hashtable -- for example
         @{ default_limit = 1073741824 }.
     .PARAMETER RemoteId
-        Performs the operation on the array connection with the specified remote array ID.
-    .PARAMETER RemoteName
-        Performs the operation on the array connection with the specified remote array name.
+        Narrows the operation to the array connection with the specified remote array ID. This
+        is an additional filter, not a selector: it cannot be used on its own, so combine it
+        with -RemoteName or -Id. To select purely by remote array ID, filter client-side -- see
+        the last example.
     .PARAMETER Attributes
         A hashtable of array connection attributes to modify. Mutually exclusive with the
         individual typed parameters above.
     .PARAMETER Array
         The FlashBlade connection object. If not specified, the default connection is used.
     .EXAMPLE
-        Update-PfbArrayConnection -Name "remote-fb-dc2" -Attributes @{ management_address = "10.0.2.101" }
+        Update-PfbArrayConnection -RemoteName "FB-B" -Attributes @{ management_address = "10.0.2.101" }
 
-        Updates the management address for the array connection named "remote-fb-dc2".
+        Updates the management address for the connection to the remote array named "FB-B".
     .EXAMPLE
-        Update-PfbArrayConnection -Name "remote-fb-dr" -Attributes @{ replication_addresses = @("10.0.3.101") }
+        Update-PfbArrayConnection -Id "10314f42-020d-7080-8013-000ddt400077" -ReplicationAddresses @("10.0.3.101")
 
-        Updates the replication address for the "remote-fb-dr" array connection.
+        Updates the replication address for the array connection identified by the specified ID.
     .EXAMPLE
-        Update-PfbArrayConnection -Id "10314f42-020d-7080-8013-000ddt400077" -Attributes @{ status = "connected" }
+        Update-PfbArrayConnection -RemoteName "FB-B" -ManagementAddress "10.0.2.101" -Encrypted $true
 
-        Updates the status of the array connection identified by the specified ID.
+        Updates the management address and encryption setting using typed parameters.
     .EXAMPLE
-        Update-PfbArrayConnection -Name "remote-fb-dc2" -ManagementAddress "10.0.2.101" -Encrypted $true -RemoteId "remote-1"
+        Get-PfbArrayConnection | Where-Object type -eq 'async-replication' |
+            Update-PfbArrayConnection -Throttle @{ default_limit = 1073741824 }
 
-        Updates the management address and encryption setting for "remote-fb-dc2" using typed
-        parameters, filtered to the connection whose remote array ID is "remote-1".
+        Throttles every asynchronous replication connection. The type filter is required, not
+        optional: fleet-management connections are managed by the system and reject writes.
+    .EXAMPLE
+        Get-PfbArrayConnection |
+            Where-Object { $_.remote.id -eq '10314f42-020d-7080-8013-000133810cd0' } |
+            Update-PfbArrayConnection -Throttle @{ default_limit = 1073741824 }
+
+        Selects a connection by the remote array's id. -RemoteId narrows a request that is
+        already scoped by -RemoteName or -Id; it cannot select on its own, so filter
+        client-side and let the connection's own id bind through the pipeline.
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium',
-                   DefaultParameterSetName = 'ByNameIndividual')]
+                   DefaultParameterSetName = 'ByRemoteNameIndividual')]
     param(
-        [Parameter(ParameterSetName = 'ByNameIndividual', Mandatory, ValueFromPipelineByPropertyName)]
-        [Parameter(ParameterSetName = 'ByNameAttributes',  Mandatory, ValueFromPipelineByPropertyName)]
-        [string]$Name,
+        [Parameter(ParameterSetName = 'ByRemoteNameIndividual', Mandatory, ValueFromPipelineByPropertyName)]
+        [Parameter(ParameterSetName = 'ByRemoteNameAttributes',  Mandatory, ValueFromPipelineByPropertyName)]
+        [Alias('Name')]
+        [string]$RemoteName,
 
-        [Parameter(ParameterSetName = 'ByIdIndividual', Mandatory)]
-        [Parameter(ParameterSetName = 'ByIdAttributes',  Mandatory)]
+        [Parameter(ParameterSetName = 'ByIdIndividual', Mandatory, ValueFromPipelineByPropertyName)]
+        [Parameter(ParameterSetName = 'ByIdAttributes',  Mandatory, ValueFromPipelineByPropertyName)]
         [string]$Id,
 
-        [Parameter(ParameterSetName = 'ByNameIndividual')]
+        [Parameter(ParameterSetName = 'ByRemoteNameIndividual')]
         [Parameter(ParameterSetName = 'ByIdIndividual')]
         [string]$ManagementAddress,
 
-        [Parameter(ParameterSetName = 'ByNameIndividual')]
+        [Parameter(ParameterSetName = 'ByRemoteNameIndividual')]
         [Parameter(ParameterSetName = 'ByIdIndividual')]
         [string[]]$ReplicationAddresses,
 
-        [Parameter(ParameterSetName = 'ByNameIndividual')]
+        [Parameter(ParameterSetName = 'ByRemoteNameIndividual')]
         [Parameter(ParameterSetName = 'ByIdIndividual')]
         [string]$CaCertificateGroup,
 
-        [Parameter(ParameterSetName = 'ByNameIndividual')]
+        [Parameter(ParameterSetName = 'ByRemoteNameIndividual')]
         [Parameter(ParameterSetName = 'ByIdIndividual')]
         [Nullable[bool]]$Encrypted,
 
-        [Parameter(ParameterSetName = 'ByNameIndividual')]
+        [Parameter(ParameterSetName = 'ByRemoteNameIndividual')]
         [Parameter(ParameterSetName = 'ByIdIndividual')]
         [string]$Remote,
 
-        [Parameter(ParameterSetName = 'ByNameIndividual')]
+        [Parameter(ParameterSetName = 'ByRemoteNameIndividual')]
         [Parameter(ParameterSetName = 'ByIdIndividual')]
         [hashtable]$Throttle,
 
-        [Parameter(ParameterSetName = 'ByNameAttributes', Mandatory)]
+        [Parameter(ParameterSetName = 'ByRemoteNameAttributes', Mandatory)]
         [Parameter(ParameterSetName = 'ByIdAttributes',   Mandatory)]
         [hashtable]$Attributes,
 
-        # Constraint 17: remote_ids/remote_names are orthogonal query filters, not body fields,
-        # so they are declared bare rather than added to the Individual parameter sets -- they
-        # must stay usable alongside -Attributes.
+        # Constraint 17: remote_ids is an orthogonal query FILTER, not a body field and not a
+        # selector, so it is declared bare rather than added to the Individual parameter sets --
+        # it must stay usable alongside -Attributes. remote_names used to live here too, but
+        # issue #64 promoted it into the by-name parameter sets: an array connection has no name
+        # of its own, so the remote array's name IS the selector. remote_ids remains a filter
+        # that narrows an already-selected request; see the .PARAMETER RemoteId help.
         [Parameter()] [string]$RemoteId,
-        [Parameter()] [string]$RemoteName,
 
         [Parameter()] [PSCustomObject]$Array
     )
@@ -112,10 +131,9 @@ function Update-PfbArrayConnection {
 
     process {
         $queryParams = @{}
-        if ($Name) { $queryParams['names'] = $Name }
+        if ($RemoteName) { $queryParams['remote_names'] = $RemoteName }
         if ($Id) { $queryParams['ids'] = $Id }
-        if ($PSBoundParameters.ContainsKey('RemoteId'))   { $queryParams['remote_ids']   = $RemoteId }
-        if ($PSBoundParameters.ContainsKey('RemoteName')) { $queryParams['remote_names'] = $RemoteName }
+        if ($PSBoundParameters.ContainsKey('RemoteId')) { $queryParams['remote_ids'] = $RemoteId }
 
         if ($PSCmdlet.ParameterSetName -like '*Attributes') {
             $body = $Attributes
@@ -138,7 +156,7 @@ function Update-PfbArrayConnection {
             if ($PSBoundParameters.ContainsKey('Throttle'))           { $body['throttle'] = $Throttle }
         }
 
-        $target = if ($Name) { $Name } else { $Id }
+        $target = if ($RemoteName) { $RemoteName } else { $Id }
         if ($PSCmdlet.ShouldProcess($target, 'Update array connection')) {
             Invoke-PfbApiRequest -Array $Array -Method PATCH -Endpoint 'array-connections' -Body $body -QueryParams $queryParams
         }

--- a/Reports/PfbApiDriftReport.json
+++ b/Reports/PfbApiDriftReport.json
@@ -559,8 +559,7 @@
       ],
       "missingQueryParameters": [
         "context_names",
-        "remote_ids",
-        "remote_names"
+        "remote_ids"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -2301,8 +2300,7 @@
       "missingQueryParameters": [
         "allow_errors",
         "context_names",
-        "remote_ids",
-        "remote_names"
+        "remote_ids"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -2341,8 +2339,7 @@
         "allow_errors",
         "context_names",
         "ids",
-        "remote_ids",
-        "remote_names"
+        "remote_ids"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -2362,7 +2359,6 @@
       "missingQueryParameters": [
         "ids",
         "remote_ids",
-        "remote_names",
         "total_only"
       ],
       "missingBodyProperties": [],
@@ -14875,28 +14871,6 @@
       "annotations": []
     },
     {
-      "name": "remote_names",
-      "endpointCount": 13,
-      "queryEndpointCount": 13,
-      "bodyEndpointCount": 0,
-      "endpoints": [
-        "DELETE /array-connections",
-        "DELETE /file-system-replica-links/policies",
-        "DELETE /file-system-snapshots/transfer",
-        "DELETE /policies/file-system-replica-links",
-        "GET /array-connections",
-        "GET /array-connections/path",
-        "GET /array-connections/performance/replication",
-        "GET /bucket-replica-links",
-        "GET /file-system-replica-links",
-        "GET /file-system-replica-links/policies",
-        "GET /file-system-replica-links/transfer",
-        "GET /policies-all/members",
-        "GET /policies/file-system-replica-links"
-      ],
-      "annotations": []
-    },
-    {
       "name": "policy_names",
       "endpointCount": 11,
       "queryEndpointCount": 11,
@@ -14931,6 +14905,24 @@
         "GET /usage/groups",
         "GET /usage/users",
         "POST /quotas/groups"
+      ],
+      "annotations": []
+    },
+    {
+      "name": "remote_names",
+      "endpointCount": 9,
+      "queryEndpointCount": 9,
+      "bodyEndpointCount": 0,
+      "endpoints": [
+        "DELETE /file-system-replica-links/policies",
+        "DELETE /file-system-snapshots/transfer",
+        "DELETE /policies/file-system-replica-links",
+        "GET /bucket-replica-links",
+        "GET /file-system-replica-links",
+        "GET /file-system-replica-links/policies",
+        "GET /file-system-replica-links/transfer",
+        "GET /policies-all/members",
+        "GET /policies/file-system-replica-links"
       ],
       "annotations": []
     },
@@ -17521,7 +17513,7 @@
   "conventionStrength": [
     {
       "name": "names",
-      "cmdletCount": 314,
+      "cmdletCount": 308,
       "cmdlets": [
         "Get-PfbActiveDirectory",
         "Get-PfbAdmin",
@@ -17530,10 +17522,7 @@
         "Get-PfbAlertWatcher",
         "Get-PfbApiClient",
         "Get-PfbApiToken",
-        "Get-PfbArrayConnection",
         "Get-PfbArrayConnectionKey",
-        "Get-PfbArrayConnectionPath",
-        "Get-PfbArrayConnectionPerformanceReplication",
         "Get-PfbAsyncLog",
         "Get-PfbAsyncLogDownload",
         "Get-PfbAudit",
@@ -17695,7 +17684,6 @@
         "Remove-PfbAlertWatcher",
         "Remove-PfbApiClient",
         "Remove-PfbApiToken",
-        "Remove-PfbArrayConnection",
         "Remove-PfbAuditFileSystemPolicy",
         "Remove-PfbAuditObjectStorePolicy",
         "Remove-PfbBucket",
@@ -17776,8 +17764,6 @@
         "Update-PfbAlert",
         "Update-PfbAlertWatcher",
         "Update-PfbApiClient",
-        "Update-PfbArrayConnection",
-        "Update-PfbAsyncLog",
         "Update-PfbAuditFileSystemPolicy",
         "Update-PfbAuditObjectStorePolicy",
         "Update-PfbBucket",
@@ -17841,7 +17827,7 @@
     },
     {
       "name": "ids",
-      "cmdletCount": 224,
+      "cmdletCount": 223,
       "cmdlets": [
         "Get-PfbAdmin",
         "Get-PfbAdminCache",
@@ -18015,7 +18001,6 @@
         "Update-PfbAlertWatcher",
         "Update-PfbApiClient",
         "Update-PfbArrayConnection",
-        "Update-PfbAsyncLog",
         "Update-PfbAuditFileSystemPolicy",
         "Update-PfbAuditObjectStorePolicy",
         "Update-PfbBucket",
@@ -19287,6 +19272,21 @@
       ]
     },
     {
+      "name": "remote_names",
+      "cmdletCount": 9,
+      "cmdlets": [
+        "Get-PfbArrayConnection",
+        "Get-PfbArrayConnectionPath",
+        "Get-PfbArrayConnectionPerformanceReplication",
+        "New-PfbFileSystemReplicaLink",
+        "New-PfbFileSystemReplicaLinkPolicy",
+        "New-PfbPolicyFileSystemReplicaLink",
+        "Remove-PfbArrayConnection",
+        "Remove-PfbFileSystemReplicaLink",
+        "Update-PfbArrayConnection"
+      ]
+    },
+    {
       "name": "location",
       "cmdletCount": 8,
       "cmdlets": [
@@ -19357,17 +19357,6 @@
         "New-PfbFileSystemReplicaLinkPolicy",
         "New-PfbPolicyFileSystemReplicaLink",
         "Remove-PfbFileSystemReplicaLink"
-      ]
-    },
-    {
-      "name": "remote_names",
-      "cmdletCount": 5,
-      "cmdlets": [
-        "New-PfbFileSystemReplicaLink",
-        "New-PfbFileSystemReplicaLinkPolicy",
-        "New-PfbPolicyFileSystemReplicaLink",
-        "Remove-PfbFileSystemReplicaLink",
-        "Update-PfbArrayConnection"
       ]
     },
     {

--- a/Reports/PfbApiDriftReport.md
+++ b/Reports/PfbApiDriftReport.md
@@ -23,7 +23,7 @@ This report accepts **false positives in order to eliminate false negatives**. A
 - Uncovered endpoints: 96
 - Endpoints with parameter gaps: 438
 - Missing body properties (addable): 422
-- Missing query parameters (addable): 956
+- Missing query parameters (addable): 952
 - Read-only body fields (not addable -- see the Read-only fields section below): 382
 - Phantom fields silently excluded (accumulated in the capability map, absent from the newest analysed spec): 40
 - Partial-confidence endpoints (see `How to read this report` above, and each row's marker in the Parameter gaps table): 59
@@ -45,8 +45,8 @@ Showing the top 25 of 252 findings by endpoint count -- the full list is in the 
 |---|---|---|---|---|---|
 | `context_names` | 270 | 270 | 0 | 0 | not yet implemented |
 | `allow_errors` | 118 | 118 | 0 | 0 | not yet implemented |
-| `ids` | 43 | 43 | 0 | 224 |  |
-| `names` | 31 | 31 | 0 | 314 |  |
+| `ids` | 43 | 43 | 0 | 223 |  |
+| `names` | 31 | 31 | 0 | 308 |  |
 | `sort` | 28 | 28 | 0 | 180 |  |
 | `bucket_ids` | 17 | 17 | 0 | 2 |  |
 | `policy_ids` | 17 | 17 | 0 | 98 |  |
@@ -54,9 +54,9 @@ Showing the top 25 of 252 findings by endpoint count -- the full list is in the 
 | `bucket_names` | 16 | 16 | 0 | 3 |  |
 | `member_ids` | 15 | 15 | 0 | 85 |  |
 | `remote_ids` | 15 | 15 | 0 | 3 |  |
-| `remote_names` | 13 | 13 | 0 | 5 |  |
 | `policy_names` | 11 | 11 | 0 | 118 |  |
 | `file_system_ids` | 9 | 9 | 0 | 9 |  |
+| `remote_names` | 9 | 9 | 0 | 9 |  |
 | `local_file_system_ids` | 8 | 8 | 0 | 2 |  |
 | `actions` | 7 | 0 | 7 | 2 |  |
 | `limit` | 7 | 7 | 0 | 199 |  |
@@ -80,7 +80,7 @@ Endpoints an existing cmdlet already calls, where the capability map knows of a 
 | `DELETE /admins/cache` | Remove-PfbAdminCache | context_names |  | `high` |  |
 | `DELETE /admins/management-access-policies` | Remove-PfbAdminManagementAccessPolicy | context_names |  | `high` | POST/PATCH/DELETE return 403 regardless of account; not an implementation bug |
 | `DELETE /admins/ssh-certificate-authority-policies` | Remove-PfbAdminSshCaPolicy | context_names |  | `high` |  |
-| `DELETE /array-connections` | Remove-PfbArrayConnection | context_names, remote_ids, remote_names |  | `high` |  |
+| `DELETE /array-connections` | Remove-PfbArrayConnection | context_names, remote_ids |  | `high` |  |
 | `DELETE /arrays/ssh-certificate-authority-policies` | Remove-PfbArraySshCaPolicy | context_names |  | `high` |  |
 | `DELETE /audit-file-systems-policies` | Remove-PfbAuditFileSystemPolicy | context_names |  | `high` |  |
 | `DELETE /audit-file-systems-policies/members` | Remove-PfbAuditFileSystemPolicyMember | context_names |  | `high` |  |
@@ -166,10 +166,10 @@ Endpoints an existing cmdlet already calls, where the capability map knows of a 
 | `GET /admins/management-access-policies` | Get-PfbAdminManagementAccessPolicy | allow_errors, context_names, sort |  | `high` | POST/PATCH/DELETE return 403 regardless of account; not an implementation bug |
 | `GET /admins/ssh-certificate-authority-policies` | Get-PfbAdminSshCaPolicy | allow_errors, context_names, sort |  | `high` |  |
 | `GET /alert-watchers/test` | Test-PfbAlertWatcher | filter, sort |  | `high` |  |
-| `GET /array-connections` | Get-PfbArrayConnection | allow_errors, context_names, remote_ids, remote_names |  | `high` |  |
+| `GET /array-connections` | Get-PfbArrayConnection | allow_errors, context_names, remote_ids |  | `high` |  |
 | `GET /array-connections/connection-key` | Get-PfbArrayConnectionKey | ids |  | `high` |  |
-| `GET /array-connections/path` | Get-PfbArrayConnectionPath | allow_errors, context_names, ids, remote_ids, remote_names |  | `high` |  |
-| `GET /array-connections/performance/replication` | Get-PfbArrayConnectionPerformanceReplication | ids, remote_ids, remote_names, total_only |  | `high` |  |
+| `GET /array-connections/path` | Get-PfbArrayConnectionPath | allow_errors, context_names, ids, remote_ids |  | `high` |  |
+| `GET /array-connections/performance/replication` | Get-PfbArrayConnectionPerformanceReplication | ids, remote_ids, total_only |  | `high` |  |
 | `GET /arrays` | Get-PfbArray, Test-PfbConnection | allow_errors, context_names |  | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
 | `GET /arrays/clients/performance` | Get-PfbArrayClientPerformance | names, protocol, total_only |  | `high` |  |
 | `GET /arrays/clients/s3-specific-performance` | Get-PfbArrayClientS3Performance | names, total_only |  | `high` |  |

--- a/Reports/PfbFieldCmdletMap.json
+++ b/Reports/PfbFieldCmdletMap.json
@@ -724,8 +724,8 @@
     },
     {
       "cmdlet": "Get-PfbArrayConnection",
-      "parameter": "Name",
-      "wireName": "names",
+      "parameter": "RemoteName",
+      "wireName": "remote_names",
       "status": "no-spec-enum-found",
       "matchedKey": null,
       "specValues": null,
@@ -804,8 +804,8 @@
     },
     {
       "cmdlet": "Get-PfbArrayConnectionPath",
-      "parameter": "Name",
-      "wireName": "names",
+      "parameter": "RemoteName",
+      "wireName": "remote_names",
       "status": "no-spec-enum-found",
       "matchedKey": null,
       "specValues": null,
@@ -854,8 +854,8 @@
     },
     {
       "cmdlet": "Get-PfbArrayConnectionPerformanceReplication",
-      "parameter": "Name",
-      "wireName": "names",
+      "parameter": "RemoteName",
+      "wireName": "remote_names",
       "status": "no-spec-enum-found",
       "matchedKey": null,
       "specValues": null,
@@ -14229,8 +14229,8 @@
     },
     {
       "cmdlet": "Remove-PfbArrayConnection",
-      "parameter": "Name",
-      "wireName": "names",
+      "parameter": "RemoteName",
+      "wireName": "remote_names",
       "status": "no-spec-enum-found",
       "matchedKey": null,
       "specValues": null,
@@ -17179,16 +17179,6 @@
     },
     {
       "cmdlet": "Update-PfbArrayConnection",
-      "parameter": "Name",
-      "wireName": "names",
-      "status": "no-spec-enum-found",
-      "matchedKey": null,
-      "specValues": null,
-      "stableSinceOldestVersion": null,
-      "recommendation": null
-    },
-    {
-      "cmdlet": "Update-PfbArrayConnection",
       "parameter": "Remote",
       "wireName": "remote",
       "status": "no-spec-enum-found",
@@ -17251,26 +17241,6 @@
       "cmdlet": "Update-PfbAsyncLog",
       "parameter": "HardwareComponents",
       "wireName": "hardware_components",
-      "status": "no-spec-enum-found",
-      "matchedKey": null,
-      "specValues": null,
-      "stableSinceOldestVersion": null,
-      "recommendation": null
-    },
-    {
-      "cmdlet": "Update-PfbAsyncLog",
-      "parameter": "Id",
-      "wireName": "ids",
-      "status": "no-spec-enum-found",
-      "matchedKey": null,
-      "specValues": null,
-      "stableSinceOldestVersion": null,
-      "recommendation": null
-    },
-    {
-      "cmdlet": "Update-PfbAsyncLog",
-      "parameter": "Name",
-      "wireName": "names",
       "status": "no-spec-enum-found",
       "matchedKey": null,
       "specValues": null,

--- a/Reports/PfbFieldCmdletMapping.md
+++ b/Reports/PfbFieldCmdletMapping.md
@@ -9,7 +9,7 @@ Reporting only -- no `Public/` cmdlet is edited by this script. Every `matched` 
 - matched: 1
 - collision: 1
 - not-found-in-resource: 29
-- no-spec-enum-found: 1984
+- no-spec-enum-found: 1981
 
 | Cmdlet | Parameter | Wire name | Status | Spec values | Recommendation |
 |---|---|---|---|---|---|

--- a/Tests/Get-PfbArrayConnection.Tests.ps1
+++ b/Tests/Get-PfbArrayConnection.Tests.ps1
@@ -69,6 +69,22 @@ Describe 'Get-PfbArrayConnection - selector query keys (#64)' {
         }
     }
 
+    It 'binds -RemoteName by property name from a user-built object' {
+        [pscustomobject]@{ RemoteName = 'FB-B' } | Get-PfbArrayConnection -Array $fakeArray
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['remote_names'] -eq 'FB-B' -and -not $QueryParams.ContainsKey('ids')
+        }
+    }
+
+    It 'binds by property name through the Name alias' {
+        [pscustomobject]@{ Name = 'FB-B' } | Get-PfbArrayConnection -Array $fakeArray
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['remote_names'] -eq 'FB-B' -and -not $QueryParams.ContainsKey('ids')
+        }
+    }
+
     It 'still routes filter/sort/limit through the common helper' {
         Get-PfbArrayConnection -Filter "status='connected'" -Sort 'name' -Limit 10 -Array $fakeArray
 

--- a/Tests/Get-PfbArrayConnection.Tests.ps1
+++ b/Tests/Get-PfbArrayConnection.Tests.ps1
@@ -86,11 +86,11 @@ Describe 'Get-PfbArrayConnection - selector query keys (#64)' {
     }
 
     It 'still routes filter/sort/limit through the common helper' {
-        Get-PfbArrayConnection -Filter "status='connected'" -Sort 'name' -Limit 10 -Array $fakeArray
+        Get-PfbArrayConnection -Filter "status='connected'" -Sort 'id' -Limit 10 -Array $fakeArray
 
         Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
             $QueryParams['filter'] -eq "status='connected'" -and
-            $QueryParams['sort'] -eq 'name' -and $QueryParams['limit'] -eq 10
+            $QueryParams['sort'] -eq 'id' -and $QueryParams['limit'] -eq 10
         }
     }
 

--- a/Tests/Get-PfbArrayConnection.Tests.ps1
+++ b/Tests/Get-PfbArrayConnection.Tests.ps1
@@ -85,6 +85,16 @@ Describe 'Get-PfbArrayConnection - selector query keys (#64)' {
         }
     }
 
+    It 'rejects a piped object that carries no id/name property instead of stringifying it' {
+        # -Id absorbs a real connection object at binding pass 2. An object without id, name or
+        # remoteName falls through to pass 3 and is ToString()-ed into -RemoteName, so the guard
+        # is reachable here too.
+        {
+            [PSCustomObject]@{ status = 'connected'; type = 'async-replication' } |
+                Get-PfbArrayConnection -Array $fakeArray
+        } | Should -Throw -ExpectedMessage '*stringified object*'
+    }
+
     It 'still routes filter/sort/limit through the common helper' {
         Get-PfbArrayConnection -Filter "status='connected'" -Sort 'id' -Limit 10 -Array $fakeArray
 

--- a/Tests/Get-PfbArrayConnection.Tests.ps1
+++ b/Tests/Get-PfbArrayConnection.Tests.ps1
@@ -1,0 +1,89 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    $moduleRoot = Split-Path -Parent $PSScriptRoot
+    $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
+    Import-Module $manifest -Force
+
+    $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
+}
+
+Describe 'Get-PfbArrayConnection - selector query keys (#64)' {
+
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+    }
+
+    It 'sends remote_names, never names' {
+        Get-PfbArrayConnection -RemoteName 'FB-B' -Array $fakeArray
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'GET' -and $Endpoint -eq 'array-connections' -and
+            $QueryParams['remote_names'] -eq 'FB-B' -and -not $QueryParams.ContainsKey('names')
+        }
+    }
+
+    It 'still binds -Name through the alias, and emits remote_names for it' {
+        Get-PfbArrayConnection -Name 'FB-B' -Array $fakeArray
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['remote_names'] -eq 'FB-B' -and -not $QueryParams.ContainsKey('names')
+        }
+    }
+
+    It 'declares Name as an alias of -RemoteName' {
+        (Get-Command Get-PfbArrayConnection).Parameters['RemoteName'].Aliases | Should -Contain 'Name'
+    }
+
+    It 'comma-joins multiple remote names into one key' {
+        Get-PfbArrayConnection -RemoteName 'FB-B','FB-C' -Array $fakeArray
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['remote_names'] -eq 'FB-B,FB-C'
+        }
+    }
+
+    It 'accumulates remote names piped by value into a single request' {
+        'FB-B','FB-C' | Get-PfbArrayConnection -Array $fakeArray
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['remote_names'] -eq 'FB-B,FB-C'
+        }
+    }
+
+    It 'sends ids when -Id is used, and no remote_names' {
+        Get-PfbArrayConnection -Id 'conn-1','conn-2' -Array $fakeArray
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['ids'] -eq 'conn-1,conn-2' -and -not $QueryParams.ContainsKey('remote_names')
+        }
+    }
+
+    It 'binds piped connection objects by id' {
+        @([PSCustomObject]@{ id = 'conn-1' }, [PSCustomObject]@{ id = 'conn-2' }) |
+            Get-PfbArrayConnection -Array $fakeArray
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['ids'] -eq 'conn-1,conn-2' -and -not $QueryParams.ContainsKey('remote_names')
+        }
+    }
+
+    It 'still routes filter/sort/limit through the common helper' {
+        Get-PfbArrayConnection -Filter "status='connected'" -Sort 'name' -Limit 10 -Array $fakeArray
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['filter'] -eq "status='connected'" -and
+            $QueryParams['sort'] -eq 'name' -and $QueryParams['limit'] -eq 10
+        }
+    }
+
+    It 'sends no selector key at all when listing everything' {
+        Get-PfbArrayConnection -Array $fakeArray
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            -not $QueryParams.ContainsKey('remote_names') -and
+            -not $QueryParams.ContainsKey('names') -and -not $QueryParams.ContainsKey('ids')
+        }
+    }
+}

--- a/Tests/Get-PfbArrayConnectionPath.Tests.ps1
+++ b/Tests/Get-PfbArrayConnectionPath.Tests.ps1
@@ -44,6 +44,22 @@ Describe 'Get-PfbArrayConnectionPath - selector query keys (#64)' {
         }
     }
 
+    It 'binds -RemoteName by property name from a user-built object' {
+        [pscustomobject]@{ RemoteName = 'FB-B' } | Get-PfbArrayConnectionPath -Array $fakeArray
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['remote_names'] -eq 'FB-B'
+        }
+    }
+
+    It 'binds by property name through the Name alias' {
+        [pscustomobject]@{ Name = 'FB-B' } | Get-PfbArrayConnectionPath -Array $fakeArray
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['remote_names'] -eq 'FB-B'
+        }
+    }
+
     It 'does NOT coerce a piped object into -RemoteName (binding-order guard)' {
         $global:pfbCapturedRemoteNames = $null
         Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest {

--- a/Tests/Get-PfbArrayConnectionPath.Tests.ps1
+++ b/Tests/Get-PfbArrayConnectionPath.Tests.ps1
@@ -80,11 +80,11 @@ Describe 'Get-PfbArrayConnectionPath - selector query keys (#64)' {
     }
 
     It 'still routes filter/sort/limit through the common helper' {
-        Get-PfbArrayConnectionPath -Filter "status='connected'" -Sort 'name' -Limit 5 -Array $fakeArray
+        Get-PfbArrayConnectionPath -Filter "status='connected'" -Sort 'id' -Limit 5 -Array $fakeArray
 
         Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
             $QueryParams['filter'] -eq "status='connected'" -and
-            $QueryParams['sort'] -eq 'name' -and $QueryParams['limit'] -eq 5
+            $QueryParams['sort'] -eq 'id' -and $QueryParams['limit'] -eq 5
         }
     }
 

--- a/Tests/Get-PfbArrayConnectionPath.Tests.ps1
+++ b/Tests/Get-PfbArrayConnectionPath.Tests.ps1
@@ -44,6 +44,25 @@ Describe 'Get-PfbArrayConnectionPath - selector query keys (#64)' {
         }
     }
 
+    It 'does NOT coerce a piped object into -RemoteName (binding-order guard)' {
+        $global:pfbCapturedRemoteNames = $null
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest {
+            $global:pfbCapturedRemoteNames = $QueryParams['remote_names']
+        }
+
+        {
+            [PSCustomObject]@{
+                id     = '10314f42-aaaa'
+                status = 'connected'
+                remote = [PSCustomObject]@{ id = 'r-1'; name = 'FB-B' }
+            } | Get-PfbArrayConnectionPath -Array $fakeArray
+        } | Should -Throw -ExpectedMessage '*stringified object*'
+
+        $captured = $global:pfbCapturedRemoteNames
+        Remove-Variable -Name pfbCapturedRemoteNames -Scope Global -ErrorAction SilentlyContinue
+        $captured | Should -Not -BeLike '*@{*' -Because 'a whole piped object must not be stringified onto the remote_names filter'
+    }
+
     It 'still routes filter/sort/limit through the common helper' {
         Get-PfbArrayConnectionPath -Filter "status='connected'" -Sort 'name' -Limit 5 -Array $fakeArray
 

--- a/Tests/Get-PfbArrayConnectionPath.Tests.ps1
+++ b/Tests/Get-PfbArrayConnectionPath.Tests.ps1
@@ -61,11 +61,6 @@ Describe 'Get-PfbArrayConnectionPath - selector query keys (#64)' {
     }
 
     It 'does NOT coerce a piped object into -RemoteName (binding-order guard)' {
-        $global:pfbCapturedRemoteNames = $null
-        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest {
-            $global:pfbCapturedRemoteNames = $QueryParams['remote_names']
-        }
-
         {
             [PSCustomObject]@{
                 id     = '10314f42-aaaa'
@@ -74,9 +69,8 @@ Describe 'Get-PfbArrayConnectionPath - selector query keys (#64)' {
             } | Get-PfbArrayConnectionPath -Array $fakeArray
         } | Should -Throw -ExpectedMessage '*stringified object*'
 
-        $captured = $global:pfbCapturedRemoteNames
-        Remove-Variable -Name pfbCapturedRemoteNames -Scope Global -ErrorAction SilentlyContinue
-        $captured | Should -Not -BeLike '*@{*' -Because 'a whole piped object must not be stringified onto the remote_names filter'
+        # The throw is terminating, so the end block never runs and no request is issued at all.
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 0 -Exactly
     }
 
     It 'still routes filter/sort/limit through the common helper' {

--- a/Tests/Get-PfbArrayConnectionPath.Tests.ps1
+++ b/Tests/Get-PfbArrayConnectionPath.Tests.ps1
@@ -1,0 +1,63 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    $moduleRoot = Split-Path -Parent $PSScriptRoot
+    $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
+    Import-Module $manifest -Force
+
+    $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
+}
+
+Describe 'Get-PfbArrayConnectionPath - selector query keys (#64)' {
+
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+    }
+
+    It 'sends remote_names, never names' {
+        Get-PfbArrayConnectionPath -RemoteName 'FB-B' -Array $fakeArray
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'GET' -and $Endpoint -eq 'array-connections/path' -and
+            $QueryParams['remote_names'] -eq 'FB-B' -and -not $QueryParams.ContainsKey('names')
+        }
+    }
+
+    It 'still binds -Name through the alias, and emits remote_names for it' {
+        Get-PfbArrayConnectionPath -Name 'FB-B' -Array $fakeArray
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['remote_names'] -eq 'FB-B' -and -not $QueryParams.ContainsKey('names')
+        }
+    }
+
+    It 'declares Name as an alias of -RemoteName' {
+        (Get-Command Get-PfbArrayConnectionPath).Parameters['RemoteName'].Aliases | Should -Contain 'Name'
+    }
+
+    It 'accumulates remote names piped by value into a single comma-joined key' {
+        'FB-B','FB-C' | Get-PfbArrayConnectionPath -Array $fakeArray
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['remote_names'] -eq 'FB-B,FB-C'
+        }
+    }
+
+    It 'still routes filter/sort/limit through the common helper' {
+        Get-PfbArrayConnectionPath -Filter "status='connected'" -Sort 'name' -Limit 5 -Array $fakeArray
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['filter'] -eq "status='connected'" -and
+            $QueryParams['sort'] -eq 'name' -and $QueryParams['limit'] -eq 5
+        }
+    }
+
+    It 'sends no selector key at all when listing everything' {
+        Get-PfbArrayConnectionPath -Array $fakeArray
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            -not $QueryParams.ContainsKey('remote_names') -and -not $QueryParams.ContainsKey('names')
+        }
+    }
+}

--- a/Tests/Get-PfbArrayConnectionPerformanceReplication.Tests.ps1
+++ b/Tests/Get-PfbArrayConnectionPerformanceReplication.Tests.ps1
@@ -62,6 +62,22 @@ Describe 'Get-PfbArrayConnectionPerformanceReplication' {
         }
     }
 
+    It 'binds -RemoteName by property name from a user-built object' {
+        [pscustomobject]@{ RemoteName = 'FB-B' } | Get-PfbArrayConnectionPerformanceReplication -Array $fakeArray
+
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['remote_names'] -eq 'FB-B'
+        }
+    }
+
+    It 'binds by property name through the Name alias' {
+        [pscustomobject]@{ Name = 'FB-B' } | Get-PfbArrayConnectionPerformanceReplication -Array $fakeArray
+
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['remote_names'] -eq 'FB-B'
+        }
+    }
+
     It 'does NOT coerce a piped object into -RemoteName (binding-order guard)' {
         $global:pfbCapturedRemoteNames = $null
         Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest {

--- a/Tests/Get-PfbArrayConnectionPerformanceReplication.Tests.ps1
+++ b/Tests/Get-PfbArrayConnectionPerformanceReplication.Tests.ps1
@@ -79,11 +79,6 @@ Describe 'Get-PfbArrayConnectionPerformanceReplication' {
     }
 
     It 'does NOT coerce a piped object into -RemoteName (binding-order guard)' {
-        $global:pfbCapturedRemoteNames = $null
-        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest {
-            $global:pfbCapturedRemoteNames = $QueryParams['remote_names']
-        }
-
         {
             [PSCustomObject]@{
                 id     = '10314f42-aaaa'
@@ -92,9 +87,8 @@ Describe 'Get-PfbArrayConnectionPerformanceReplication' {
             } | Get-PfbArrayConnectionPerformanceReplication -Array $fakeArray
         } | Should -Throw -ExpectedMessage '*stringified object*'
 
-        $captured = $global:pfbCapturedRemoteNames
-        Remove-Variable -Name pfbCapturedRemoteNames -Scope Global -ErrorAction SilentlyContinue
-        $captured | Should -Not -BeLike '*@{*' -Because 'a whole piped object must not be stringified onto the remote_names filter'
+        # The throw is terminating, so the end block never runs and no request is issued at all.
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 0 -Exactly
     }
 
     It 'keeps remote_names alongside the time-range keys' {

--- a/Tests/Get-PfbArrayConnectionPerformanceReplication.Tests.ps1
+++ b/Tests/Get-PfbArrayConnectionPerformanceReplication.Tests.ps1
@@ -36,4 +36,31 @@ Describe 'Get-PfbArrayConnectionPerformanceReplication' {
             -not $QueryParams.ContainsKey('type')
         }
     }
+
+    It 'sends remote_names, never names' {
+        Get-PfbArrayConnectionPerformanceReplication -RemoteName 'FB-B' -Array $fakeArray
+
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            $Endpoint -eq 'array-connections/performance/replication' -and
+            $QueryParams['remote_names'] -eq 'FB-B' -and -not $QueryParams.ContainsKey('names')
+        }
+    }
+
+    It 'still binds -Name through the alias, and emits remote_names for it' {
+        Get-PfbArrayConnectionPerformanceReplication -Name 'FB-B' -Array $fakeArray
+
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['remote_names'] -eq 'FB-B' -and -not $QueryParams.ContainsKey('names')
+        }
+    }
+
+    It 'keeps remote_names alongside the time-range keys' {
+        Get-PfbArrayConnectionPerformanceReplication -RemoteName 'FB-B' -Resolution 86400000 `
+            -StartTime 1609459200000 -Array $fakeArray
+
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['remote_names'] -eq 'FB-B' -and
+            $QueryParams['resolution'] -eq 86400000 -and $QueryParams['start_time'] -eq 1609459200000
+        }
+    }
 }

--- a/Tests/Get-PfbArrayConnectionPerformanceReplication.Tests.ps1
+++ b/Tests/Get-PfbArrayConnectionPerformanceReplication.Tests.ps1
@@ -54,6 +54,33 @@ Describe 'Get-PfbArrayConnectionPerformanceReplication' {
         }
     }
 
+    It 'accumulates remote names piped by value into a single comma-joined key' {
+        'FB-B','FB-C' | Get-PfbArrayConnectionPerformanceReplication -Array $fakeArray
+
+        Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['remote_names'] -eq 'FB-B,FB-C'
+        }
+    }
+
+    It 'does NOT coerce a piped object into -RemoteName (binding-order guard)' {
+        $global:pfbCapturedRemoteNames = $null
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest {
+            $global:pfbCapturedRemoteNames = $QueryParams['remote_names']
+        }
+
+        {
+            [PSCustomObject]@{
+                id     = '10314f42-aaaa'
+                status = 'connected'
+                remote = [PSCustomObject]@{ id = 'r-1'; name = 'FB-B' }
+            } | Get-PfbArrayConnectionPerformanceReplication -Array $fakeArray
+        } | Should -Throw -ExpectedMessage '*stringified object*'
+
+        $captured = $global:pfbCapturedRemoteNames
+        Remove-Variable -Name pfbCapturedRemoteNames -Scope Global -ErrorAction SilentlyContinue
+        $captured | Should -Not -BeLike '*@{*' -Because 'a whole piped object must not be stringified onto the remote_names filter'
+    }
+
     It 'keeps remote_names alongside the time-range keys' {
         Get-PfbArrayConnectionPerformanceReplication -RemoteName 'FB-B' -Resolution 86400000 `
             -StartTime 1609459200000 -Array $fakeArray

--- a/Tests/Remove-PfbArrayConnection.Tests.ps1
+++ b/Tests/Remove-PfbArrayConnection.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
 
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot

--- a/Tests/Remove-PfbArrayConnection.Tests.ps1
+++ b/Tests/Remove-PfbArrayConnection.Tests.ps1
@@ -1,0 +1,78 @@
+﻿#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    $moduleRoot = Split-Path -Parent $PSScriptRoot
+    $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
+    Import-Module $manifest -Force
+
+    $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
+}
+
+Describe 'Remove-PfbArrayConnection - selector query keys (#64)' {
+
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+    }
+
+    It 'sends remote_names, never names' {
+        Remove-PfbArrayConnection -RemoteName 'FB-B' -Confirm:$false -Array $fakeArray
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'DELETE' -and $Endpoint -eq 'array-connections' -and
+            $QueryParams['remote_names'] -eq 'FB-B' -and -not $QueryParams.ContainsKey('names')
+        }
+    }
+
+    It 'still binds -Name through the alias, and emits remote_names for it' {
+        Remove-PfbArrayConnection -Name 'FB-B' -Confirm:$false -Array $fakeArray
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['remote_names'] -eq 'FB-B' -and -not $QueryParams.ContainsKey('names')
+        }
+    }
+
+    It 'declares Name as an alias of -RemoteName' {
+        (Get-Command Remove-PfbArrayConnection).Parameters['RemoteName'].Aliases | Should -Contain 'Name'
+    }
+
+    It 'targets the connection by id when -Id is used' {
+        Remove-PfbArrayConnection -Id 'conn-1' -Confirm:$false -Array $fakeArray
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['ids'] -eq 'conn-1' -and -not $QueryParams.ContainsKey('remote_names')
+        }
+    }
+
+    It 'binds a piped connection object by id' {
+        [PSCustomObject]@{ id = 'conn-9' } |
+            Remove-PfbArrayConnection -Confirm:$false -Array $fakeArray
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['ids'] -eq 'conn-9'
+        }
+    }
+
+    It 'does NOT coerce a piped object into -RemoteName (binding-order guard)' {
+        [PSCustomObject]@{ id = 'conn-9' } |
+            Remove-PfbArrayConnection -Confirm:$false -Array $fakeArray
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            -not $QueryParams.ContainsKey('remote_names') -and $QueryParams['ids'] -notlike '*@{*'
+        }
+    }
+
+    It 'still accepts a bare remote name piped by value' {
+        'FB-B' | Remove-PfbArrayConnection -Confirm:$false -Array $fakeArray
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['remote_names'] -eq 'FB-B'
+        }
+    }
+
+    It 'makes no API call when ShouldProcess is declined via -WhatIf' {
+        Remove-PfbArrayConnection -RemoteName 'FB-B' -WhatIf -Array $fakeArray
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 0 -Exactly
+    }
+}

--- a/Tests/Remove-PfbArrayConnection.Tests.ps1
+++ b/Tests/Remove-PfbArrayConnection.Tests.ps1
@@ -62,12 +62,40 @@ Describe 'Remove-PfbArrayConnection - selector query keys (#64)' {
         }
     }
 
+    It 'binds -RemoteName by property name from a user-built object' {
+        [pscustomobject]@{ RemoteName = 'FB-B' } |
+            Remove-PfbArrayConnection -Confirm:$false -Array $fakeArray
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['remote_names'] -eq 'FB-B' -and -not $QueryParams.ContainsKey('ids')
+        }
+    }
+
+    It 'binds by property name through the Name alias' {
+        [pscustomobject]@{ Name = 'FB-B' } |
+            Remove-PfbArrayConnection -Confirm:$false -Array $fakeArray
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['remote_names'] -eq 'FB-B' -and -not $QueryParams.ContainsKey('ids')
+        }
+    }
+
     It 'still accepts a bare remote name piped by value' {
         'FB-B' | Remove-PfbArrayConnection -Confirm:$false -Array $fakeArray
 
         Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
             $QueryParams['remote_names'] -eq 'FB-B'
         }
+    }
+
+    It 'rejects a piped object that carries no id/name property instead of stringifying it' {
+        # -Id absorbs a real connection object at binding pass 2. An object without id, name or
+        # remoteName falls through to pass 3 and is ToString()-ed into -RemoteName, so the guard
+        # is reachable here too -- and this cmdlet is a DELETE.
+        {
+            [PSCustomObject]@{ status = 'connected'; type = 'async-replication' } |
+                Remove-PfbArrayConnection -Confirm:$false -Array $fakeArray
+        } | Should -Throw -ExpectedMessage '*stringified object*'
     }
 
     It 'makes no API call when ShouldProcess is declined via -WhatIf' {

--- a/Tests/Update-PfbArrayConnection.Tests.ps1
+++ b/Tests/Update-PfbArrayConnection.Tests.ps1
@@ -200,6 +200,28 @@ Describe 'Update-PfbArrayConnection - typed body parameters (#31)' {
         }
     }
 
+    Context 'issue #64 -- pipeline binding by property name on -RemoteName' {
+        It 'binds -RemoteName by property name from a user-built object' {
+            [pscustomobject]@{ RemoteName = 'FB-B' } |
+                Update-PfbArrayConnection -Throttle @{ default_limit = 1073741824 } `
+                    -Confirm:$false -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                $QueryParams['remote_names'] -eq 'FB-B' -and -not $QueryParams.ContainsKey('ids')
+            }
+        }
+
+        It 'binds by property name through the Name alias' {
+            [pscustomobject]@{ Name = 'FB-B' } |
+                Update-PfbArrayConnection -Throttle @{ default_limit = 1073741824 } `
+                    -Confirm:$false -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                $QueryParams['remote_names'] -eq 'FB-B' -and -not $QueryParams.ContainsKey('ids')
+            }
+        }
+    }
+
     Context 'issue #64 -- pipeline binding on -Id' {
         It 'binds a piped connection object by id' {
             [PSCustomObject]@{ id = 'conn-9' } |

--- a/Tests/Update-PfbArrayConnection.Tests.ps1
+++ b/Tests/Update-PfbArrayConnection.Tests.ps1
@@ -17,18 +17,18 @@ Describe 'Update-PfbArrayConnection - typed body parameters (#31)' {
 
     Context 'typed parameters build the body' {
         It 'sends management_address as a body field' {
-            Update-PfbArrayConnection -Name 'remote-fb-dc2' -ManagementAddress '10.0.2.101' `
+            Update-PfbArrayConnection -RemoteName 'remote-fb-dc2' -ManagementAddress '10.0.2.101' `
                 -Confirm:$false -Array $fakeArray
 
             Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
                 $Method -eq 'PATCH' -and $Endpoint -eq 'array-connections' -and
-                $QueryParams['names'] -eq 'remote-fb-dc2' -and
+                $QueryParams['remote_names'] -eq 'remote-fb-dc2' -and
                 $Body['management_address'] -eq '10.0.2.101'
             }
         }
 
         It 'sends replication_addresses as an array (constraint 7 shape 2)' {
-            Update-PfbArrayConnection -Name 'remote-fb-dr' -ReplicationAddresses '10.0.3.101','10.0.3.102' `
+            Update-PfbArrayConnection -RemoteName 'remote-fb-dr' -ReplicationAddresses '10.0.3.101','10.0.3.102' `
                 -Confirm:$false -Array $fakeArray
 
             Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
@@ -38,7 +38,7 @@ Describe 'Update-PfbArrayConnection - typed body parameters (#31)' {
         }
 
         It 'sends an EMPTY array for -ReplicationAddresses @() so the list can be cleared' {
-            Update-PfbArrayConnection -Name 'remote-fb-dr' -ReplicationAddresses @() `
+            Update-PfbArrayConnection -RemoteName 'remote-fb-dr' -ReplicationAddresses @() `
                 -Confirm:$false -Array $fakeArray
 
             Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
@@ -48,7 +48,7 @@ Describe 'Update-PfbArrayConnection - typed body parameters (#31)' {
         }
 
         It 'sends an explicit -Encrypted:$false (ContainsKey semantics, not truthiness)' {
-            Update-PfbArrayConnection -Name 'remote-fb-dc2' -Encrypted $false -Confirm:$false -Array $fakeArray
+            Update-PfbArrayConnection -RemoteName 'remote-fb-dc2' -Encrypted $false -Confirm:$false -Array $fakeArray
 
             Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
                 $Body.ContainsKey('encrypted') -and $Body['encrypted'] -eq $false
@@ -56,7 +56,7 @@ Describe 'Update-PfbArrayConnection - typed body parameters (#31)' {
         }
 
         It 'omits encrypted entirely when not supplied' {
-            Update-PfbArrayConnection -Name 'remote-fb-dc2' -ManagementAddress '10.0.2.101' `
+            Update-PfbArrayConnection -RemoteName 'remote-fb-dc2' -ManagementAddress '10.0.2.101' `
                 -Confirm:$false -Array $fakeArray
 
             Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
@@ -65,7 +65,7 @@ Describe 'Update-PfbArrayConnection - typed body parameters (#31)' {
         }
 
         It 'builds ca_certificate_group as a name-reference object (constraint 8a)' {
-            Update-PfbArrayConnection -Name 'remote-fb-dc2' -CaCertificateGroup 'my-certs' `
+            Update-PfbArrayConnection -RemoteName 'remote-fb-dc2' -CaCertificateGroup 'my-certs' `
                 -Confirm:$false -Array $fakeArray
 
             Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
@@ -74,7 +74,7 @@ Describe 'Update-PfbArrayConnection - typed body parameters (#31)' {
         }
 
         It 'builds remote as a name-reference object (constraint 8a)' {
-            Update-PfbArrayConnection -Name 'remote-fb-dc2' -Remote 'remote-fb' `
+            Update-PfbArrayConnection -RemoteName 'remote-fb-dc2' -Remote 'remote-fb' `
                 -Confirm:$false -Array $fakeArray
 
             Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
@@ -83,7 +83,7 @@ Describe 'Update-PfbArrayConnection - typed body parameters (#31)' {
         }
 
         It 'passes throttle straight through as a composite hashtable (constraint 8c)' {
-            Update-PfbArrayConnection -Name 'remote-fb-dc2' -Throttle @{ window_limit = 2097152 } `
+            Update-PfbArrayConnection -RemoteName 'remote-fb-dc2' -Throttle @{ window_limit = 2097152 } `
                 -Confirm:$false -Array $fakeArray
 
             Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
@@ -92,7 +92,7 @@ Describe 'Update-PfbArrayConnection - typed body parameters (#31)' {
         }
 
         It 'omits every body key when no typed body parameter is supplied' {
-            Update-PfbArrayConnection -Name 'remote-fb-dc2' -Confirm:$false -Array $fakeArray
+            Update-PfbArrayConnection -RemoteName 'remote-fb-dc2' -Confirm:$false -Array $fakeArray
 
             Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
                 $Body.Count -eq 0
@@ -110,7 +110,7 @@ Describe 'Update-PfbArrayConnection - typed body parameters (#31)' {
 
     Context 'new query parameters (constraint 17 -- declared bare, not in the Individual sets)' {
         It 'sends remote_ids as a bare query parameter alongside -Attributes' {
-            Update-PfbArrayConnection -Name 'remote-fb-dc2' -Attributes @{ management_address = '10.0.2.101' } `
+            Update-PfbArrayConnection -RemoteName 'remote-fb-dc2' -Attributes @{ management_address = '10.0.2.101' } `
                 -RemoteId 'remote-1' -Confirm:$false -Array $fakeArray
 
             Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
@@ -118,27 +118,28 @@ Describe 'Update-PfbArrayConnection - typed body parameters (#31)' {
             }
         }
 
-        It 'sends remote_names as a bare query parameter alongside a typed parameter' {
-            Update-PfbArrayConnection -Name 'remote-fb-dc2' -ManagementAddress '10.0.2.101' `
-                -RemoteName 'remote-array' -Confirm:$false -Array $fakeArray
+        It 'still sends remote_ids alongside -RemoteName, which is now the selector' {
+            Update-PfbArrayConnection -RemoteName 'remote-fb-dc2' -ManagementAddress '10.0.2.101' `
+                -RemoteId 'remote-1' -Confirm:$false -Array $fakeArray
 
             Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
-                $QueryParams['remote_names'] -eq 'remote-array'
+                $QueryParams['remote_names'] -eq 'remote-fb-dc2' -and
+                $QueryParams['remote_ids'] -eq 'remote-1'
             }
         }
 
-        It 'omits remote_ids/remote_names entirely when not supplied' {
-            Update-PfbArrayConnection -Name 'remote-fb-dc2' -Confirm:$false -Array $fakeArray
+        It 'omits remote_ids entirely when not supplied' {
+            Update-PfbArrayConnection -RemoteName 'remote-fb-dc2' -Confirm:$false -Array $fakeArray
 
             Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
-                -not $QueryParams.ContainsKey('remote_ids') -and -not $QueryParams.ContainsKey('remote_names')
+                -not $QueryParams.ContainsKey('remote_ids')
             }
         }
     }
 
     Context '-Attributes remains supported and is mutually exclusive' {
         It 'still sends a raw -Attributes body' {
-            Update-PfbArrayConnection -Name 'remote-fb-dc2' -Attributes @{ management_address = '10.0.2.101' } `
+            Update-PfbArrayConnection -RemoteName 'remote-fb-dc2' -Attributes @{ management_address = '10.0.2.101' } `
                 -Confirm:$false -Array $fakeArray
 
             Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
@@ -147,7 +148,7 @@ Describe 'Update-PfbArrayConnection - typed body parameters (#31)' {
         }
 
         It 'rejects -Attributes combined with a typed parameter at bind time' {
-            { Update-PfbArrayConnection -Name 'remote-fb-dc2' -ManagementAddress '10.0.2.101' `
+            { Update-PfbArrayConnection -RemoteName 'remote-fb-dc2' -ManagementAddress '10.0.2.101' `
                 -Attributes @{ management_address = 'y' } -Confirm:$false -Array $fakeArray -ErrorAction Stop } |
                 Should -Throw -ExpectedMessage '*Parameter set cannot be resolved*'
         }
@@ -167,6 +168,69 @@ Describe 'Update-PfbArrayConnection - typed body parameters (#31)' {
             $attrs = (Get-Command Update-PfbArrayConnection).Parameters[$Parameter].Attributes
             @($attrs | Where-Object { $_ -is [System.Management.Automation.ValidateSetAttribute] }).Count |
                 Should -Be 0
+        }
+    }
+
+    Context 'issue #64 -- the dead `names` key is gone' {
+        It 'sends remote_names, never names' {
+            Update-PfbArrayConnection -RemoteName 'FB-B' -ManagementAddress '10.0.2.101' `
+                -Confirm:$false -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                $QueryParams['remote_names'] -eq 'FB-B' -and -not $QueryParams.ContainsKey('names')
+            }
+        }
+
+        It 'still binds -Name through the alias, and emits remote_names for it' {
+            Update-PfbArrayConnection -Name 'FB-B' -ManagementAddress '10.0.2.101' `
+                -Confirm:$false -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                $QueryParams['remote_names'] -eq 'FB-B' -and -not $QueryParams.ContainsKey('names')
+            }
+        }
+
+        It 'declares Name as an alias of -RemoteName' {
+            (Get-Command Update-PfbArrayConnection).Parameters['RemoteName'].Aliases |
+                Should -Contain 'Name'
+        }
+
+        It 'no longer declares a -Name parameter of its own' {
+            (Get-Command Update-PfbArrayConnection).Parameters.Keys | Should -Not -Contain 'Name'
+        }
+    }
+
+    Context 'issue #64 -- pipeline binding on -Id' {
+        It 'binds a piped connection object by id' {
+            [PSCustomObject]@{ id = 'conn-9' } |
+                Update-PfbArrayConnection -Throttle @{ default_limit = 1073741824 } `
+                    -Confirm:$false -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                $QueryParams['ids'] -eq 'conn-9'
+            }
+        }
+
+        It 'does NOT coerce a piped object into -RemoteName (binding-order guard)' {
+            [PSCustomObject]@{ id = 'conn-9' } |
+                Update-PfbArrayConnection -Throttle @{ default_limit = 1073741824 } `
+                    -Confirm:$false -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                -not $QueryParams.ContainsKey('remote_names') -and
+                $QueryParams['ids'] -notlike '*@{*'
+            }
+        }
+
+        It 'processes each of several piped connections individually' {
+            @([PSCustomObject]@{ id = 'conn-1' }, [PSCustomObject]@{ id = 'conn-2' }) |
+                Update-PfbArrayConnection -Throttle @{ default_limit = 1 } `
+                    -Confirm:$false -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 2 -Exactly
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                $QueryParams['ids'] -eq 'conn-2'
+            }
         }
     }
 }

--- a/Tests/Update-PfbAsyncLog.Tests.ps1
+++ b/Tests/Update-PfbAsyncLog.Tests.ps1
@@ -17,19 +17,18 @@ Describe 'Update-PfbAsyncLog - typed body parameters (#31)' {
 
     Context 'typed parameters build the body' {
         It 'sends end_time and start_time as body fields' {
-            Update-PfbAsyncLog -Name 'log-job-1' -StartTime 1700000000000 -EndTime 1700003600000 `
+            Update-PfbAsyncLog -StartTime 1700000000000 -EndTime 1700003600000 `
                 -Confirm:$false -Array $fakeArray
 
             Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
                 $Method -eq 'PATCH' -and $Endpoint -eq 'logs-async' -and
-                $QueryParams['names'] -eq 'log-job-1' -and
                 $Body['start_time'] -eq 1700000000000 -and
                 $Body['end_time'] -eq 1700003600000
             }
         }
 
         It 'sends an explicit -StartTime 0 rather than dropping it (constraint 2, integer field)' {
-            Update-PfbAsyncLog -Name 'log-job-1' -StartTime 0 -Confirm:$false -Array $fakeArray
+            Update-PfbAsyncLog -StartTime 0 -Confirm:$false -Array $fakeArray
 
             Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
                 $Body.ContainsKey('start_time') -and $Body['start_time'] -eq 0
@@ -37,7 +36,7 @@ Describe 'Update-PfbAsyncLog - typed body parameters (#31)' {
         }
 
         It 'sends an explicit -EndTime 0 rather than dropping it (constraint 2, integer field)' {
-            Update-PfbAsyncLog -Name 'log-job-1' -EndTime 0 -Confirm:$false -Array $fakeArray
+            Update-PfbAsyncLog -EndTime 0 -Confirm:$false -Array $fakeArray
 
             Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
                 $Body.ContainsKey('end_time') -and $Body['end_time'] -eq 0
@@ -45,7 +44,7 @@ Describe 'Update-PfbAsyncLog - typed body parameters (#31)' {
         }
 
         It 'builds hardware_components as name-reference objects' {
-            Update-PfbAsyncLog -Name 'log-job-1' -HardwareComponents 'CH1.FB1','CH1.FB2' `
+            Update-PfbAsyncLog -HardwareComponents 'CH1.FB1','CH1.FB2' `
                 -Confirm:$false -Array $fakeArray
 
             Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
@@ -56,7 +55,7 @@ Describe 'Update-PfbAsyncLog - typed body parameters (#31)' {
         }
 
         It 'sends an EMPTY array for -HardwareComponents @() so the list can be cleared' {
-            Update-PfbAsyncLog -Name 'log-job-1' -HardwareComponents @() -Confirm:$false -Array $fakeArray
+            Update-PfbAsyncLog -HardwareComponents @() -Confirm:$false -Array $fakeArray
 
             Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
                 $Body.ContainsKey('hardware_components') -and
@@ -65,34 +64,27 @@ Describe 'Update-PfbAsyncLog - typed body parameters (#31)' {
         }
 
         It 'omits every body key when no typed body parameter is supplied' {
-            Update-PfbAsyncLog -Name 'log-job-1' -Confirm:$false -Array $fakeArray
+            Update-PfbAsyncLog -Confirm:$false -Array $fakeArray
 
             Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
                 $Body.Count -eq 0
             }
         }
 
-        It 'targets the job by id when -Id is used' {
-            Update-PfbAsyncLog -Id 'log-1' -StartTime 1 -Confirm:$false -Array $fakeArray
-
-            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
-                $QueryParams['ids'] -eq 'log-1' -and -not $QueryParams.ContainsKey('names')
-            }
-        }
     }
 
     Context '-Attributes remains supported and is mutually exclusive' {
         It 'still sends a raw -Attributes body' {
-            Update-PfbAsyncLog -Name 'log-job-1' -Attributes @{ status = 'cancelled' } `
+            Update-PfbAsyncLog -Attributes @{ start_time = 1700000000000 } `
                 -Confirm:$false -Array $fakeArray
 
             Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
-                $Body['status'] -eq 'cancelled'
+                $Body['start_time'] -eq 1700000000000
             }
         }
 
         It 'rejects -Attributes combined with a typed parameter at bind time' {
-            { Update-PfbAsyncLog -Name 'log-job-1' -StartTime 1 -Attributes @{ status = 'cancelled' } `
+            { Update-PfbAsyncLog -StartTime 1 -Attributes @{ start_time = 2 } `
                 -Confirm:$false -Array $fakeArray -ErrorAction Stop } |
                 Should -Throw -ExpectedMessage '*Parameter set cannot be resolved*'
         }
@@ -114,6 +106,28 @@ Describe 'Update-PfbAsyncLog - typed body parameters (#31)' {
             foreach ($ro in 'AvailableFiles','LastRequestTime','Processing','Progress') {
                 $keys | Should -Not -Contain $ro
             }
+        }
+    }
+
+    Context 'issue #64 -- the endpoint takes no query parameters' {
+        It 'sends no query parameters at all' {
+            Update-PfbAsyncLog -StartTime 1700000000000 -Confirm:$false -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                $Method -eq 'PATCH' -and $Endpoint -eq 'logs-async' -and
+                ($null -eq $QueryParams -or $QueryParams.Count -eq 0)
+            }
+        }
+
+        It 'exposes neither -Name nor -Id, which had no endpoint support to bind to' {
+            $keys = (Get-Command Update-PfbAsyncLog).Parameters.Keys
+            $keys | Should -Not -Contain 'Name'
+            $keys | Should -Not -Contain 'Id'
+        }
+
+        It 'collapses to exactly two parameter sets' {
+            (Get-Command Update-PfbAsyncLog).ParameterSets.Name | Sort-Object |
+                Should -Be @('Attributes', 'Individual')
         }
     }
 }

--- a/Tests/Update-PfbAsyncLog.Tests.ps1
+++ b/Tests/Update-PfbAsyncLog.Tests.ps1
@@ -70,7 +70,6 @@ Describe 'Update-PfbAsyncLog - typed body parameters (#31)' {
                 $Body.Count -eq 0
             }
         }
-
     }
 
     Context '-Attributes remains supported and is mutually exclusive' {
@@ -103,7 +102,11 @@ Describe 'Update-PfbAsyncLog - typed body parameters (#31)' {
 
         It 'does not expose any of the 6 read-only fields as parameters (constraint 11)' {
             $keys = (Get-Command Update-PfbAsyncLog).Parameters.Keys
-            foreach ($ro in 'AvailableFiles','LastRequestTime','Processing','Progress') {
+            # All six are readOnly on LogsAsync in every cached spec version (verified 2.9 and
+            # 2.26): available_files, id, last_request_time, name, processing, progress. Id and
+            # Name were previously omitted from this loop only because they were parameters;
+            # issue #64 removed them, so the loop can now cover the full read-only set.
+            foreach ($ro in 'AvailableFiles','Id','LastRequestTime','Name','Processing','Progress') {
                 $keys | Should -Not -Contain $ro
             }
         }


### PR DESCRIPTION
Fixes #64.

Six cmdlets sent a `names=` query key to endpoints that do not accept one. A FlashBlade **silently ignores** an unrecognised query key on a read, so `-Name` looked like it worked and filtered nothing — every call returned the full, unfiltered set. On the write cmdlets the same dead key meant the selector never reached the array.

`ArrayConnection` has no `name` field in **any** spec version 2.0 through 2.28. Its human-readable identifier is `remote.name`, matched on the wire by `remote_names=`.

## What changed

| Cmdlet | Change |
|---|---|
| `Get-PfbArrayConnection` | `-Name` → `-RemoteName`, emits `remote_names=` |
| `Get-PfbArrayConnectionPath` | same |
| `Get-PfbArrayConnectionPerformanceReplication` | same |
| `Remove-PfbArrayConnection` | same |
| `Update-PfbArrayConnection` | redundant `-Name`/`-RemoteName` pair collapsed onto `-RemoteName` |
| `Update-PfbAsyncLog` | `-Name`/`-Id` removed outright |

`[Alias('Name')]` is on all five array-connection cmdlets, so `-Name` keeps binding. Reads take `[string[]]` (the endpoints accept a multi-value filter); writes take `[string]` (one connection per request, and there is no per-object error reporting to make a batch safe).

`Private/Add-PfbCommonQueryParams.ps1` is deliberately **not** modified. It centralises the six genuinely universal query params, and `names` alone appears on 148 endpoints; `remote_names` appears on ~11 and is a replication-family filter, not a common one. Adding it there would hand a meaningless parameter to 200+ callers. Five cmdlets already emit `remote_names` inline today, so these follow the established convention rather than inventing one.

`Reports/` is regenerated by `tools/Build-PfbFieldCmdletMap.ps1` and `tools/Build-PfbApiDriftReport.ps1`. No hand edits — re-running both generators against the committed tree leaves `git status` empty.

## ⚠️ Breaking change (one, and the issue text understated it)

**`Update-PfbArrayConnection -Name X -RemoteName Y` is now a parameter-binding error.**

```
Cannot bind parameter because parameter 'RemoteName' is specified more than once.
```

This needs care, because the callers it affects are exactly the ones whose scripts were **actually working**. At base the cmdlet had *both* `[string]$Name` (Mandatory in its parameter sets, emitting the dead `names=`) and `[string]$RemoteName` (emitting the live `remote_names=`). Since `-Name` satisfied the Mandatory requirement while `-RemoteName` did the real filtering, passing **both** was the only way to genuinely update by remote name. That was not hypothetical — it was covered by a test in this repo (`Tests/Update-PfbArrayConnection.Tests.ps1:121-128` before this branch).

Migration: drop the now-redundant argument.

```powershell
# before (the only form that actually filtered)
Update-PfbArrayConnection -Name 'remote-fb-dc2' -RemoteName 'remote-array' -ManagementAddress '10.0.2.101'
# after
Update-PfbArrayConnection -RemoteName 'remote-array' -ManagementAddress '10.0.2.101'
```

`-Id <id> -RemoteName <name>` was also accepted at base and is now a parameter-set resolution failure. Same fix: pass one selector.

`-Name`-only callers are unaffected — the alias covers them.

## Other behaviour changes worth knowing about

**A nonexistent remote name now throws instead of returning empty.** Live-measured:

```
FlashBlade API error: Array connection does not exist.
```

That is the array's own response to a `remote_names` value it cannot resolve, not something this change introduces. Previously the key was ignored, so the same call returned every connection.

**`Get-PfbArrayConnection | Get-PfbArrayConnectionPath` now raises a guard error** where it previously returned everything unfiltered. This is the one genuinely new failure mode here, and it is deliberate.

PowerShell resolves pipeline binding in three passes: ByValue-no-coercion → ByPropertyName-no-coercion → ByValue-**with**-coercion. A piped connection object binds on `id` at pass 2 for cmdlets that have an `-Id` parameter. `Get-PfbArrayConnectionPath` and `Get-PfbArrayConnectionPerformanceReplication` have no `-Id` at all, so the object falls to pass 3 and is `ToString()`-ed whole into `[string[]]$RemoteName`:

```
remote_names=@{id=10314f42-aaaa; status=connected; remote=}
```

Under the old dead key that was silently ignored and the pipeline appeared to work. Now `remote_names` is live, so `Private/Assert-PfbRemoteNameNotCoerced.ps1` rejects it at the module boundary with the extraction recipe, rather than letting a garbage filter reach the array:

```powershell
Get-PfbArrayConnection | Select-Object -ExpandProperty remote |
    Select-Object -ExpandProperty name | Get-PfbArrayConnectionPath
```

The guard is on the four cmdlets that declare `ValueFromPipeline` on `-RemoteName`, and deliberately **not** on `Update-PfbArrayConnection`, where neither parameter declares it, pass-3 coercion is unreachable, and the guard would be dead code.

It is called imperatively rather than as `[ValidateScript({ ... })]`, which looks inconsistent with `Assert-PfbSafeName` and is not. A `ValidateScript` failure on a *pipeline-bound* argument is non-terminating and per-item: PowerShell drops the item and still runs the `end` block. Since these cmdlets accumulate in `process` and emit in `end`, the dropped item would leave the accumulator empty and the request would go out with **no `remote_names` key at all** — a silently unfiltered read, i.e. the exact bug this PR fixes. The declarative form was implemented, measured, and reverted; `Should -Invoke -Times 0 -Exactly` in both guard tests now pins that down so it is not re-attempted. `Assert-PfbSafeName`'s call sites don't hit this because their value arrives as a direct argument, which terminates the whole invocation.

**`Update-PfbAsyncLog` loses `-Name`/`-Id` with no replacement** — the one removal here with no alias behind it. `PATCH /logs-async` has no selector query param of any kind, so there was nothing to redirect them to; they never did anything. Its test now covers all six `readOnly` fields rather than four (`available_files`, `id`, `last_request_time`, `name`, `processing`, `progress` — identical in every cached spec from 2.4 to 2.28).

**`-Sort` docstrings** now name `id` instead of `name`. `name` was never a valid sort field on either resource, since neither schema has it. The new wording claims only that the named fields **exist** on the resource — `components.parameters.Sort` carries no enum (just `pattern: ^[a-z]+(_[a-z]+)*-?`), so nothing is spec-certified as sortable and it would be wrong to imply otherwise. `Get-PfbArrayConnectionPerformanceReplication`'s `-Sort "time"` is untouched and correct.

## Testing

108 tests across the six affected files, passing on **both** Windows PowerShell 5.1 and pwsh 7 (Pester 6.0.1).

Every cmdlet gets a wire-key rail asserting `remote_names` is present **and** `names` is absent, plus a rail asserting `-Name` still binds through the alias. The negative assertion is wire-level rather than vacuous: `Invoke-PfbApiRequest` declares `[hashtable]$QueryParams`, so the parameter is `$null` only when genuinely omitted.

### Live verification against a FlashBlade (REST 2.26)

Mocked tests verify the request a cmdlet *intended* to build, not the one the array accepts, which is how this class of bug shipped in the first place. The read path was measured against a real array. It has four array connections — two to one remote, two to another — so a correct filter yields a **partial** set, which an ignored key cannot imitate:

| Call | Result |
|---|---|
| `Get-PfbArrayConnection` unfiltered | 4 |
| `Get-PfbArrayConnection -RemoteName <remote>` | **4 → 2** |
| `Get-PfbArrayConnectionPath -RemoteName <remote>` | **8 → 4** |
| `Get-PfbArrayConnectionPerformanceReplication -RemoteName <remote>` | **2 → 1** |
| `-Name <remote>` (alias) | identical to `-RemoteName` on all three |

Measured at `fc028de`; the two later fix rounds changed only guards, tests and docstrings, not query construction.

### What was *not* live-tested, and why

Being explicit so this doesn't read as an oversight:

- **`Update-PfbArrayConnection` and `Update-PfbAsyncLog`** — covered by mocked wire-key rails plus a direct `PATCH /array-connections` probe that measured the endpoint's filter-required guard (`remote_names=<name>` vs the dead `names=<name>` vs no query at all). Not exercised through the cmdlets, because doing so means mutating a live array connection or triggering log preparation on a lab array whose replication links are in use.
- **`Remove-PfbArrayConnection`** — behaviour is **inferred from the PATCH probe, not measured**. `DELETE /array-connections` cannot be exercised safely on an array carrying real connections; an unfiltered call would tear all of them down. That blast radius is the same reason the unfiltered-selector risk in #64 is worth fixing.

## Note on scope

No version bump and no CHANGELOG entry, per the maintainer's call on those being separate decisions.

**Correcting something I said in the issue thread.** I wrote there that `Get-*` → `Update-*` chaining "cannot work regardless of this fix" because the response carries no `name` or top-level `remote_name`. That conflated two different things and is wrong as stated. Measured:

- `Get-PfbArrayConnection | Update-PfbArrayConnection -ManagementAddress <addr>` **works** — the response item has `id`, which binds by property name to `-Id` (set `ByIdIndividual`).
- `Get-PfbArrayConnection | Update-PfbArrayConnection` with no other argument **fails**, but on parameter-set resolution, not on missing properties: `id` alone satisfies both `ByIdIndividual` and `ByIdAttributes`, and `DefaultParameterSetName` is a `ByRemoteName*` set, so it cannot disambiguate.
- What genuinely never binds is `-RemoteName` from a response object — the item exposes only a nested `remote.name`, so there is no `name`/`remoteName` property to match.

All three are pre-existing and untouched by this PR. The middle one turned out to affect **37 cmdlets**, not just this one — every `Update-*` following the Individual/Attributes convention from #31 with a Mandatory pipeline-bound selector in both sets. Filed as #89, kept out of here deliberately: it is a decision about that convention, and #64 gives no mandate over those files.

The coercion guard above also generalises. Array connections were the pathological case only because the resource has no `name` field at all, so pass-3 coercion was guaranteed; most resources bind at pass 2 on `name` and never reach it. But any cmdlet whose pipeline-bound selector doesn't match a field the resource actually returns has the same silent failure, and this PR's guard covers only these four. Filed as #90, with `Reports/PfbFieldCmdletMap.json` as the input for the audit.

Also worth being explicit, since it is destructive: `Get-PfbArrayConnection | Remove-PfbArrayConnection` binds on `id` for **every** piped item and would remove each one. That works today and is unchanged here — but with `-Name` previously dead on the wire, an unfiltered `Get-` feeding that pipeline was a realistic way to remove more than intended, which is the same risk #64 identifies from the other direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
