### PR TITLE
chore(release): 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,55 @@
 
 All notable changes to `PureStorageFlashBladePowerShell` are documented in this file.
 
+## [2.3.0] - 2026-08-04
+
+Typed write-cmdlet parameters, new quota-policy cmdlets, and a batch of
+correctness fixes surfaced by an active field migration.
+
+### Added
+
+- Typed, validated body/query parameters for 56 `New-*`/`Update-*` write
+  cmdlets, previously reachable only via a raw `-Attributes` hashtable.
+  `-Attributes` is retained on every cmdlet, mutually exclusive with the new
+  typed parameters via parameter sets (#66, #31).
+- User and group quota-policy cmdlets (#68, #34).
+
+### Fixed
+
+- `-Limit` was ignored under AutoPaginate; centralized `-Filter`/`-Sort`/
+  `-Limit`/`-TotalOnly` handling across the `Get-Pfb*` surface, and an explicit
+  `-Limit 0` is now sent (#48/#30, #49/#32, #51/#33).
+- Array-connection cmdlets filtered on a dead `names` query key that the array
+  silently ignores, so `-Name` returned the full unfiltered set and a PATCH or
+  DELETE could fan out to every connection. They now use `remote_names`, the
+  real wire identifier (#91, #64).
+- `New-PfbFileSystemReplicaLink` could never suppress the remote default
+  exports; `-RemoteDefaultExports $false` now does (#93, #55).
+- `Set-PfbPresetWorkload` and `Set-PfbWorkloadTag` folded onto the shared
+  request path; a single workload tag now serializes as a JSON array, and both
+  now honor capability gating and bearer-token auth (#78/#76, #81/#77).
+- API error messages now include the HTTP status, e.g. `(HTTP 400)` (#92).
+
+### Changed
+
+- **Breaking.** `Update-PfbArrayConnection`: `-Name` is now an alias of
+  `-RemoteName`. Supplying both together is a bind error (previously the only
+  form that actually filtered); drop the redundant argument.
+- **Breaking.** `New-PfbFileSystemReplicaLink`: `-RemoteDefaultExports` changed
+  from `[switch]` to `[Nullable[bool]]`; the bare form now requires a value
+  (`-RemoteDefaultExports $true`).
+- **Breaking.** `Update-PfbAsyncLog`: removed `-Name`/`-Id` (`PATCH /logs-async`
+  has no selector query parameter; they never filtered).
+
+### Maintainer / tooling (no runtime impact)
+
+- Drift-report toolchain: per-parameter confidence, a response-shape drift axis,
+  a Fusion `context_names` cardinality check, canonical record ordering,
+  repo-relative paths, and the REST 2.28 capability map (#53, #60, #61, #62,
+  #67, #70, #73, #75, #86).
+- CI: survive PowerShell Gallery outages (pinned Pester 6.0.1 / Posh-SSH), and
+  gate gallery publish on the full cross-platform matrix (#54, #29, #19).
+
 ## [2.2.0] - 2026-07-22
 
 API version-awareness plus seven documented-but-unexposed query-parameter enums.

--- a/PureStorageFlashBladePowerShell.psd1
+++ b/PureStorageFlashBladePowerShell.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule        = 'PureStorageFlashBladePowerShell.psm1'
-    ModuleVersion     = '2.2.0'
+    ModuleVersion     = '2.3.0'
     GUID              = 'b25473b3-9eb7-414d-8da1-264e10f73d86'
     Author            = 'Pure Storage, Inc.'
     CompanyName       = 'Pure Storage, Inc.'
@@ -568,6 +568,19 @@
             LicenseUri   = 'https://github.com/PureStorage-OpenConnect/flashblade-powershell/blob/main/LICENSE'
             # ReleaseNotes carries only the latest-version highlight; full history is in CHANGELOG.md.
             ReleaseNotes = @'
+v2.3.0 - Typed write-cmdlet parameters + field-migration correctness fixes.
+  56 New-*/Update-* write cmdlets gain typed, validated parameters for documented body/
+  query fields previously reachable only via a raw -Attributes hashtable (-Attributes
+  retained, mutually exclusive via parameter sets). Adds user/group quota-policy cmdlets.
+  Fixes: array-connection cmdlets now filter on remote_names (the real wire key) instead
+  of a dead 'names' key that returned the full set and could fan a PATCH/DELETE out to
+  every connection; New-PfbFileSystemReplicaLink -RemoteDefaultExports $false can now
+  suppress remote default exports; -Limit honored under AutoPaginate; API errors now
+  include the HTTP status. Breaking: Update-PfbArrayConnection -Name is now an alias of
+  -RemoteName (both together is a bind error); New-PfbFileSystemReplicaLink
+  -RemoteDefaultExports is now [Nullable[bool]] and the bare form needs a value;
+  Update-PfbAsyncLog drops -Name/-Id (the endpoint has no selector).
+
 v2.2.0 - API version-awareness + feature-gap parameters.
   Adds a generated capability map of every FlashBlade REST endpoint/parameter/field to
   the API version that introduced it, and a fail-fast runtime check that rejects a call


### PR DESCRIPTION
## 2.3.0 release

Bumps `ModuleVersion` 2.2.0 → 2.3.0, adds the 2.3.0 CHANGELOG entry, and refreshes the manifest `ReleaseNotes` highlight.

### Merge order — this PR goes LAST

It documents three PRs that are reviewed merge-ready and green but not yet merged. Land them first, then this:

- **#91** array-connection `remote_names` filter (fixes #64) — *breaking*
- **#92** HTTP status in API error messages
- **#93** `New-PfbFileSystemReplicaLink -RemoteDefaultExports` suppression (refs #55) — *breaking*

If any of those is held back, edit the CHANGELOG here before merging so it matches what actually shipped.

### Breaking changes (also called out in the CHANGELOG)

- `Update-PfbArrayConnection`: `-Name` is now an alias of `-RemoteName`; supplying both together is a bind error.
- `New-PfbFileSystemReplicaLink`: `-RemoteDefaultExports` is now `[Nullable[bool]]`; the bare form needs a value.
- `Update-PfbAsyncLog`: `-Name`/`-Id` removed (endpoint has no selector).

Two breaking changes in a minor is consistent with repo practice (2.1.2 removed cmdlets), but if we'd rather signal them with a major, this becomes 3.0.0 — one-line change here.

### After merge (maintainer)

1. Tag `v2.3.0` and cut the GitHub release.
2. Gallery publish of the branded package (`Publish-Gallery.ps1` reads this manifest version).
3. Re-sync the Pure org fork so customers pulling from it get 2.3.0.

Manifest verified to parse (`Import-PowerShellDataFile` → ModuleVersion 2.3.0).
