### PR TITLE
fix(replication): let RemoteDefaultExports suppress remote default exports (#55)

### DIFF
--- a/Public/Replication/New-PfbFileSystemReplicaLink.ps1
+++ b/Public/Replication/New-PfbFileSystemReplicaLink.ps1
@@ -23,7 +23,13 @@ function New-PfbFileSystemReplicaLink {
         Name of the target file system on the remote array. If omitted, the FlashBlade
         will name it after the local file system.
     .PARAMETER RemoteDefaultExports
-        If true, create default NFS/SMB exports on the remote file system after replication.
+        Controls whether default NFS/SMB exports are created on the remote file system after
+        replication. Tri-state:
+          - omitted: the array's own default is used (the FlashBlade creates default exports),
+          - $true:   explicitly create default exports on the remote,
+          - $false:  suppress the default exports so the remote file system has none.
+        Pass -RemoteDefaultExports $false to keep replica file systems export-free (previously
+        impossible: this was a [switch] that could only ever request 'true').
     .PARAMETER Array
         FlashBlade connection (the source/local array).
     .EXAMPLE
@@ -49,7 +55,7 @@ function New-PfbFileSystemReplicaLink {
         [string]$RemoteFileSystemName,
 
         [Parameter()]
-        [switch]$RemoteDefaultExports,
+        [Nullable[bool]]$RemoteDefaultExports,
 
         [Parameter()]
         [PSCustomObject]$Array
@@ -62,7 +68,11 @@ function New-PfbFileSystemReplicaLink {
         'remote_names'            = $RemoteArrayName
     }
     if ($RemoteFileSystemName)   { $queryParams['remote_file_system_names'] = $RemoteFileSystemName }
-    if ($RemoteDefaultExports)   { $queryParams['remote_default_exports']    = 'true' }
+    # Send only when the caller bound it, so an omitted value defers to the array default.
+    # $false must reach the wire to suppress the exports, so guard on presence not truthiness.
+    if ($PSBoundParameters.ContainsKey('RemoteDefaultExports')) {
+        $queryParams['remote_default_exports'] = if ($RemoteDefaultExports) { 'true' } else { 'false' }
+    }
 
     # POST /file-system-replica-links requires a body even if empty
     $body = @{}

--- a/Tests/New-PfbFileSystemReplicaLink.Tests.ps1
+++ b/Tests/New-PfbFileSystemReplicaLink.Tests.ps1
@@ -1,0 +1,74 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    $moduleRoot = Split-Path -Parent $PSScriptRoot
+    $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
+    Import-Module $manifest -Force
+
+    $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
+}
+
+Describe 'New-PfbFileSystemReplicaLink - query parameters' {
+
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+    }
+
+    Context 'required selectors' {
+        It 'sends local_file_system_names and remote_names to POST /file-system-replica-links' {
+            New-PfbFileSystemReplicaLink -LocalFileSystemName 'fs01' -RemoteArrayName 'remote-fb' `
+                -Confirm:$false -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                $Method -eq 'POST' -and $Endpoint -eq 'file-system-replica-links' -and
+                $QueryParams['local_file_system_names'] -eq 'fs01' -and
+                $QueryParams['remote_names'] -eq 'remote-fb'
+            }
+        }
+
+        It 'sends remote_file_system_names when supplied' {
+            New-PfbFileSystemReplicaLink -LocalFileSystemName 'fs01' -RemoteArrayName 'remote-fb' `
+                -RemoteFileSystemName 'fs01-dr' -Confirm:$false -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                $QueryParams['remote_file_system_names'] -eq 'fs01-dr'
+            }
+        }
+    }
+
+    Context 'RemoteDefaultExports tri-state (fixes: [switch] could never suppress remote default exports)' {
+        It 'omits remote_default_exports entirely when the parameter is not bound (defers to array default)' {
+            New-PfbFileSystemReplicaLink -LocalFileSystemName 'fs01' -RemoteArrayName 'remote-fb' `
+                -Confirm:$false -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                -not $QueryParams.ContainsKey('remote_default_exports')
+            }
+        }
+
+        It 'sends remote_default_exports=true when -RemoteDefaultExports $true' {
+            New-PfbFileSystemReplicaLink -LocalFileSystemName 'fs01' -RemoteArrayName 'remote-fb' `
+                -RemoteDefaultExports $true -Confirm:$false -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                $QueryParams['remote_default_exports'] -eq 'true'
+            }
+        }
+
+        It 'sends remote_default_exports=false when -RemoteDefaultExports $false (the previously-impossible case)' {
+            New-PfbFileSystemReplicaLink -LocalFileSystemName 'fs01' -RemoteArrayName 'remote-fb' `
+                -RemoteDefaultExports $false -Confirm:$false -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                $QueryParams['remote_default_exports'] -eq 'false'
+            }
+        }
+
+        It 'exposes -RemoteDefaultExports as a nullable bool, not a switch' {
+            $p = (Get-Command New-PfbFileSystemReplicaLink).Parameters['RemoteDefaultExports']
+            $p.ParameterType | Should -Be ([Nullable[bool]])
+            $p.SwitchParameter | Should -BeFalse
+        }
+    }
+}


### PR DESCRIPTION
## What

`New-PfbFileSystemReplicaLink -RemoteDefaultExports` was a `[switch]`, so it could only ever send `remote_default_exports=true`. Omitting it sent nothing, letting the array apply its own default (create the exports). **There was no way to send `false`.**

Consequence, hit on every share during an active field migration: each replicated file system came up with default NFS/SMB exports on the remote array that had to be deleted by hand.

## Fix

- `-RemoteDefaultExports` becomes `[Nullable[bool]]`, matching the module's existing tri-state idiom (e.g. `New-PfbFileSystem -SnapshotDirectoryEnabled`, `-Writable`).
- The query param is sent only when the caller bound it, guarding on presence (`$PSBoundParameters.ContainsKey`) not truthiness, so `$false` reaches the wire:
  - **omitted** → array default (unchanged behavior)
  - **`$true`** → `remote_default_exports=true`
  - **`$false`** → `remote_default_exports=false` (previously impossible)

## Tests

Adds `Tests/New-PfbFileSystemReplicaLink.Tests.ps1` — the cmdlet had **no** test file. Asserts the wire value for all three states, the required selectors, and that the parameter is a nullable bool rather than a switch. Green on Pester 6.0.1 (6/6).

## Breaking change

The bare `-RemoteDefaultExports` switch form now requires a value: use `-RemoteDefaultExports $true`. Worth a CHANGELOG "breaking" note when the release is cut.

## Scope

This is the **replica-link half** of #55, which is verified and safe. The **create-side** half (suppressing the `array_server` default exports on `New-PfbFileSystem`) is intentionally not included here: neither `default_exports` nor `remote_default_exports` is modeled in the committed capability map, and the raw spec is not committed, so the exact create-side wire shape (empty array vs bool vs query key) can't be confirmed from repo artifacts. The field user is compiling written API notes with the exact observation; that half stays tracked in #55 to land once the wire format is confirmed, rather than guessed.

Refs #55.
