### PR TITLE
feat(core): report the HTTP status in API error messages

### DIFF
--- a/Private/Invoke-PfbApiRequest.ps1
+++ b/Private/Invoke-PfbApiRequest.ps1
@@ -313,6 +313,19 @@ function ConvertTo-PfbApiError {
     <#
     .SYNOPSIS
         Formats a FlashBlade API error into a readable message, preserving the original exception.
+    .DESCRIPTION
+        Includes the HTTP status as "(HTTP nnn)" whenever the failure actually reached the array
+        and came back with one.
+
+        This matters for anything that consumes these failures programmatically -- automated
+        tests, log analysis, retry logic -- because the status is what separates "the request was
+        malformed" (400) from "the credential lacks permission" (403) from "the endpoint does not
+        exist at this REST version" (404) from "transient, retry" (503). Those need different
+        responses, and the human-readable message alone frequently cannot distinguish them: a
+        FlashBlade 400 and 403 can both come back as nothing more specific than "Bad Request".
+
+        The status is only omitted when there genuinely is none to report -- a DNS failure,
+        connection timeout or rejected certificate never produced an HTTP response at all.
     #>
     [CmdletBinding()]
     param(
@@ -321,7 +334,28 @@ function ConvertTo-PfbApiError {
         [System.Management.Automation.ErrorRecord]$ErrorRecord
     )
 
-    $errorMessage = "FlashBlade API error on ${Method} ${Endpoint}: $($ErrorRecord.Exception.Message)"
+    # Read from the TRANSPORT layer, never from the error body's own "code" field. The two are
+    # not the same number: "code" is an application error code that sometimes coincides with the
+    # HTTP status (401, 403) and sometimes does not -- a write rejected for operating on the
+    # wrong array in a fleet returns code 13 inside an HTTP 400. Trusting "code" would therefore
+    # report a plausible but wrong status part of the time, which is worse than reporting none:
+    # a missing status reads as "unknown", a wrong one gets believed.
+    #
+    # Same access pattern as the reconnect gate above, which reads the status off the same
+    # exceptions in this same catch block.
+    $statusPart = ''
+    if ($ErrorRecord.Exception.Response) {
+        # HttpResponseException (PS 6+) and WebException (5.1) hold different response types but
+        # both expose .StatusCode as a System.Net.HttpStatusCode, which casts to int.
+        # Range-checked so a response object carrying no usable status contributes nothing
+        # rather than "(HTTP 0)".
+        $statusCode = [int]$ErrorRecord.Exception.Response.StatusCode
+        if ($statusCode -ge 100 -and $statusCode -le 599) {
+            $statusPart = " (HTTP $statusCode)"
+        }
+    }
+
+    $errorMessage = "FlashBlade API error on ${Method} ${Endpoint}${statusPart}: $($ErrorRecord.Exception.Message)"
     if ($ErrorRecord.ErrorDetails.Message) {
         try {
             $apiError = $ErrorRecord.ErrorDetails.Message | ConvertFrom-Json
@@ -331,7 +365,11 @@ function ConvertTo-PfbApiError {
             # if both are somehow present.
             $errorList = if ($apiError.errors) { $apiError.errors } else { $apiError.error }
             if ($errorList) {
-                $errorMessage = "FlashBlade API error: $($errorList[0].message)"
+                # $statusPart is repeated because this branch REPLACES the message above rather
+                # than extending it. Without it the status would be dropped from precisely the
+                # failures that returned a parseable body -- i.e. every deliberate API rejection,
+                # which is the case where knowing the status is most useful.
+                $errorMessage = "FlashBlade API error${statusPart}: $($errorList[0].message)"
             }
         }
         catch { }

--- a/Tests/ConvertTo-PfbApiError.Tests.ps1
+++ b/Tests/ConvertTo-PfbApiError.Tests.ps1
@@ -8,13 +8,45 @@ BeforeAll {
     function New-ErrorRecordWithBody {
         param(
             [string]$Body,
-            [string]$Message = 'mock http error'
+            [string]$Message = 'mock http error',
+            # Omitted entirely = an exception with NO .Response at all, i.e. a failure that never
+            # reached the array (DNS, timeout, certificate rejection).
+            [int]$StatusCode,
+            # Attach .Response but with an unusable status, to exercise the range guard.
+            [switch]$ResponseWithoutStatus
         )
         $ex = New-Object System.Exception($Message)
+
+        # Duck-typed the same way Tests/Invoke-PfbApiRequest.Reconnect.Tests.ps1 fakes it, which
+        # is also how the production reconnect gate reads it. A real HttpResponseException cannot
+        # be constructed identically on both PowerShell 5.1 and 7, and this module supports both.
+        if ($ResponseWithoutStatus) {
+            # An object with no StatusCode member at all. [System.Net.HttpStatusCode]0 cannot be
+            # used here -- 0 is not a defined value of that enum and the cast throws.
+            $response = [PSCustomObject]@{ ReasonPhrase = 'none' }
+            Add-Member -InputObject $ex -MemberType NoteProperty -Name Response -Value $response -Force
+        }
+        elseif ($PSBoundParameters.ContainsKey('StatusCode')) {
+            $response = [PSCustomObject]@{ StatusCode = [System.Net.HttpStatusCode]$StatusCode }
+            Add-Member -InputObject $ex -MemberType NoteProperty -Name Response -Value $response -Force
+        }
+
         $errorRecord = New-Object System.Management.Automation.ErrorRecord(
             $ex, 'MockError', [System.Management.Automation.ErrorCategory]::NotSpecified, $null)
-        $errorRecord.ErrorDetails = New-Object System.Management.Automation.ErrorDetails($Body)
+        if ($PSBoundParameters.ContainsKey('Body')) {
+            $errorRecord.ErrorDetails = New-Object System.Management.Automation.ErrorDetails($Body)
+        }
         return $errorRecord
+    }
+
+    function Invoke-Convert {
+        param([System.Management.Automation.ErrorRecord]$ErrorRecord, [string]$Method = 'GET',
+              [string]$Endpoint = 'arrays')
+        InModuleScope PureStorageFlashBladePowerShell -Parameters @{
+            errorRecord = $ErrorRecord; method = $Method; endpoint = $Endpoint
+        } {
+            ConvertTo-PfbApiError -Method $method -Endpoint $endpoint -ErrorRecord $errorRecord
+        }
     }
 }
 
@@ -51,5 +83,66 @@ Describe 'ConvertTo-PfbApiError' {
         }
 
         $result | Should -Be 'FlashBlade API error: plural wins'
+    }
+}
+
+Describe 'ConvertTo-PfbApiError HTTP status reporting' {
+    It 'reports the status on a parsed error body, which replaces the message wholesale' {
+        # The regression this guards: the body-parsing branch REPLACES the transport message, and
+        # the transport message is where the status text lived. So the failures that carry a
+        # readable body -- every deliberate API rejection -- were the ones that lost the status.
+        $result = Invoke-Convert (New-ErrorRecordWithBody -StatusCode 403 `
+            -Body '{"error":[{"code":403,"context":"/api/2.26/arrays","message":"Access Denied"}]}')
+
+        $result | Should -Be 'FlashBlade API error (HTTP 403): Access Denied'
+    }
+
+    It 'reports the status when there is no parseable body' {
+        $result = Invoke-Convert (New-ErrorRecordWithBody -StatusCode 503 -Message 'Service Unavailable')
+
+        $result | Should -Be 'FlashBlade API error on GET arrays (HTTP 503): Service Unavailable'
+    }
+
+    It 'does not confuse the body error code with the HTTP status' {
+        # These are different numbers and only sometimes agree. A write rejected for targeting the
+        # wrong array in a fleet comes back as application code 13 inside an HTTP 400. Taking the
+        # status from the body would report "(HTTP 13)" -- not a status code at all, yet entirely
+        # believable to whatever is reading it.
+        $result = Invoke-Convert (New-ErrorRecordWithBody -StatusCode 400 `
+            -Body '{"errors":[{"code":13,"message":"Cannot be modified on a member array."}]}')
+
+        $result | Should -Be 'FlashBlade API error (HTTP 400): Cannot be modified on a member array.'
+        $result | Should -Not -Match 'HTTP 13'
+    }
+
+    It 'omits the status entirely when the failure never produced an HTTP response' {
+        # A DNS failure, connection timeout or rejected certificate has no status to report, and
+        # must not be given a fabricated one. Absent reads as unknown; wrong gets believed.
+        $result = Invoke-Convert (New-ErrorRecordWithBody -Message 'The remote name could not be resolved')
+
+        $result | Should -Be 'FlashBlade API error on GET arrays: The remote name could not be resolved'
+        $result | Should -Not -Match 'HTTP'
+    }
+
+    It 'omits the status when a response exists but carries no usable one, rather than saying HTTP 0' {
+        # Defensive rather than a known live shape: no real HTTP response reports status 0. It
+        # guards the [int] cast, which turns an absent StatusCode into 0 rather than $null.
+        $result = Invoke-Convert (New-ErrorRecordWithBody -ResponseWithoutStatus -Message 'truncated response')
+
+        $result | Should -Not -Match 'HTTP'
+    }
+
+    It 'emits the status in a form a consumer can actually parse back out' {
+        # The message string is the whole interface here: callers catching this across a module
+        # boundary get a plain RuntimeException with no structured status field to read. So the
+        # exact "(HTTP nnn)" shape is the contract, and this asserts it stays machine-readable
+        # rather than merely containing the digits somewhere.
+        foreach ($code in 400, 403, 404, 500, 503) {
+            $result = Invoke-Convert (New-ErrorRecordWithBody -StatusCode $code `
+                -Body "{`"errors`":[{`"code`":$code,`"message`":`"rejected`"}]}")
+
+            $result | Should -Match '\(HTTP\s+\d{3}\)'
+            [int]([regex]::Match($result, '\(HTTP\s+(\d{3})\)').Groups[1].Value) | Should -Be $code
+        }
     }
 }

--- a/Tests/Invoke-PfbApiRequest.Reconnect.Tests.ps1
+++ b/Tests/Invoke-PfbApiRequest.Reconnect.Tests.ps1
@@ -156,4 +156,32 @@ Describe 'Invoke-PfbApiRequest reconnect on session-token rejection' {
 
         Should -Invoke -ModuleName PureStorageFlashBladePowerShell Connect-PfbArrayInternal -Times 0
     }
+
+    It 'carries the HTTP status out of the reconnect-then-throw path, not just the direct one' {
+        # WHY SEPARATELY FROM Tests/ConvertTo-PfbApiError.Tests.ps1
+        #
+        # Invoke-PfbApiRequest has TWO throw sites that both call ConvertTo-PfbApiError, reached by
+        # different statuses. A 400 takes the plain else branch. A 401/403 on a reconnectable
+        # session goes through reconnect-and-retry first and, when the retry also fails, throws
+        # from inside that block instead -- where the ErrorRecord being formatted is the OUTER
+        # catch's original error, not the retry's.
+        #
+        # A live 400 against the lab array confirmed the direct branch end to end. The 403 branch
+        # could NOT be provoked live: the lab credential is a full array admin, so no read is
+        # refused. This pins the branch that live testing could not reach, and is mocked
+        # deliberately rather than presented as live evidence.
+        $array = New-TestConnection
+        Mock -ModuleName PureStorageFlashBladePowerShell Connect-PfbArrayInternal {
+            [PSCustomObject]@{ AuthToken = 'refreshed-token'; ConnectedAt = [datetime]::UtcNow }
+        }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
+            throw (New-MockHttpError -StatusCode 403 -Message 'Access Denied')
+        } -ParameterFilter { $Uri -like '*file-systems*' }
+
+        {
+            InModuleScope PureStorageFlashBladePowerShell -Parameters @{ array = $array } {
+                Invoke-PfbApiRequest -Array $array -Method GET -Endpoint 'file-systems' | Out-Null
+            }
+        } | Should -Throw -ExpectedMessage '*(HTTP 403)*'
+    }
 }


### PR DESCRIPTION
## What this changes

`ConvertTo-PfbApiError` now includes the HTTP status in the message it returns, as `(HTTP nnn)`:

```
FlashBlade API error (HTTP 400): Syntax error in query.
FlashBlade API error on GET arrays (HTTP 503): Service Unavailable
```

## Why

Anything consuming these failures programmatically — automated tests, log analysis, retry logic —
needs the status to tell apart cases that call for completely different responses: a malformed
request (400), a credential without permission (403), an endpoint absent at the connected REST
version (404), something transient worth retrying (503). The prose message alone frequently cannot
distinguish them; a FlashBlade 400 and 403 can both arrive as nothing more specific than
`Bad Request`.

The status was previously unavailable on exactly the failures where it matters most. The
body-parsing branch **replaces** the message rather than extending it:

```powershell
$errorMessage = "FlashBlade API error on ${Method} ${Endpoint}: $(...Exception.Message)"   # had the status
if ($ErrorRecord.ErrorDetails.Message) {
    ...
    $errorMessage = "FlashBlade API error: $($errorList[0].message)"                       # dropped it
}
```

So every error that returned a readable JSON body — i.e. every deliberate API rejection — discarded
the transport text that carried the status. Only connection-level failures kept it, incidentally,
because nothing overwrote them.

## Where the status comes from, and where it deliberately doesn't

Read from the **transport layer** (`Exception.Response.StatusCode`), never from the error body's own
`code` field. Those are different numbers that only sometimes agree — a write rejected for targeting
the wrong array in a fleet returns application code `13` inside an HTTP 400. Reading `code` would
report a plausible but wrong status some of the time, which is worse than reporting none: a missing
status reads as unknown, a wrong one gets believed. There's a test pinning that specific case.

Absent when there is genuinely no status to report — DNS failure, connection timeout, rejected
certificate. Range-checked so a response carrying no usable status contributes nothing rather than
`(HTTP 0)`.

This reuses the access pattern already in the same `catch` block for the 401/403 reconnect gate,
rather than introducing a second idiom. The `[int]` cast is left unguarded for the same reason that
one is: lines 146-149 perform the identical cast unconditionally at the top of the block, before
control can reach `ConvertTo-PfbApiError`, so an exception with an uncastable `StatusCode` fails
there first.

## Verification

**Live, against a lab FlashBlade** (Purity//FB REST 2.26) — a malformed filter, which the array
rejects with a JSON error body:

```
Get-PfbFileSystem -Filter "name='unclosed"
  -> FlashBlade API error (HTTP 400): Syntax error in query.
```

That is the body-parsing branch, so it exercises the case that previously lost the status.

**One branch could not be reached live, and is mocked instead.** `Invoke-PfbApiRequest` has two
throw sites that both format through this function. A 400 takes the plain `else`. A 401/403 on a
reconnectable session reconnects and retries first, and when the retry also fails it throws from
inside that block — where the record being formatted is the outer `catch`'s original error, not the
retry's. The lab credential is a full array admin, so no read it can issue is refused; I probed 19
read cmdlets across admin, api-tokens, legal-holds, rapid-data-locking, KMIP, keytabs, sessions,
roles and SAML/OIDC without provoking a 403. The second commit pins that branch with a mocked test,
labelled in the test body as mocked so it isn't later mistaken for live evidence.

**Test suite:**

- Full suite at `b84b1cb`: **1701 passed / 0 failed** (PowerShell 7)
- The affected test files at `0848541`: **17/17 on both PowerShell 7 and Windows PowerShell 5.1**

`ConvertTo-PfbApiError.Tests.ps1` goes 3 → 9 tests. The three existing exact-match assertions pass
**unchanged** — they build an exception with no `.Response`, so no status is added and the old
expected strings still describe real behaviour.

New coverage: the status on both message branches, the body-`code`-is-not-the-status case, absent
when there was no HTTP response, absent rather than `(HTTP 0)` when a response carries no usable
status, and a round-trip asserting the `(HTTP nnn)` form stays machine-readable across 400/403/404/
500/503.

## Knock-on effect worth flagging

Three call sites interpolate this message into their own strings, so their text now carries the
status too:

- `Public/Connection/Connect-PfbArray.ps1:190` and `:294`
- `Private/Invoke-PfbApiTokenLogin.ps1:39`

No test asserts on their exact wording, and the change is an improvement there — a failed connect
now says whether it was refused or unreachable. Noting it because it's user-visible beyond the one
function.

## Not included

No version bump and no CHANGELOG entry, per the project convention that those are the maintainer's
own decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
