### PR TITLE
feat(fusion): Phase 0 prerequisites - contextScope in the capability map, centralised component resolution, staleness warning

### DIFF
--- a/Data/PfbCapabilityMap.json
+++ b/Data/PfbCapabilityMap.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "generatedFrom": [
     "2.0",
     "2.1",
@@ -224,6 +224,10 @@
         "subject_token": "2.0",
         "subject_token_type": "2.0"
       },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "X-Request-ID": null
       }
@@ -233,7 +237,11 @@
       "parameters": {
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "POST /api/login": {
       "minVersion": "2.0",
@@ -244,6 +252,10 @@
       "bodyProperties": {
         "password": "2.26",
         "username": "2.26"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       }
     },
     "POST /api/logout": {
@@ -251,14 +263,22 @@
       "parameters": {
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /api/login-banner": {
       "minVersion": "2.0",
       "parameters": {
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /active-directory": {
       "minVersion": "2.0",
@@ -272,7 +292,11 @@
         "sort": "2.0",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /active-directory": {
       "minVersion": "2.0",
@@ -282,7 +306,11 @@
         "names": "2.0",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /active-directory": {
       "minVersion": "2.0",
@@ -301,6 +329,10 @@
         "global_catalog_servers": "2.12",
         "ca_certificate": "2.27",
         "ca_certificate_group": "2.27"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       }
     },
     "POST /active-directory": {
@@ -324,6 +356,10 @@
         "global_catalog_servers": "2.12",
         "ca_certificate": "2.27",
         "ca_certificate_group": "2.27"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       }
     },
     "GET /active-directory/test": {
@@ -340,6 +376,10 @@
         "continuation_token": "2.23"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -360,6 +400,10 @@
         "context_names": "2.22"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -380,6 +424,10 @@
         "role": "2.15",
         "authorization_model": "2.24",
         "management_access_policies": "2.24"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       }
     },
     "GET /admins/api-tokens": {
@@ -398,6 +446,10 @@
         "context_names": "2.24"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -411,7 +463,11 @@
         "X-Request-ID": "2.14",
         "context_names": "2.24"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /admins/api-tokens": {
       "minVersion": "2.0",
@@ -421,7 +477,11 @@
         "X-Request-ID": "2.14",
         "context_names": "2.24"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /admins/cache": {
       "minVersion": "2.0",
@@ -439,6 +499,10 @@
         "context_names": "2.24"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -451,7 +515,11 @@
         "X-Request-ID": "2.14",
         "context_names": "2.24"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /alerts": {
       "minVersion": "2.0",
@@ -465,7 +533,11 @@
         "sort": "2.0",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /alerts": {
       "minVersion": "2.0",
@@ -512,7 +584,11 @@
         "summary",
         "updated",
         "variables"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /alert-watchers": {
       "minVersion": "2.0",
@@ -526,7 +602,11 @@
         "sort": "2.0",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "POST /alert-watchers": {
       "minVersion": "2.0",
@@ -536,6 +616,10 @@
       },
       "bodyProperties": {
         "minimum_notification_severity": "2.0"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       },
       "parameterComponentOverrides": {
         "names": "Names_required"
@@ -557,7 +641,11 @@
       "readOnlyBodyProperties": [
         "id",
         "name"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /alert-watchers": {
       "minVersion": "2.0",
@@ -566,7 +654,11 @@
         "names": "2.0",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /alert-watchers/test": {
       "minVersion": "2.0",
@@ -577,7 +669,11 @@
         "sort": "2.0",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /api-clients": {
       "minVersion": "2.0",
@@ -591,7 +687,11 @@
         "sort": "2.0",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "POST /api-clients": {
       "minVersion": "2.0",
@@ -605,6 +705,10 @@
         "public_key": "2.0",
         "access_token_ttl_in_ms": "2.0",
         "access_policies": "2.19"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       }
     },
     "PATCH /api-clients": {
@@ -633,7 +737,11 @@
         "key_id",
         "name",
         "public_key"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /api-clients": {
       "minVersion": "2.0",
@@ -642,7 +750,11 @@
         "names": "2.0",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /arrays": {
       "minVersion": "2.0",
@@ -657,6 +769,10 @@
         "context_names": "2.22"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -697,7 +813,11 @@
         "security_update",
         "smb_mode",
         "version"
-      ]
+      ],
+      "contextScope": {
+        "scope": "unknown",
+        "provenance": "unknown"
+      }
     },
     "GET /arrays/clients/performance": {
       "minVersion": "2.0",
@@ -711,6 +831,10 @@
         "protocol": "2.18"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "unknown",
+        "provenance": "unknown"
+      },
       "parameterComponentOverrides": {
         "protocol": "Protocol_clients"
       }
@@ -725,7 +849,11 @@
         "sort": "2.0",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /arrays/eula": {
       "minVersion": "2.0",
@@ -738,7 +866,11 @@
       },
       "readOnlyBodyProperties": [
         "agreement"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /array-connections": {
       "minVersion": "2.0",
@@ -756,6 +888,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -791,6 +927,10 @@
         "type",
         "version"
       ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "remote_ids": "Remote_ids_deprecated",
         "remote_names": "Remote_names_deprecated"
@@ -824,7 +964,11 @@
         "status",
         "type",
         "version"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /array-connections": {
       "minVersion": "2.0",
@@ -836,6 +980,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "remote_ids": "Remote_ids_deprecated",
         "remote_names": "Remote_names_deprecated"
@@ -853,14 +1001,22 @@
         "sort": "2.0",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "POST /array-connections/connection-key": {
       "minVersion": "2.0",
       "parameters": {
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /array-connections/path": {
       "minVersion": "2.0",
@@ -878,6 +1034,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -901,6 +1061,10 @@
         "X-Request-ID": "2.14"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "type": "Type_for_performance"
       }
@@ -916,6 +1080,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "unknown",
+        "provenance": "unknown"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -931,6 +1099,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "unknown",
+        "provenance": "unknown"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -947,6 +1119,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "unknown",
+        "provenance": "unknown"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -963,6 +1139,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "unknown",
+        "provenance": "unknown"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get",
         "type": "Type_for_performance"
@@ -979,6 +1159,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "unknown",
+        "provenance": "unknown"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -995,6 +1179,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "unknown",
+        "provenance": "unknown"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -1010,7 +1198,11 @@
         "sort": "2.0",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /audits": {
       "minVersion": "2.0",
@@ -1027,6 +1219,10 @@
         "context_names": "2.28"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -1044,7 +1240,11 @@
         "total_only": "2.0",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /buckets": {
       "minVersion": "2.0",
@@ -1063,6 +1263,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -1082,6 +1286,10 @@
         "quota_limit": "2.8",
         "retention_lock": "2.8",
         "eradication_config": "2.13"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       },
       "parameterComponentOverrides": {
         "names": "Names_required"
@@ -1117,6 +1325,10 @@
         "storage_class": "2.19",
         "qos_policy": "2.20"
       },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "ignore_usage": "Ignore_usage"
       }
@@ -1129,7 +1341,11 @@
         "X-Request-ID": "2.14",
         "context_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /buckets/performance": {
       "minVersion": "2.0",
@@ -1147,7 +1363,11 @@
         "total_only": "2.0",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /buckets/s3-specific-performance": {
       "minVersion": "2.0",
@@ -1165,7 +1385,11 @@
         "total_only": "2.0",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /bucket-replica-links": {
       "minVersion": "2.0",
@@ -1187,6 +1411,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -1205,6 +1433,10 @@
       "bodyProperties": {
         "paused": "2.0",
         "cascading_enabled": "2.2"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       }
     },
     "PATCH /bucket-replica-links": {
@@ -1243,7 +1475,11 @@
         "recovery_point",
         "status",
         "status_details"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /bucket-replica-links": {
       "minVersion": "2.0",
@@ -1257,7 +1493,11 @@
         "X-Request-ID": "2.17",
         "context_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /certificates": {
       "minVersion": "2.0",
@@ -1271,7 +1511,11 @@
         "sort": "2.0",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "POST /certificates": {
       "minVersion": "2.0",
@@ -1311,7 +1555,11 @@
         "status",
         "valid_from",
         "valid_to"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /certificates": {
       "minVersion": "2.0",
@@ -1354,7 +1602,11 @@
         "status",
         "valid_from",
         "valid_to"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /certificates": {
       "minVersion": "2.0",
@@ -1363,7 +1615,11 @@
         "names": "2.0",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /certificates/certificate-groups": {
       "minVersion": "2.0",
@@ -1379,7 +1635,11 @@
         "sort": "2.0",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "POST /certificates/certificate-groups": {
       "minVersion": "2.0",
@@ -1390,7 +1650,11 @@
         "certificate_names": "2.0",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /certificates/certificate-groups": {
       "minVersion": "2.0",
@@ -1401,7 +1665,11 @@
         "certificate_names": "2.0",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /certificates/uses": {
       "minVersion": "2.0",
@@ -1415,7 +1683,11 @@
         "sort": "2.0",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /certificate-groups": {
       "minVersion": "2.0",
@@ -1429,7 +1701,11 @@
         "sort": "2.0",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "POST /certificate-groups": {
       "minVersion": "2.0",
@@ -1437,7 +1713,11 @@
         "names": "2.0",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /certificate-groups": {
       "minVersion": "2.0",
@@ -1446,7 +1726,11 @@
         "names": "2.0",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /certificate-groups/certificates": {
       "minVersion": "2.0",
@@ -1462,7 +1746,11 @@
         "sort": "2.0",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "POST /certificate-groups/certificates": {
       "minVersion": "2.0",
@@ -1473,7 +1761,11 @@
         "certificate_names": "2.0",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /certificate-groups/certificates": {
       "minVersion": "2.0",
@@ -1484,7 +1776,11 @@
         "certificate_names": "2.0",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /certificate-groups/uses": {
       "minVersion": "2.0",
@@ -1498,7 +1794,11 @@
         "sort": "2.0",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /directory-services": {
       "minVersion": "2.0",
@@ -1512,7 +1812,11 @@
         "sort": "2.0",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /directory-services": {
       "minVersion": "2.0",
@@ -1540,7 +1844,11 @@
         "id",
         "name",
         "services"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /directory-services/roles": {
       "minVersion": "2.0",
@@ -1557,6 +1865,10 @@
         "names": "2.14"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "ids": "Ids_for_directory_service_roles",
         "names": "Names_for_directory_service_roles",
@@ -1580,6 +1892,10 @@
         "group_base": "2.0",
         "name": "2.18",
         "management_access_policies": "2.19"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       },
       "readOnlyBodyProperties": [
         "id",
@@ -1607,6 +1923,10 @@
         "continuation_token": "2.23"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -1643,7 +1963,11 @@
         "id",
         "name",
         "services"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /dns": {
       "minVersion": "2.0",
@@ -1660,6 +1984,10 @@
         "context_names": "2.25"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -1688,7 +2016,11 @@
         "context",
         "id",
         "realms"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /file-systems": {
       "minVersion": "2.0",
@@ -1709,6 +2041,10 @@
         "workload_names": "2.23"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -1746,6 +2082,10 @@
         "node_group": "2.18",
         "workload": "2.23"
       },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "readOnlyBodyProperties": [
         "requested_promotion_state"
       ]
@@ -1758,7 +2098,11 @@
         "X-Request-ID": "2.14",
         "context_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /file-systems": {
       "minVersion": "2.0",
@@ -1802,6 +2146,10 @@
         "quiesce": "2.28",
         "skip_quiesce": "2.28"
       },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "readOnlyBodyProperties": [
         "created",
         "id",
@@ -1827,6 +2175,10 @@
         "X-Request-ID": "2.14"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "gids": "Gids_not_strict",
         "group_names": "Group_names_not_strict"
@@ -1849,7 +2201,11 @@
         "total_only": "2.0",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /file-systems/policies": {
       "minVersion": "2.0",
@@ -1868,6 +2224,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -1882,7 +2242,11 @@
         "X-Request-ID": "2.14",
         "context_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /file-systems/policies": {
       "minVersion": "2.0",
@@ -1894,7 +2258,11 @@
         "X-Request-ID": "2.14",
         "context_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /file-systems/users/performance": {
       "minVersion": "2.0",
@@ -1911,6 +2279,10 @@
         "X-Request-ID": "2.14"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "uids": "Uids_not_strict",
         "user_names": "User_names_not_strict"
@@ -1936,6 +2308,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -1974,7 +2350,11 @@
         "recovery_point",
         "status",
         "status_details"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /file-system-replica-links/policies": {
       "minVersion": "2.0",
@@ -1998,6 +2378,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -2015,7 +2399,11 @@
         "X-Request-ID": "2.14",
         "context_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /file-system-replica-links/policies": {
       "minVersion": "2.0",
@@ -2030,7 +2418,11 @@
         "X-Request-ID": "2.14",
         "context_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /file-system-replica-links/transfer": {
       "minVersion": "2.0",
@@ -2050,6 +2442,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -2072,6 +2468,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -2088,6 +2488,10 @@
       },
       "bodyProperties": {
         "suffix": "2.0"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       }
     },
     "DELETE /file-system-snapshots": {
@@ -2098,7 +2502,11 @@
         "X-Request-ID": "2.14",
         "context_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /file-system-snapshots": {
       "minVersion": "2.0",
@@ -2132,7 +2540,11 @@
         "policies",
         "suffix",
         "time_remaining"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /file-system-snapshots/policies": {
       "minVersion": "2.0",
@@ -2151,6 +2563,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -2165,7 +2581,11 @@
         "X-Request-ID": "2.14",
         "context_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /file-system-snapshots/transfer": {
       "minVersion": "2.0",
@@ -2183,6 +2603,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -2197,7 +2621,11 @@
         "X-Request-ID": "2.14",
         "context_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /hardware": {
       "minVersion": "2.0",
@@ -2211,7 +2639,11 @@
         "ids": "2.17",
         "names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /hardware": {
       "minVersion": "2.0",
@@ -2254,7 +2686,11 @@
         "status",
         "temperature",
         "type"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /hardware-connectors": {
       "minVersion": "2.0",
@@ -2268,7 +2704,11 @@
         "ids": "2.17",
         "names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /hardware-connectors": {
       "minVersion": "2.0",
@@ -2286,6 +2726,10 @@
         "transceiver_type": "2.0",
         "port_speed": "2.15",
         "lanes_per_port": "2.20"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       },
       "readOnlyBodyProperties": [
         "connector_type",
@@ -2306,7 +2750,11 @@
         "sort": "2.0",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /keytabs": {
       "minVersion": "2.0",
@@ -2315,7 +2763,11 @@
         "names": "2.0",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "POST /keytabs": {
       "minVersion": "2.0",
@@ -2325,6 +2777,10 @@
       },
       "bodyProperties": {
         "source": "2.0"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       }
     },
     "GET /keytabs/download": {
@@ -2334,7 +2790,11 @@
         "keytab_names": "2.0",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "POST /keytabs/upload": {
       "minVersion": "2.0",
@@ -2344,6 +2804,10 @@
       },
       "bodyProperties": {
         "keytab_file": "2.16"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       }
     },
     "GET /lifecycle-rules": {
@@ -2363,6 +2827,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -2382,6 +2850,10 @@
         "abort_incomplete_multipart_uploads_after": "2.1",
         "keep_current_version_for": "2.1",
         "keep_current_version_until": "2.1"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       }
     },
     "PATCH /lifecycle-rules": {
@@ -2402,6 +2874,10 @@
         "abort_incomplete_multipart_uploads_after": "2.1",
         "keep_current_version_for": "2.1",
         "keep_current_version_until": "2.1"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       }
     },
     "DELETE /lifecycle-rules": {
@@ -2414,7 +2890,11 @@
         "X-Request-ID": "2.14",
         "context_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /link-aggregation-groups": {
       "minVersion": "2.0",
@@ -2428,7 +2908,11 @@
         "sort": "2.0",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "POST /link-aggregation-groups": {
       "minVersion": "2.0",
@@ -2453,6 +2937,10 @@
         "port_speed",
         "status"
       ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "names": "Names_required"
       }
@@ -2468,6 +2956,10 @@
         "ports": "2.0",
         "add_ports": "2.0",
         "remove_ports": "2.0"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       }
     },
     "DELETE /link-aggregation-groups": {
@@ -2477,7 +2969,11 @@
         "names": "2.0",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /logs": {
       "minVersion": "2.0",
@@ -2486,7 +2982,11 @@
         "start_time": "2.0",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /network-interfaces": {
       "minVersion": "2.0",
@@ -2500,7 +3000,11 @@
         "sort": "2.0",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "POST /network-interfaces": {
       "minVersion": "2.0",
@@ -2530,6 +3034,10 @@
         "name",
         "realms"
       ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "names": "Names_required"
       }
@@ -2547,6 +3055,10 @@
         "server": "2.16",
         "attached_servers": "2.20",
         "rdma_enabled": "2.28"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       }
     },
     "DELETE /network-interfaces": {
@@ -2556,7 +3068,11 @@
         "names": "2.0",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /object-store-access-keys": {
       "minVersion": "2.0",
@@ -2572,6 +3088,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -2586,6 +3106,10 @@
       "bodyProperties": {
         "user": "2.0",
         "secret_access_key": "2.0"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       },
       "parameterComponentOverrides": {
         "names": "Access_key_names"
@@ -2615,6 +3139,10 @@
         "secret_access_key",
         "user"
       ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "names": "Names_required"
       }
@@ -2627,6 +3155,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "names": "Names_required"
       }
@@ -2647,6 +3179,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -2668,6 +3204,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -2682,7 +3222,11 @@
         "X-Request-ID": "2.14",
         "context_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /object-store-access-policies/object-store-users": {
       "minVersion": "2.0",
@@ -2694,7 +3238,11 @@
         "X-Request-ID": "2.14",
         "context_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /object-store-accounts": {
       "minVersion": "2.0",
@@ -2712,6 +3260,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -2729,6 +3281,10 @@
         "quota_limit": "2.8",
         "account_exports": "2.20"
       },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "names": "Names_required"
       }
@@ -2741,7 +3297,11 @@
         "X-Request-ID": "2.14",
         "context_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /object-store-remote-credentials": {
       "minVersion": "2.0",
@@ -2758,6 +3318,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -2772,6 +3336,10 @@
       "bodyProperties": {
         "access_key_id": "2.0",
         "secret_access_key": "2.0"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       },
       "parameterComponentOverrides": {
         "names": "Names_required"
@@ -2798,7 +3366,11 @@
         "context",
         "id",
         "realms"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /object-store-remote-credentials": {
       "minVersion": "2.0",
@@ -2808,7 +3380,11 @@
         "X-Request-ID": "2.14",
         "context_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /object-store-users": {
       "minVersion": "2.0",
@@ -2825,6 +3401,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -2838,6 +3418,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "names": "Names_required"
       }
@@ -2850,7 +3434,11 @@
         "X-Request-ID": "2.14",
         "context_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /object-store-users/object-store-access-policies": {
       "minVersion": "2.0",
@@ -2869,6 +3457,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -2883,7 +3475,11 @@
         "X-Request-ID": "2.14",
         "context_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /object-store-users/object-store-access-policies": {
       "minVersion": "2.0",
@@ -2895,7 +3491,11 @@
         "X-Request-ID": "2.14",
         "context_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /object-store-virtual-hosts": {
       "minVersion": "2.0",
@@ -2912,6 +3512,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -2931,6 +3535,10 @@
         "hostname": "2.20",
         "realms": "2.20"
       },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "readOnlyBodyProperties": [
         "context",
         "id",
@@ -2949,7 +3557,11 @@
         "X-Request-ID": "2.14",
         "context_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /policies": {
       "minVersion": "2.0",
@@ -2968,6 +3580,10 @@
         "workload_names": "2.23"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -2998,6 +3614,10 @@
         "realms",
         "retention_lock"
       ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "names": "Names_required"
       }
@@ -3010,7 +3630,11 @@
         "X-Request-ID": "2.14",
         "context_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /policies": {
       "minVersion": "2.0",
@@ -3042,7 +3666,11 @@
         "policy_type",
         "realms",
         "retention_lock"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /policies/file-systems": {
       "minVersion": "2.0",
@@ -3061,6 +3689,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -3075,7 +3707,11 @@
         "X-Request-ID": "2.14",
         "context_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /policies/file-systems": {
       "minVersion": "2.0",
@@ -3087,7 +3723,11 @@
         "X-Request-ID": "2.14",
         "context_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /policies/file-system-snapshots": {
       "minVersion": "2.0",
@@ -3106,6 +3746,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -3120,7 +3764,11 @@
         "X-Request-ID": "2.14",
         "context_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /policies/members": {
       "minVersion": "2.0",
@@ -3146,6 +3794,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get",
         "member_types": "Member_types"
@@ -3173,6 +3825,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -3190,7 +3846,11 @@
         "X-Request-ID": "2.14",
         "context_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /policies/file-system-replica-links": {
       "minVersion": "2.0",
@@ -3205,7 +3865,11 @@
         "X-Request-ID": "2.14",
         "context_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /quotas/groups": {
       "minVersion": "2.0",
@@ -3225,6 +3889,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get",
         "gids": "Group_quota_gids"
@@ -3247,6 +3915,10 @@
       "readOnlyBodyProperties": [
         "name"
       ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "gids": "Group_quota_gids"
       }
@@ -3263,6 +3935,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "gids": "Group_quota_gids"
       }
@@ -3285,6 +3961,10 @@
       "readOnlyBodyProperties": [
         "name"
       ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "gids": "Group_quota_gids"
       }
@@ -3296,7 +3976,11 @@
         "names": "2.0",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /quotas/settings": {
       "minVersion": "2.0",
@@ -3312,7 +3996,11 @@
       "readOnlyBodyProperties": [
         "id",
         "name"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /quotas/users": {
       "minVersion": "2.0",
@@ -3332,6 +4020,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get",
         "uids": "User_quota_uids"
@@ -3354,6 +4046,10 @@
       "readOnlyBodyProperties": [
         "name"
       ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "uids": "User_quota_uids"
       }
@@ -3370,6 +4066,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "uids": "User_quota_uids"
       }
@@ -3392,6 +4092,10 @@
       "readOnlyBodyProperties": [
         "name"
       ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "uids": "User_quota_uids"
       }
@@ -3408,7 +4112,11 @@
         "sort": "2.0",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /smtp-servers": {
       "minVersion": "2.0",
@@ -3422,7 +4130,11 @@
         "sort": "2.0",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /smtp-servers": {
       "minVersion": "2.0",
@@ -3439,7 +4151,11 @@
       "readOnlyBodyProperties": [
         "id",
         "name"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /snmp-agents": {
       "minVersion": "2.0",
@@ -3453,7 +4169,11 @@
         "sort": "2.0",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /snmp-agents": {
       "minVersion": "2.0",
@@ -3472,14 +4192,22 @@
         "engine_id",
         "id",
         "name"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /snmp-agents/mib": {
       "minVersion": "2.0",
       "parameters": {
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /snmp-managers": {
       "minVersion": "2.0",
@@ -3493,7 +4221,11 @@
         "sort": "2.0",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "POST /snmp-managers": {
       "minVersion": "2.0",
@@ -3507,6 +4239,10 @@
         "version": "2.0",
         "v2c": "2.0",
         "v3": "2.0"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       },
       "parameterComponentOverrides": {
         "names": "Names_required"
@@ -3530,7 +4266,11 @@
       },
       "readOnlyBodyProperties": [
         "id"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /snmp-managers": {
       "minVersion": "2.0",
@@ -3539,7 +4279,11 @@
         "names": "2.0",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /snmp-managers/test": {
       "minVersion": "2.0",
@@ -3553,7 +4297,11 @@
         "sort": "2.0",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /subnets": {
       "minVersion": "2.0",
@@ -3567,7 +4315,11 @@
         "sort": "2.0",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "POST /subnets": {
       "minVersion": "2.0",
@@ -3586,6 +4338,10 @@
         "prefix": "2.18",
         "services": "2.18",
         "vlan": "2.18"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       },
       "readOnlyBodyProperties": [
         "enabled",
@@ -3617,6 +4373,10 @@
         "services": "2.18",
         "vlan": "2.18"
       },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "readOnlyBodyProperties": [
         "enabled",
         "id",
@@ -3632,7 +4392,11 @@
         "names": "2.0",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /support": {
       "minVersion": "2.0",
@@ -3641,7 +4405,11 @@
         "names": "2.0",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /support": {
       "minVersion": "2.0",
@@ -3669,7 +4437,11 @@
         "remote_assist_opened",
         "remote_assist_paths",
         "remote_assist_status"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /support/test": {
       "minVersion": "2.0",
@@ -3679,7 +4451,11 @@
         "test_type": "2.0",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /syslog-servers": {
       "minVersion": "2.0",
@@ -3696,6 +4472,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get",
         "names": "Names_for_syslog"
@@ -3711,6 +4491,10 @@
         "uri": "2.14",
         "services": "2.14",
         "sources": "2.20"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       },
       "parameterComponentOverrides": {
         "names": "Names_for_syslog"
@@ -3728,6 +4512,10 @@
         "services": "2.14",
         "sources": "2.20"
       },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "names": "Names_for_syslog"
       }
@@ -3740,6 +4528,10 @@
         "X-Request-ID": "2.14"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "names": "Names_for_syslog"
       }
@@ -3756,7 +4548,11 @@
         "sort": "2.0",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /syslog-servers/settings": {
       "minVersion": "2.0",
@@ -3774,7 +4570,11 @@
       "readOnlyBodyProperties": [
         "id",
         "name"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /syslog-servers/test": {
       "minVersion": "2.0",
@@ -3782,7 +4582,11 @@
         "continuation_token": "2.0",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /targets": {
       "minVersion": "2.0",
@@ -3799,6 +4603,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -3811,6 +4619,10 @@
       },
       "bodyProperties": {
         "address": "2.0"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       },
       "parameterComponentOverrides": {
         "names": "Names_required"
@@ -3835,7 +4647,11 @@
         "id",
         "status",
         "status_details"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /targets": {
       "minVersion": "2.0",
@@ -3844,7 +4660,11 @@
         "names": "2.0",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /targets/performance/replication": {
       "minVersion": "2.0",
@@ -3862,7 +4682,11 @@
         "total_only": "2.0",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /usage/groups": {
       "minVersion": "2.0",
@@ -3881,6 +4705,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get",
         "gids": "Group_quota_gids"
@@ -3903,6 +4731,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get",
         "uids": "User_quota_uids"
@@ -3918,21 +4750,33 @@
         "sort": "2.1",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /arrays/factory-reset-token": {
       "minVersion": "2.1",
       "parameters": {
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "POST /arrays/factory-reset-token": {
       "minVersion": "2.1",
       "parameters": {
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /kmip": {
       "minVersion": "2.1",
@@ -3946,7 +4790,11 @@
         "continuation_token": "2.1",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "POST /kmip": {
       "minVersion": "2.1",
@@ -3960,6 +4808,10 @@
         "ca_certificate": "2.18",
         "ca_certificate_group": "2.18",
         "uris": "2.18"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       },
       "readOnlyBodyProperties": [
         "id",
@@ -3980,6 +4832,10 @@
         "ca_certificate_group": "2.18",
         "uris": "2.18"
       },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "readOnlyBodyProperties": [
         "id",
         "name"
@@ -3992,7 +4848,11 @@
         "ids": "2.1",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /kmip/test": {
       "minVersion": "2.1",
@@ -4001,14 +4861,22 @@
         "ids": "2.1",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /rapid-data-locking": {
       "minVersion": "2.1",
       "parameters": {
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /rapid-data-locking": {
       "minVersion": "2.1",
@@ -4018,6 +4886,10 @@
       "bodyProperties": {
         "enabled": "2.1",
         "kmip_server": "2.1"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       }
     },
     "GET /rapid-data-locking/test": {
@@ -4025,14 +4897,22 @@
       "parameters": {
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "POST /rapid-data-locking/rotate": {
       "minVersion": "2.1",
       "parameters": {
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "POST /object-store-access-policies": {
       "minVersion": "2.2",
@@ -4045,6 +4925,10 @@
       "bodyProperties": {
         "rules": "2.2",
         "description": "2.2"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       },
       "parameterComponentOverrides": {
         "names": "Names_required"
@@ -4061,6 +4945,10 @@
       },
       "bodyProperties": {
         "rules": "2.2"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       }
     },
     "DELETE /object-store-access-policies": {
@@ -4071,7 +4959,11 @@
         "X-Request-ID": "2.14",
         "context_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /object-store-access-policies/rules": {
       "minVersion": "2.2",
@@ -4089,6 +4981,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -4108,6 +5004,10 @@
         "conditions": "2.2",
         "resources": "2.2",
         "effect": "2.18"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       },
       "parameterComponentOverrides": {
         "names": "Names_required"
@@ -4130,6 +5030,10 @@
         "effect": "2.2",
         "policy": "2.2",
         "resources": "2.2"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       }
     },
     "DELETE /object-store-access-policies/rules": {
@@ -4141,7 +5045,11 @@
         "X-Request-ID": "2.14",
         "context_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /object-store-access-policy-actions": {
       "minVersion": "2.2",
@@ -4157,6 +5065,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -4176,6 +5088,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -4204,6 +5120,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get",
         "member_types": "Member_types"
@@ -4219,7 +5139,11 @@
         "sort": "2.3",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /admins/settings": {
       "minVersion": "2.3",
@@ -4230,6 +5154,10 @@
         "lockout_duration": "2.3",
         "max_login_attempts": "2.3",
         "min_password_length": "2.3"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       }
     },
     "GET /file-systems/policies-all": {
@@ -4249,6 +5177,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -4268,7 +5200,11 @@
         "total_only": "2.3",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /nfs-export-policies": {
       "minVersion": "2.3",
@@ -4287,6 +5223,10 @@
         "workload_names": "2.23"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -4315,6 +5255,10 @@
         "policy_type",
         "realms"
       ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "names": "Names_required"
       }
@@ -4346,7 +5290,11 @@
         "policy_type",
         "realms",
         "version"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /nfs-export-policies": {
       "minVersion": "2.3",
@@ -4357,7 +5305,11 @@
         "X-Request-ID": "2.14",
         "context_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /nfs-export-policies/rules": {
       "minVersion": "2.3",
@@ -4376,6 +5328,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -4409,6 +5365,10 @@
         "index": "2.18",
         "context": "2.18"
       },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "readOnlyBodyProperties": [
         "context",
         "id",
@@ -4425,7 +5385,11 @@
         "X-Request-ID": "2.14",
         "context_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /nfs-export-policies/rules": {
       "minVersion": "2.3",
@@ -4456,6 +5420,10 @@
         "index": "2.18",
         "context": "2.18"
       },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "readOnlyBodyProperties": [
         "id",
         "name"
@@ -4473,7 +5441,11 @@
         "sort": "2.3",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /drives": {
       "minVersion": "2.4",
@@ -4488,7 +5460,11 @@
         "total_only": "2.4",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /logs-async": {
       "minVersion": "2.4",
@@ -4502,7 +5478,11 @@
         "sort": "2.4",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /logs-async": {
       "minVersion": "2.4",
@@ -4527,7 +5507,11 @@
         "name",
         "processing",
         "progress"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /logs-async/download": {
       "minVersion": "2.4",
@@ -4535,7 +5519,11 @@
         "names": "2.4",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /network-interfaces/ping": {
       "minVersion": "2.6",
@@ -4549,7 +5537,11 @@
         "resolve_hostname": "2.6",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /network-interfaces/trace": {
       "minVersion": "2.6",
@@ -4564,7 +5556,11 @@
         "resolve_hostname": "2.6",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /support/verification-keys": {
       "minVersion": "2.7",
@@ -4576,7 +5572,11 @@
         "sort": "2.7",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /support/verification-keys": {
       "minVersion": "2.7",
@@ -4585,6 +5585,10 @@
       },
       "bodyProperties": {
         "signed_verification_key": "2.7"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       }
     },
     "GET /file-systems/locks": {
@@ -4604,6 +5608,10 @@
         "context_names": "2.22"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -4622,6 +5630,10 @@
         "context_names": "2.22"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "recursive": "Recursive"
       }
@@ -4637,6 +5649,10 @@
         "context_names": "2.22"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -4647,7 +5663,11 @@
         "X-Request-ID": "2.14",
         "context_names": "2.22"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /object-store-accounts": {
       "minVersion": "2.8",
@@ -4663,6 +5683,10 @@
         "hard_limit_enabled": "2.8",
         "quota_limit": "2.8",
         "public_access_config": "2.12"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       },
       "parameterComponentOverrides": {
         "ignore_usage": "Ignore_usage"
@@ -4682,7 +5706,11 @@
         "X-Request-ID": "2.14",
         "context_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /file-systems/sessions": {
       "minVersion": "2.10",
@@ -4698,6 +5726,10 @@
         "context_names": "2.22"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get",
         "user_names": "Sessions_user_names"
@@ -4715,6 +5747,10 @@
         "context_names": "2.22"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "user_names": "Sessions_user_names"
       }
@@ -4736,6 +5772,10 @@
         "workload_names": "2.23"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -4764,6 +5804,10 @@
         "policy_type",
         "realms"
       ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "names": "Names_required"
       }
@@ -4795,7 +5839,11 @@
         "policy_type",
         "realms",
         "version"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /smb-client-policies": {
       "minVersion": "2.10",
@@ -4805,7 +5853,11 @@
         "X-Request-ID": "2.14",
         "context_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /smb-client-policies/rules": {
       "minVersion": "2.10",
@@ -4824,6 +5876,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -4850,7 +5906,11 @@
       "readOnlyBodyProperties": [
         "id",
         "name"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /smb-client-policies/rules": {
       "minVersion": "2.10",
@@ -4879,7 +5939,11 @@
         "id",
         "name",
         "policy_version"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /smb-client-policies/rules": {
       "minVersion": "2.10",
@@ -4890,7 +5954,11 @@
         "X-Request-ID": "2.14",
         "context_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /smb-share-policies": {
       "minVersion": "2.10",
@@ -4909,6 +5977,10 @@
         "workload_names": "2.23"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -4936,6 +6008,10 @@
         "policy_type",
         "realms"
       ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "names": "Names_required"
       }
@@ -4964,7 +6040,11 @@
         "is_local",
         "policy_type",
         "realms"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /smb-share-policies": {
       "minVersion": "2.10",
@@ -4974,7 +6054,11 @@
         "X-Request-ID": "2.14",
         "context_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /smb-share-policies/rules": {
       "minVersion": "2.10",
@@ -4993,6 +6077,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -5016,7 +6104,11 @@
       "readOnlyBodyProperties": [
         "id",
         "name"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /smb-share-policies/rules": {
       "minVersion": "2.10",
@@ -5040,7 +6132,11 @@
       "readOnlyBodyProperties": [
         "id",
         "name"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /smb-share-policies/rules": {
       "minVersion": "2.10",
@@ -5052,7 +6148,11 @@
         "X-Request-ID": "2.14",
         "context_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /buckets/cross-origin-resource-sharing-policies": {
       "minVersion": "2.12",
@@ -5070,6 +6170,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -5084,6 +6188,10 @@
       },
       "bodyProperties": {
         "rules": "2.12"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       }
     },
     "DELETE /buckets/cross-origin-resource-sharing-policies": {
@@ -5095,7 +6203,11 @@
         "X-Request-ID": "2.14",
         "context_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /buckets/cross-origin-resource-sharing-policies/rules": {
       "minVersion": "2.12",
@@ -5114,6 +6226,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -5133,6 +6249,10 @@
         "allowed_methods": "2.12",
         "allowed_origins": "2.12"
       },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "names": "Names_required"
       }
@@ -5147,7 +6267,11 @@
         "X-Request-ID": "2.14",
         "context_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /buckets/bucket-access-policies": {
       "minVersion": "2.12",
@@ -5165,6 +6289,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -5179,6 +6307,10 @@
       },
       "bodyProperties": {
         "rules": "2.12"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       }
     },
     "DELETE /buckets/bucket-access-policies": {
@@ -5190,7 +6322,11 @@
         "X-Request-ID": "2.14",
         "context_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /buckets/bucket-access-policies/rules": {
       "minVersion": "2.12",
@@ -5209,6 +6345,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -5232,6 +6372,10 @@
       "readOnlyBodyProperties": [
         "effect"
       ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "names": "Names_required"
       }
@@ -5246,7 +6390,11 @@
         "X-Request-ID": "2.14",
         "context_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /network-access-policies": {
       "minVersion": "2.13",
@@ -5260,7 +6408,11 @@
         "sort": "2.13",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /network-access-policies": {
       "minVersion": "2.13",
@@ -5287,7 +6439,11 @@
         "policy_type",
         "realms",
         "version"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /network-access-policies/members": {
       "minVersion": "2.13",
@@ -5303,7 +6459,11 @@
         "sort": "2.13",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /network-access-policies/rules": {
       "minVersion": "2.13",
@@ -5319,7 +6479,11 @@
         "sort": "2.13",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "POST /network-access-policies/rules": {
       "minVersion": "2.13",
@@ -5342,7 +6506,11 @@
       "readOnlyBodyProperties": [
         "id",
         "name"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /network-access-policies/rules": {
       "minVersion": "2.13",
@@ -5368,7 +6536,11 @@
         "id",
         "name",
         "policy_version"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /network-access-policies/rules": {
       "minVersion": "2.13",
@@ -5378,7 +6550,11 @@
         "versions": "2.13",
         "X-Request-ID": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /admins/ssh-certificate-authority-policies": {
       "minVersion": "2.14",
@@ -5397,6 +6573,10 @@
         "context_names": "2.24"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -5411,7 +6591,11 @@
         "policy_names": "2.14",
         "context_names": "2.24"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /admins/ssh-certificate-authority-policies": {
       "minVersion": "2.14",
@@ -5423,7 +6607,11 @@
         "policy_names": "2.14",
         "context_names": "2.24"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /arrays/ssh-certificate-authority-policies": {
       "minVersion": "2.14",
@@ -5442,6 +6630,10 @@
         "context_names": "2.24"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "unknown",
+        "provenance": "unknown"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -5456,7 +6648,11 @@
         "policy_names": "2.14",
         "context_names": "2.24"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "unknown",
+        "provenance": "unknown"
+      }
     },
     "DELETE /arrays/ssh-certificate-authority-policies": {
       "minVersion": "2.14",
@@ -5468,7 +6664,11 @@
         "policy_names": "2.14",
         "context_names": "2.24"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "unknown",
+        "provenance": "unknown"
+      }
     },
     "GET /audit-file-systems-policies": {
       "minVersion": "2.14",
@@ -5485,6 +6685,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -5514,6 +6718,10 @@
         "policy_type",
         "realms"
       ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "names": "Names_required"
       }
@@ -5545,7 +6753,11 @@
         "is_local",
         "policy_type",
         "realms"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /audit-file-systems-policies": {
       "minVersion": "2.14",
@@ -5555,7 +6767,11 @@
         "names": "2.14",
         "context_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /audit-file-systems-policies/members": {
       "minVersion": "2.14",
@@ -5574,6 +6790,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -5588,7 +6808,11 @@
         "policy_names": "2.14",
         "context_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /audit-file-systems-policies/members": {
       "minVersion": "2.14",
@@ -5600,7 +6824,11 @@
         "policy_names": "2.14",
         "context_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "POST /directory-services/roles": {
       "minVersion": "2.14",
@@ -5615,6 +6843,10 @@
         "name": "2.18",
         "role": "2.18",
         "management_access_policies": "2.19"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       }
     },
     "DELETE /directory-services/roles": {
@@ -5624,7 +6856,11 @@
         "names": "2.14",
         "ids": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /file-systems/audit-policies": {
       "minVersion": "2.14",
@@ -5643,6 +6879,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -5657,7 +6897,11 @@
         "policy_names": "2.14",
         "context_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /file-systems/audit-policies": {
       "minVersion": "2.14",
@@ -5669,7 +6913,11 @@
         "policy_names": "2.14",
         "context_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /public-keys": {
       "minVersion": "2.14",
@@ -5683,7 +6931,11 @@
         "offset": "2.14",
         "sort": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "POST /public-keys": {
       "minVersion": "2.14",
@@ -5693,6 +6945,10 @@
       },
       "bodyProperties": {
         "public_key": "2.14"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       },
       "parameterComponentOverrides": {
         "names": "Names_required"
@@ -5705,7 +6961,11 @@
         "ids": "2.14",
         "names": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /public-keys/uses": {
       "minVersion": "2.14",
@@ -5719,7 +6979,11 @@
         "offset": "2.14",
         "sort": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /ssh-certificate-authority-policies": {
       "minVersion": "2.14",
@@ -5736,6 +7000,10 @@
         "context_names": "2.24"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -5763,6 +7031,10 @@
         "policy_type",
         "realms"
       ],
+      "contextScope": {
+        "scope": "unknown",
+        "provenance": "unknown"
+      },
       "parameterComponentOverrides": {
         "names": "Names_required"
       }
@@ -5774,7 +7046,11 @@
         "ids": "2.14",
         "names": "2.14"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /ssh-certificate-authority-policies": {
       "minVersion": "2.14",
@@ -5801,7 +7077,11 @@
         "is_local",
         "policy_type",
         "realms"
-      ]
+      ],
+      "contextScope": {
+        "scope": "unknown",
+        "provenance": "unknown"
+      }
     },
     "GET /ssh-certificate-authority-policies/admins": {
       "minVersion": "2.14",
@@ -5820,6 +7100,10 @@
         "context_names": "2.24"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -5834,7 +7118,11 @@
         "policy_names": "2.14",
         "context_names": "2.24"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /ssh-certificate-authority-policies/admins": {
       "minVersion": "2.14",
@@ -5846,7 +7134,11 @@
         "policy_names": "2.14",
         "context_names": "2.24"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /ssh-certificate-authority-policies/arrays": {
       "minVersion": "2.14",
@@ -5865,6 +7157,10 @@
         "context_names": "2.24"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -5879,7 +7175,11 @@
         "policy_names": "2.14",
         "context_names": "2.24"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /ssh-certificate-authority-policies/arrays": {
       "minVersion": "2.14",
@@ -5891,7 +7191,11 @@
         "policy_names": "2.14",
         "context_names": "2.24"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /ssh-certificate-authority-policies/members": {
       "minVersion": "2.14",
@@ -5910,6 +7214,10 @@
         "context_names": "2.24"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -5927,6 +7235,10 @@
         "role": "2.15",
         "management_access_policies": "2.19",
         "admin_type": "2.26"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       }
     },
     "DELETE /admins": {
@@ -5937,7 +7249,11 @@
         "names": "2.15",
         "context_names": "2.24"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /file-systems/worm-data-policies": {
       "minVersion": "2.15",
@@ -5956,6 +7272,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -5972,7 +7292,11 @@
         "offset": "2.15",
         "sort": "2.15"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "POST /sso/saml2/idps": {
       "minVersion": "2.15",
@@ -5995,6 +7319,10 @@
       "readOnlyBodyProperties": [
         "prn"
       ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "names": "Names_required"
       }
@@ -6006,7 +7334,11 @@
         "ids": "2.15",
         "names": "2.15"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /sso/saml2/idps": {
       "minVersion": "2.15",
@@ -6026,6 +7358,10 @@
         "prn": "2.18",
         "services": "2.18",
         "management": "2.24"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       },
       "readOnlyBodyProperties": [
         "id",
@@ -6047,6 +7383,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -6072,6 +7412,10 @@
         "retention_lock": "2.18",
         "context": "2.18",
         "realms": "2.19"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       },
       "readOnlyBodyProperties": [
         "context",
@@ -6108,6 +7452,10 @@
         "context": "2.18",
         "realms": "2.19"
       },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "readOnlyBodyProperties": [
         "context",
         "id",
@@ -6125,7 +7473,11 @@
         "names": "2.15",
         "context_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /worm-data-policies/members": {
       "minVersion": "2.15",
@@ -6144,6 +7496,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -6163,7 +7519,11 @@
         "storage_class_names": "2.16",
         "total_only": "2.16"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "POST /dns": {
       "minVersion": "2.16",
@@ -6182,6 +7542,10 @@
         "ca_certificate": "2.25",
         "ca_certificate_group": "2.25"
       },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "names": "Names_required"
       }
@@ -6194,7 +7558,11 @@
         "names": "2.16",
         "context_names": "2.25"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /file-system-exports": {
       "minVersion": "2.16",
@@ -6213,6 +7581,10 @@
         "workload_names": "2.23"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -6231,6 +7603,10 @@
         "export_name": "2.16",
         "server": "2.16",
         "share_policy": "2.16"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       }
     },
     "PATCH /file-system-exports": {
@@ -6261,7 +7637,11 @@
         "name",
         "policy_type",
         "status"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /file-system-exports": {
       "minVersion": "2.16",
@@ -6271,7 +7651,11 @@
         "names": "2.16",
         "context_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /maintenance-windows": {
       "minVersion": "2.16",
@@ -6285,7 +7669,11 @@
         "offset": "2.16",
         "sort": "2.16"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "POST /maintenance-windows": {
       "minVersion": "2.16",
@@ -6295,6 +7683,10 @@
       },
       "bodyProperties": {
         "timeout": "2.16"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       },
       "parameterComponentOverrides": {
         "names": "Names_required"
@@ -6307,7 +7699,11 @@
         "ids": "2.16",
         "names": "2.16"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /password-policies": {
       "minVersion": "2.16",
@@ -6321,7 +7717,11 @@
         "offset": "2.16",
         "sort": "2.16"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /password-policies": {
       "minVersion": "2.16",
@@ -6354,7 +7754,11 @@
         "is_local",
         "policy_type",
         "realms"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /sso/saml2/idps/test": {
       "minVersion": "2.16",
@@ -6366,7 +7770,11 @@
         "names": "2.16",
         "sort": "2.16"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /sso/saml2/idps/test": {
       "minVersion": "2.16",
@@ -6386,6 +7794,10 @@
         "services": "2.18",
         "sp": "2.18",
         "management": "2.24"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       },
       "readOnlyBodyProperties": [
         "id",
@@ -6407,6 +7819,10 @@
         "context_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -6424,6 +7840,10 @@
         "dns": "2.18",
         "local_directory_service": "2.24"
       },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "names": "Names_required"
       }
@@ -6439,6 +7859,10 @@
         "directory_services": "2.18",
         "dns": "2.18",
         "local_directory_service": "2.24"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       }
     },
     "DELETE /servers": {
@@ -6449,7 +7873,11 @@
         "ids": "2.16",
         "names": "2.16"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /support-diagnostics": {
       "minVersion": "2.16",
@@ -6463,7 +7891,11 @@
         "offset": "2.16",
         "sort": "2.16"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "POST /support-diagnostics": {
       "minVersion": "2.16",
@@ -6472,7 +7904,11 @@
         "analysis_period_start_time": "2.16",
         "analysis_period_end_time": "2.16"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /support-diagnostics/details": {
       "minVersion": "2.16",
@@ -6486,7 +7922,11 @@
         "offset": "2.16",
         "sort": "2.16"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /software-check": {
       "minVersion": "2.16",
@@ -6501,7 +7941,11 @@
         "sort": "2.16",
         "total_item_count": "2.16"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "POST /software-check": {
       "minVersion": "2.16",
@@ -6510,7 +7954,11 @@
         "software_versions": "2.16",
         "software_names": "2.16"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /qos-policies/file-systems": {
       "minVersion": "2.17",
@@ -6529,6 +7977,10 @@
         "context_names": "2.23"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -6547,7 +7999,11 @@
         "policy_names": "2.17",
         "sort": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "POST /tls-policies/network-interfaces": {
       "minVersion": "2.17",
@@ -6558,7 +8014,11 @@
         "policy_ids": "2.17",
         "policy_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /tls-policies/network-interfaces": {
       "minVersion": "2.17",
@@ -6569,7 +8029,11 @@
         "policy_ids": "2.17",
         "policy_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /legal-holds": {
       "minVersion": "2.17",
@@ -6583,7 +8047,11 @@
         "offset": "2.17",
         "sort": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "POST /legal-holds": {
       "minVersion": "2.17",
@@ -6596,6 +8064,10 @@
         "name": "2.18",
         "description": "2.18",
         "realms": "2.19"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       },
       "readOnlyBodyProperties": [
         "id",
@@ -6613,7 +8085,11 @@
         "ids": "2.17",
         "names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /legal-holds": {
       "minVersion": "2.17",
@@ -6627,6 +8103,10 @@
         "name": "2.18",
         "description": "2.18",
         "realms": "2.19"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       },
       "readOnlyBodyProperties": [
         "id",
@@ -6649,7 +8129,11 @@
         "sort": "2.17",
         "total_only": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "POST /fleets/members": {
       "minVersion": "2.17",
@@ -6660,6 +8144,10 @@
       },
       "bodyProperties": {
         "members": "2.17"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       }
     },
     "DELETE /fleets/members": {
@@ -6670,7 +8158,11 @@
         "member_names": "2.17",
         "unreachable": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /tls-policies": {
       "minVersion": "2.17",
@@ -6686,7 +8178,11 @@
         "purity_defined": "2.17",
         "sort": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "POST /tls-policies": {
       "minVersion": "2.17",
@@ -6716,6 +8212,10 @@
         "policy_type",
         "realms"
       ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "names": "Names_required"
       }
@@ -6727,7 +8227,11 @@
         "ids": "2.17",
         "names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /tls-policies": {
       "minVersion": "2.17",
@@ -6757,7 +8261,11 @@
         "is_local",
         "policy_type",
         "realms"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /qos-policies": {
       "minVersion": "2.17",
@@ -6774,6 +8282,10 @@
         "context_names": "2.23"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -6804,6 +8316,10 @@
         "policy_type",
         "realms"
       ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "names": "Names_required"
       }
@@ -6816,7 +8332,11 @@
         "names": "2.17",
         "context_names": "2.23"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /qos-policies": {
       "minVersion": "2.17",
@@ -6844,7 +8364,11 @@
         "is_local",
         "policy_type",
         "realms"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /fleets/fleet-key": {
       "minVersion": "2.17",
@@ -6857,14 +8381,22 @@
         "sort": "2.17",
         "total_only": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "POST /fleets/fleet-key": {
       "minVersion": "2.17",
       "parameters": {
         "X-Request-ID": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /tls-policies/members": {
       "minVersion": "2.17",
@@ -6880,7 +8412,11 @@
         "policy_names": "2.17",
         "sort": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /object-store-roles": {
       "minVersion": "2.17",
@@ -6897,6 +8433,10 @@
         "sort": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -6911,6 +8451,10 @@
       "bodyProperties": {
         "max_session_duration": "2.17"
       },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "names": "Names_required"
       }
@@ -6923,7 +8467,11 @@
         "ids": "2.17",
         "names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /object-store-roles": {
       "minVersion": "2.17",
@@ -6950,7 +8498,11 @@
         "name",
         "prn",
         "trusted_entities"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /object-store-access-policies/object-store-roles": {
       "minVersion": "2.17",
@@ -6969,6 +8521,10 @@
         "sort": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -6983,7 +8539,11 @@
         "policy_ids": "2.17",
         "policy_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /object-store-access-policies/object-store-roles": {
       "minVersion": "2.17",
@@ -6995,7 +8555,11 @@
         "policy_ids": "2.17",
         "policy_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /file-systems/open-files": {
       "minVersion": "2.17",
@@ -7013,6 +8577,10 @@
         "user_names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "paths": "Open_files_paths",
         "protocols": "Protocols_required",
@@ -7025,7 +8593,11 @@
         "X-Request-ID": "2.17",
         "ids": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /remote-arrays": {
       "minVersion": "2.17",
@@ -7041,7 +8613,11 @@
         "sort": "2.17",
         "total_only": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /file-system-replica-links": {
       "minVersion": "2.17",
@@ -7055,7 +8631,11 @@
         "remote_names": "2.17",
         "replicate_now": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /network-interfaces/connectors/performance": {
       "minVersion": "2.17",
@@ -7072,7 +8652,11 @@
         "start_time": "2.17",
         "total_only": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /fleets": {
       "minVersion": "2.17",
@@ -7088,6 +8672,10 @@
         "total_only": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "ids": "Ids_single",
         "names": "Names_single"
@@ -7100,6 +8688,10 @@
         "names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "names": "Names_single"
       }
@@ -7112,6 +8704,10 @@
         "names": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "ids": "Ids_single",
         "names": "Names_single"
@@ -7126,6 +8722,10 @@
       },
       "bodyProperties": {
         "name": "2.17"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       },
       "parameterComponentOverrides": {
         "ids": "Ids_single",
@@ -7150,6 +8750,10 @@
         "context_names": "2.23"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get",
         "member_types": "Member_types_qos"
@@ -7167,7 +8771,11 @@
         "offset": "2.17",
         "sort": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /network-interfaces/connectors": {
       "minVersion": "2.17",
@@ -7185,6 +8793,10 @@
         "port_speed": "2.18",
         "transceiver_type": "2.18",
         "lanes_per_port": "2.20"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       },
       "readOnlyBodyProperties": [
         "connector_type",
@@ -7205,7 +8817,11 @@
         "offset": "2.17",
         "sort": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "POST /sso/oidc/idps": {
       "minVersion": "2.17",
@@ -7221,7 +8837,11 @@
       },
       "readOnlyBodyProperties": [
         "prn"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /sso/oidc/idps": {
       "minVersion": "2.17",
@@ -7230,7 +8850,11 @@
         "ids": "2.17",
         "names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /sso/oidc/idps": {
       "minVersion": "2.17",
@@ -7248,7 +8872,11 @@
       },
       "readOnlyBodyProperties": [
         "prn"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /object-store-roles/object-store-access-policies": {
       "minVersion": "2.17",
@@ -7267,6 +8895,10 @@
         "sort": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -7281,7 +8913,11 @@
         "policy_ids": "2.17",
         "policy_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /object-store-roles/object-store-access-policies": {
       "minVersion": "2.17",
@@ -7293,7 +8929,11 @@
         "policy_ids": "2.17",
         "policy_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /object-store-roles/object-store-trust-policies/rules": {
       "minVersion": "2.17",
@@ -7313,6 +8953,10 @@
         "sort": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -7334,6 +8978,10 @@
         "policy": "2.18",
         "principals": "2.18"
       },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "readOnlyBodyProperties": [
         "effect"
       ]
@@ -7349,7 +8997,11 @@
         "role_ids": "2.17",
         "role_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /object-store-roles/object-store-trust-policies/rules": {
       "minVersion": "2.17",
@@ -7369,6 +9021,10 @@
         "policy": "2.18",
         "principals": "2.18"
       },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "readOnlyBodyProperties": [
         "effect"
       ]
@@ -7382,7 +9038,11 @@
         "role_ids": "2.17",
         "role_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /object-store-roles/object-store-trust-policies": {
       "minVersion": "2.17",
@@ -7400,6 +9060,10 @@
         "sort": "2.17"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -7418,7 +9082,11 @@
         "policy_names": "2.17",
         "sort": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "POST /network-interfaces/tls-policies": {
       "minVersion": "2.17",
@@ -7429,7 +9097,11 @@
         "policy_ids": "2.17",
         "policy_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /network-interfaces/tls-policies": {
       "minVersion": "2.17",
@@ -7440,7 +9112,11 @@
         "policy_ids": "2.17",
         "policy_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /object-store-roles/object-store-trust-policies/download": {
       "minVersion": "2.17",
@@ -7450,7 +9126,11 @@
         "role_ids": "2.17",
         "role_names": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /network-interfaces/connectors/settings": {
       "minVersion": "2.17",
@@ -7464,7 +9144,11 @@
         "offset": "2.17",
         "sort": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /legal-holds/held-entities": {
       "minVersion": "2.17",
@@ -7478,7 +9162,11 @@
         "names": "2.17",
         "paths": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "POST /legal-holds/held-entities": {
       "minVersion": "2.17",
@@ -7491,7 +9179,11 @@
         "paths": "2.17",
         "recursive": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /legal-holds/held-entities": {
       "minVersion": "2.17",
@@ -7505,7 +9197,11 @@
         "recursive": "2.17",
         "released": "2.17"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /arrays/clients/s3-specific-performance": {
       "minVersion": "2.18",
@@ -7517,7 +9213,11 @@
         "sort": "2.18",
         "total_only": "2.18"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "POST /arrays/erasures": {
       "minVersion": "2.18",
@@ -7527,7 +9227,11 @@
         "preserve_configuration_data": "2.18",
         "skip_phonehome_check": "2.18"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /arrays/erasures": {
       "minVersion": "2.18",
@@ -7537,21 +9241,33 @@
         "eradicate_all_data": "2.18",
         "finalize": "2.18"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /arrays/erasures": {
       "minVersion": "2.18",
       "parameters": {
         "X-Request-ID": "2.18"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /arrays/erasures": {
       "minVersion": "2.18",
       "parameters": {
         "X-Request-ID": "2.18"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /audit-file-systems-policy-operations": {
       "minVersion": "2.18",
@@ -7567,6 +9283,10 @@
         "sort": "2.18"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "unknown",
+        "provenance": "unknown"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -7585,7 +9305,11 @@
         "storage_class_names": "2.18",
         "total_only": "2.18"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /network-interfaces/network-connection-statistics": {
       "minVersion": "2.18",
@@ -7601,7 +9325,11 @@
         "remote_port": "2.18",
         "sort": "2.18"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /nodes": {
       "minVersion": "2.18",
@@ -7616,7 +9344,11 @@
         "sort": "2.18",
         "total_only": "2.18"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /nodes": {
       "minVersion": "2.18",
@@ -7648,7 +9380,11 @@
         "raw_capacity",
         "status",
         "unique"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "POST /nodes/batch": {
       "minVersion": "2.18",
@@ -7656,7 +9392,11 @@
         "X-Request-ID": "2.18",
         "add_to_groups": "2.23"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /node-groups": {
       "minVersion": "2.18",
@@ -7670,7 +9410,11 @@
         "offset": "2.18",
         "sort": "2.18"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "POST /node-groups": {
       "minVersion": "2.18",
@@ -7678,7 +9422,11 @@
         "X-Request-ID": "2.18",
         "names": "2.18"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /node-groups": {
       "minVersion": "2.18",
@@ -7689,6 +9437,10 @@
       },
       "bodyProperties": {
         "name": "2.18"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       }
     },
     "DELETE /node-groups": {
@@ -7698,7 +9450,11 @@
         "ids": "2.18",
         "names": "2.18"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /node-groups/nodes": {
       "minVersion": "2.18",
@@ -7714,7 +9470,11 @@
         "offset": "2.18",
         "sort": "2.18"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "POST /node-groups/nodes": {
       "minVersion": "2.18",
@@ -7725,7 +9485,11 @@
         "node_ids": "2.18",
         "node_names": "2.18"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /node-groups/nodes": {
       "minVersion": "2.18",
@@ -7736,7 +9500,11 @@
         "node_ids": "2.18",
         "node_names": "2.18"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /node-groups/uses": {
       "minVersion": "2.18",
@@ -7750,7 +9518,11 @@
         "offset": "2.18",
         "sort": "2.18"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /storage-class-tiering-policies": {
       "minVersion": "2.18",
@@ -7764,7 +9536,11 @@
         "offset": "2.18",
         "sort": "2.18"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "POST /storage-class-tiering-policies": {
       "minVersion": "2.18",
@@ -7789,6 +9565,10 @@
         "policy_type",
         "realms"
       ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "names": "Names_required"
       }
@@ -7800,7 +9580,11 @@
         "ids": "2.18",
         "names": "2.18"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /storage-class-tiering-policies": {
       "minVersion": "2.18",
@@ -7825,7 +9609,11 @@
         "is_local",
         "policy_type",
         "realms"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /storage-class-tiering-policies/members": {
       "minVersion": "2.18",
@@ -7844,6 +9632,10 @@
         "sort": "2.18"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "unknown",
+        "provenance": "unknown"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -7865,6 +9657,10 @@
         "context_names": "2.24"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -7879,7 +9675,11 @@
         "policy_names": "2.19",
         "context_names": "2.24"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /admins/management-access-policies": {
       "minVersion": "2.19",
@@ -7891,7 +9691,11 @@
         "policy_names": "2.19",
         "context_names": "2.24"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /directory-services/roles/management-access-policies": {
       "minVersion": "2.19",
@@ -7907,7 +9711,11 @@
         "policy_names": "2.19",
         "sort": "2.19"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "POST /directory-services/roles/management-access-policies": {
       "minVersion": "2.19",
@@ -7918,7 +9726,11 @@
         "policy_ids": "2.19",
         "policy_names": "2.19"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /directory-services/roles/management-access-policies": {
       "minVersion": "2.19",
@@ -7929,7 +9741,11 @@
         "policy_ids": "2.19",
         "policy_names": "2.19"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /management-access-policies": {
       "minVersion": "2.19",
@@ -7946,6 +9762,10 @@
         "context_names": "2.24"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -7974,6 +9794,10 @@
         "policy_type",
         "realms"
       ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "names": "Names_required"
       }
@@ -7986,7 +9810,11 @@
         "names": "2.19",
         "context_names": "2.26"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /management-access-policies": {
       "minVersion": "2.19",
@@ -8016,7 +9844,11 @@
         "policy_type",
         "realms",
         "version"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /management-access-policies/admins": {
       "minVersion": "2.19",
@@ -8035,6 +9867,10 @@
         "context_names": "2.24"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -8049,7 +9885,11 @@
         "policy_names": "2.19",
         "context_names": "2.24"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /management-access-policies/admins": {
       "minVersion": "2.19",
@@ -8061,7 +9901,11 @@
         "policy_names": "2.19",
         "context_names": "2.24"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /management-access-policies/directory-services/roles": {
       "minVersion": "2.19",
@@ -8077,7 +9921,11 @@
         "policy_names": "2.19",
         "sort": "2.19"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "POST /management-access-policies/directory-services/roles": {
       "minVersion": "2.19",
@@ -8088,7 +9936,11 @@
         "policy_ids": "2.19",
         "policy_names": "2.19"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /management-access-policies/directory-services/roles": {
       "minVersion": "2.19",
@@ -8099,7 +9951,11 @@
         "policy_ids": "2.19",
         "policy_names": "2.19"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /management-access-policies/members": {
       "minVersion": "2.19",
@@ -8118,6 +9974,10 @@
         "context_names": "2.24"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -8139,6 +9999,10 @@
         "context_names": "2.23"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -8160,6 +10024,10 @@
         "context_names": "2.24"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "unknown",
+        "provenance": "unknown"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -8172,6 +10040,10 @@
         "without_default_access_list": "2.19"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "names": "Names_required"
       }
@@ -8183,7 +10055,11 @@
         "ids": "2.19",
         "names": "2.19"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /realms": {
       "minVersion": "2.19",
@@ -8200,7 +10076,11 @@
       },
       "readOnlyBodyProperties": [
         "id"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /realms/space": {
       "minVersion": "2.19",
@@ -8218,7 +10098,11 @@
         "total_only": "2.19",
         "type": "2.19"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /realms/space/storage-classes": {
       "minVersion": "2.19",
@@ -8237,7 +10121,11 @@
         "storage_class_names": "2.19",
         "total_only": "2.19"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /resource-accesses": {
       "minVersion": "2.19",
@@ -8251,6 +10139,10 @@
         "sort": "2.19"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "limit": "Limit_scale"
       }
@@ -8261,14 +10153,22 @@
         "X-Request-ID": "2.19",
         "ids": "2.19"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "POST /resource-accesses/batch": {
       "minVersion": "2.19",
       "parameters": {
         "X-Request-ID": "2.19"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /audit-object-store-policies": {
       "minVersion": "2.20",
@@ -8285,6 +10185,10 @@
         "sort": "2.20"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -8312,6 +10216,10 @@
         "policy_type",
         "realms"
       ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "names": "Names_required"
       }
@@ -8324,7 +10232,11 @@
         "ids": "2.20",
         "names": "2.20"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /audit-object-store-policies": {
       "minVersion": "2.20",
@@ -8351,7 +10263,11 @@
         "is_local",
         "policy_type",
         "realms"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /audit-object-store-policies/members": {
       "minVersion": "2.20",
@@ -8370,6 +10286,10 @@
         "sort": "2.20"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -8384,7 +10304,11 @@
         "policy_ids": "2.20",
         "policy_names": "2.20"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /audit-object-store-policies/members": {
       "minVersion": "2.20",
@@ -8396,7 +10320,11 @@
         "policy_ids": "2.20",
         "policy_names": "2.20"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /bucket-audit-filter-actions": {
       "minVersion": "2.20",
@@ -8412,6 +10340,10 @@
         "sort": "2.20"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -8432,6 +10364,10 @@
         "sort": "2.20"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -8449,6 +10385,10 @@
         "actions": "2.20",
         "s3_prefixes": "2.20"
       },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "names": "Names_required"
       }
@@ -8462,7 +10402,11 @@
         "context_names": "2.20",
         "names": "2.20"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /buckets/audit-filters": {
       "minVersion": "2.20",
@@ -8476,6 +10420,10 @@
       "bodyProperties": {
         "actions": "2.20",
         "s3_prefixes": "2.20"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       },
       "parameterComponentOverrides": {
         "names": "Names_required"
@@ -8496,6 +10444,10 @@
         "organizational_unit": "2.20",
         "state": "2.20",
         "subject_alternative_names": "2.20"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       }
     },
     "GET /log-targets/file-systems": {
@@ -8513,6 +10465,10 @@
         "sort": "2.20"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "unknown",
+        "provenance": "unknown"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -8534,6 +10490,10 @@
       "readOnlyBodyProperties": [
         "id"
       ],
+      "contextScope": {
+        "scope": "unknown",
+        "provenance": "unknown"
+      },
       "parameterComponentOverrides": {
         "names": "Names_required"
       }
@@ -8546,7 +10506,11 @@
         "ids": "2.20",
         "names": "2.20"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /log-targets/file-systems": {
       "minVersion": "2.20",
@@ -8565,7 +10529,11 @@
       },
       "readOnlyBodyProperties": [
         "id"
-      ]
+      ],
+      "contextScope": {
+        "scope": "unknown",
+        "provenance": "unknown"
+      }
     },
     "GET /log-targets/object-store": {
       "minVersion": "2.20",
@@ -8582,6 +10550,10 @@
         "sort": "2.20"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -8603,6 +10575,10 @@
       "readOnlyBodyProperties": [
         "id"
       ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "names": "Names_required"
       }
@@ -8615,7 +10591,11 @@
         "ids": "2.20",
         "names": "2.20"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /log-targets/object-store": {
       "minVersion": "2.20",
@@ -8634,7 +10614,11 @@
       },
       "readOnlyBodyProperties": [
         "id"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /network-interfaces/neighbors": {
       "minVersion": "2.20",
@@ -8648,7 +10632,11 @@
         "sort": "2.20",
         "total_item_count": "2.20"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /object-store-account-exports": {
       "minVersion": "2.20",
@@ -8665,6 +10653,10 @@
         "sort": "2.20"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -8682,6 +10674,10 @@
       "bodyProperties": {
         "export_enabled": "2.20",
         "server": "2.20"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       }
     },
     "DELETE /object-store-account-exports": {
@@ -8692,7 +10688,11 @@
         "ids": "2.20",
         "names": "2.20"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /object-store-account-exports": {
       "minVersion": "2.20",
@@ -8705,6 +10705,10 @@
       "bodyProperties": {
         "export_enabled": "2.20",
         "policy": "2.20"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       }
     },
     "PATCH /object-store-virtual-hosts": {
@@ -8725,7 +10729,11 @@
       },
       "readOnlyBodyProperties": [
         "id"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "POST /qos-policies/members": {
       "minVersion": "2.20",
@@ -8739,6 +10747,10 @@
         "context_names": "2.23"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "member_types": "Member_types_qos_no_buckets"
       }
@@ -8755,6 +10767,10 @@
         "context_names": "2.23"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "member_types": "Member_types_qos_no_buckets"
       }
@@ -8774,6 +10790,10 @@
         "sort": "2.20"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -8794,7 +10814,11 @@
       "readOnlyBodyProperties": [
         "context",
         "realm"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /s3-export-policies": {
       "minVersion": "2.20",
@@ -8811,6 +10835,10 @@
         "sort": "2.20"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -8826,6 +10854,10 @@
         "enabled": "2.20",
         "rules": "2.20"
       },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "names": "Names_required"
       }
@@ -8838,7 +10870,11 @@
         "ids": "2.20",
         "names": "2.20"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /s3-export-policies": {
       "minVersion": "2.20",
@@ -8852,6 +10888,10 @@
         "enabled": "2.20",
         "name": "2.20",
         "rules": "2.20"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       }
     },
     "GET /s3-export-policies/rules": {
@@ -8870,6 +10910,10 @@
         "sort": "2.20"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -8888,6 +10932,10 @@
         "effect": "2.20",
         "resources": "2.20"
       },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "names": "Names_required"
       }
@@ -8902,6 +10950,10 @@
         "policy_names": "2.20"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "names": "Names_required"
       }
@@ -8919,6 +10971,10 @@
         "actions": "2.20",
         "effect": "2.20",
         "resources": "2.20"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       },
       "parameterComponentOverrides": {
         "names": "Names_required"
@@ -8939,6 +10995,10 @@
         "sort": "2.21"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -8966,6 +11026,10 @@
         "policy_type",
         "realms"
       ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "names": "Names_required"
       }
@@ -8978,7 +11042,11 @@
         "ids": "2.21",
         "names": "2.21"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /data-eviction-policies": {
       "minVersion": "2.21",
@@ -9005,7 +11073,11 @@
         "is_local",
         "policy_type",
         "realms"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /data-eviction-policies/file-systems": {
       "minVersion": "2.21",
@@ -9024,6 +11096,10 @@
         "sort": "2.21"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -9038,7 +11114,11 @@
         "policy_ids": "2.21",
         "policy_names": "2.21"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /data-eviction-policies/file-systems": {
       "minVersion": "2.21",
@@ -9050,7 +11130,11 @@
         "policy_ids": "2.21",
         "policy_names": "2.21"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /data-eviction-policies/members": {
       "minVersion": "2.21",
@@ -9069,6 +11153,10 @@
         "sort": "2.21"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -9090,6 +11178,10 @@
         "sort": "2.21"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -9104,7 +11196,11 @@
         "policy_ids": "2.21",
         "policy_names": "2.21"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /file-systems/data-eviction-policies": {
       "minVersion": "2.21",
@@ -9116,7 +11212,11 @@
         "policy_ids": "2.21",
         "policy_names": "2.21"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /admins/management-authentication-policies": {
       "minVersion": "2.22",
@@ -9135,6 +11235,10 @@
         "sort": "2.22"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -9149,7 +11253,11 @@
         "policy_ids": "2.22",
         "policy_names": "2.22"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /admins/management-authentication-policies": {
       "minVersion": "2.22",
@@ -9161,7 +11269,11 @@
         "policy_ids": "2.22",
         "policy_names": "2.22"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /arrays/management-authentication-policies": {
       "minVersion": "2.22",
@@ -9180,6 +11292,10 @@
         "sort": "2.22"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -9194,7 +11310,11 @@
         "policy_ids": "2.22",
         "policy_names": "2.22"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /arrays/management-authentication-policies": {
       "minVersion": "2.22",
@@ -9206,7 +11326,11 @@
         "policy_ids": "2.22",
         "policy_names": "2.22"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /management-authentication-policies": {
       "minVersion": "2.22",
@@ -9223,6 +11347,10 @@
         "sort": "2.22"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -9250,6 +11378,10 @@
         "policy_type",
         "realms"
       ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "names": "Names_required"
       }
@@ -9262,7 +11394,11 @@
         "ids": "2.22",
         "names": "2.22"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /management-authentication-policies": {
       "minVersion": "2.22",
@@ -9289,7 +11425,11 @@
         "is_local",
         "policy_type",
         "realms"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /management-authentication-policies/members": {
       "minVersion": "2.22",
@@ -9309,6 +11449,10 @@
         "sort": "2.22"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get",
         "member_types": "Management_access_policies_member_types"
@@ -9326,6 +11470,10 @@
         "policy_names": "2.22"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "member_types": "Management_access_policies_member_types"
       }
@@ -9342,6 +11490,10 @@
         "policy_names": "2.22"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "member_types": "Management_access_policies_member_types"
       }
@@ -9355,6 +11507,10 @@
         "names": "2.23"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "declared"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -9392,6 +11548,10 @@
         "id",
         "revision"
       ],
+      "contextScope": {
+        "scope": "fleet",
+        "provenance": "declared"
+      },
       "parameterComponentOverrides": {
         "ids": "Ids_single",
         "names": "Names_single"
@@ -9424,6 +11584,10 @@
       "readOnlyBodyProperties": [
         "revision"
       ],
+      "contextScope": {
+        "scope": "fleet",
+        "provenance": "declared"
+      },
       "parameterComponentOverrides": {
         "names": "Names_single_required"
       }
@@ -9437,6 +11601,10 @@
         "names": "2.23"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "fleet",
+        "provenance": "declared"
+      },
       "parameterComponentOverrides": {
         "ids": "Ids_single",
         "names": "Names_single"
@@ -9452,6 +11620,10 @@
       },
       "bodyProperties": {
         "name": "2.23"
+      },
+      "contextScope": {
+        "scope": "fleet",
+        "provenance": "declared"
       },
       "parameterComponentOverrides": {
         "ids": "Ids_single",
@@ -9470,7 +11642,11 @@
         "offset": "2.23",
         "sort": "2.23"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /resiliency-groups/members": {
       "minVersion": "2.23",
@@ -9486,7 +11662,11 @@
         "resiliency_group_names": "2.23",
         "sort": "2.23"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /workloads": {
       "minVersion": "2.23",
@@ -9501,6 +11681,10 @@
         "names": "2.23"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -9517,6 +11701,10 @@
       "bodyProperties": {
         "parameters": "2.23"
       },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "names": "Names_single_required"
       }
@@ -9530,6 +11718,10 @@
         "names": "2.23"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "ids": "Ids_single",
         "names": "Names_single"
@@ -9546,6 +11738,10 @@
       "bodyProperties": {
         "destroyed": "2.23",
         "name": "2.23"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       },
       "parameterComponentOverrides": {
         "ids": "Ids_single",
@@ -9564,6 +11760,10 @@
         "names": "2.23"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -9607,6 +11807,10 @@
         "results",
         "status"
       ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "preset_ids": null,
         "preset_names": null
@@ -9623,6 +11827,10 @@
         "resource_names": "2.23"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "live-tested"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -9638,6 +11846,10 @@
         "resource_names": "2.23"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "namespaces": "Namespaces_delete"
       }
@@ -9650,7 +11862,11 @@
         "resource_ids": "2.23",
         "resource_names": "2.23"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /directory-services/local/directory-services": {
       "minVersion": "2.24",
@@ -9669,6 +11885,10 @@
         "total_item_count": "2.24"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get",
         "ids": "IdsSemiRequired",
@@ -9685,6 +11905,10 @@
       "bodyProperties": {
         "domain": "2.24"
       },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "names": "Names_required"
       }
@@ -9698,6 +11922,10 @@
         "names": "2.24"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "ids": "IdsSemiRequired",
         "names": "NamesSemiRequired"
@@ -9729,6 +11957,10 @@
         "server",
         "time_remaining"
       ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "ids": "IdsSemiRequired",
         "names": "NamesSemiRequired"
@@ -9752,6 +11984,10 @@
         "total_item_count": "2.24"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get",
         "ids": "IdsSemiRequired",
@@ -9771,6 +12007,10 @@
         "email": "2.24",
         "gid": "2.24"
       },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "names": "Names_required"
       }
@@ -9787,6 +12027,10 @@
         "sids": "2.24"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "names": "NamesGeneral"
       }
@@ -9815,6 +12059,10 @@
         "context",
         "sid"
       ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "names": "NamesGeneral"
       }
@@ -9840,6 +12088,10 @@
         "total_item_count": "2.24"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get",
         "group_names": "Local_group_names",
@@ -9859,6 +12111,10 @@
       },
       "bodyProperties": {
         "members": "2.24"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       },
       "parameterComponentOverrides": {
         "group_names": "Local_group_names"
@@ -9880,6 +12136,10 @@
         "member_types": "2.24"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "group_names": "Local_group_names",
         "member_ids": "Local_member_ids"
@@ -9903,6 +12163,10 @@
         "uids": "2.24"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get",
         "ids": "IdsSemiRequired",
@@ -9925,6 +12189,10 @@
         "primary_group": "2.24",
         "uid": "2.24"
       },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "names": "Names_required"
       }
@@ -9941,6 +12209,10 @@
         "uids": "2.24"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "names": "NamesGeneral"
       }
@@ -9963,6 +12235,10 @@
         "password": "2.24",
         "primary_group": "2.24",
         "uid": "2.24"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       },
       "parameterComponentOverrides": {
         "names": "NamesGeneral"
@@ -9988,6 +12264,10 @@
         "total_item_count": "2.24"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get",
         "group_names": "Local_group_names",
@@ -10009,6 +12289,10 @@
         "groups": "2.24",
         "is_primary": "2.24"
       },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "member_ids": "Local_member_ids"
       }
@@ -10029,6 +12313,10 @@
         "member_types": "2.24"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "group_names": "Local_group_names",
         "member_ids": "Local_member_ids"
@@ -10045,14 +12333,22 @@
         "sort": "2.24",
         "total_item_count": "2.24"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /support-diagnostics/settings": {
       "minVersion": "2.24",
       "parameters": {
         "X-Request-ID": "2.24"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /software-bundle": {
       "minVersion": "2.24",
@@ -10066,7 +12362,11 @@
         "sort": "2.24",
         "total_item_count": "2.24"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "POST /software-bundle": {
       "minVersion": "2.24",
@@ -10075,6 +12375,10 @@
       },
       "bodyProperties": {
         "source": "2.24"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       }
     },
     "GET /software-patches": {
@@ -10090,7 +12394,11 @@
         "sort": "2.24",
         "total_item_count": "2.24"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "POST /software-patches": {
       "minVersion": "2.24",
@@ -10099,7 +12407,11 @@
         "allow_ha_reduction": "2.24",
         "name": "2.24"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /file-systems/user-group-quota-policies": {
       "minVersion": "2.25",
@@ -10118,6 +12430,10 @@
         "sort": "2.25"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -10134,7 +12450,11 @@
         "policy_ids": "2.25",
         "policy_names": "2.25"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /file-systems/user-group-quota-policies": {
       "minVersion": "2.25",
@@ -10146,7 +12466,11 @@
         "policy_ids": "2.25",
         "policy_names": "2.25"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /file-system-junctions": {
       "minVersion": "2.25",
@@ -10167,6 +12491,10 @@
         "sort": "2.25"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -10197,6 +12525,10 @@
         "origin_file_system",
         "status"
       ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "names": "Names_single_required",
         "origin_file_system_ids": "Origin_file_system_ids_single",
@@ -10211,7 +12543,11 @@
         "ids": "2.25",
         "names": "2.25"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /file-system-group-quotas": {
       "minVersion": "2.25",
@@ -10230,6 +12566,10 @@
         "sort": "2.25"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -10251,6 +12591,10 @@
         "sort": "2.25"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -10273,6 +12617,10 @@
         "user_sids": "2.25"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -10295,6 +12643,10 @@
         "user_sids": "2.25"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -10314,7 +12666,11 @@
         "remote_realm_names": "2.25",
         "sort": "2.25"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "POST /realm-connections": {
       "minVersion": "2.25",
@@ -10337,7 +12693,11 @@
         "local_realm",
         "remote_realm",
         "status"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /realm-connections": {
       "minVersion": "2.25",
@@ -10348,7 +12708,11 @@
         "remote_realm_ids": "2.25",
         "remote_realm_names": "2.25"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /realm-connections/connection-key": {
       "minVersion": "2.25",
@@ -10362,7 +12726,11 @@
         "realm_names": "2.25",
         "sort": "2.25"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "POST /realm-connections/connection-key": {
       "minVersion": "2.25",
@@ -10371,7 +12739,11 @@
         "realm_ids": "2.25",
         "realm_names": "2.25"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /realm-connections/connection-key": {
       "minVersion": "2.25",
@@ -10380,7 +12752,11 @@
         "realm_ids": "2.25",
         "realm_names": "2.25"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /remote-realms": {
       "minVersion": "2.25",
@@ -10397,7 +12773,11 @@
         "sort": "2.25",
         "total_only": "2.25"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /user-group-quota-policies": {
       "minVersion": "2.25",
@@ -10414,6 +12794,10 @@
         "sort": "2.25"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -10443,6 +12827,10 @@
         "policy_type",
         "realms"
       ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "names": "Names_required"
       }
@@ -10476,7 +12864,11 @@
         "policy_type",
         "realms",
         "version"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /user-group-quota-policies": {
       "minVersion": "2.25",
@@ -10487,7 +12879,11 @@
         "names": "2.25",
         "versions": "2.25"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /user-group-quota-policies/rules": {
       "minVersion": "2.25",
@@ -10504,6 +12900,10 @@
         "sort": "2.25"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -10523,6 +12923,10 @@
         "quota_limit": "2.25",
         "quota_type": "2.25",
         "subject": "2.25"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       }
     },
     "DELETE /user-group-quota-policies/rules": {
@@ -10535,7 +12939,11 @@
         "policy_ids": "2.25",
         "policy_names": "2.25"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /user-group-quota-policies/rules": {
       "minVersion": "2.25",
@@ -10554,7 +12962,11 @@
       "readOnlyBodyProperties": [
         "id",
         "name"
-      ]
+      ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /user-group-quota-policies/file-systems": {
       "minVersion": "2.25",
@@ -10573,6 +12985,10 @@
         "sort": "2.25"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -10589,7 +13005,11 @@
         "policy_ids": "2.25",
         "policy_names": "2.25"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "DELETE /user-group-quota-policies/file-systems": {
       "minVersion": "2.25",
@@ -10601,7 +13021,11 @@
         "policy_ids": "2.25",
         "policy_names": "2.25"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /user-group-quota-policies/members": {
       "minVersion": "2.25",
@@ -10620,6 +13044,10 @@
         "sort": "2.25"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -10639,6 +13067,10 @@
         "sort": "2.26"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -10653,6 +13085,10 @@
       "bodyProperties": {
         "description": "2.26"
       },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "names": "Names_required"
       }
@@ -10665,7 +13101,11 @@
         "ids": "2.26",
         "names": "2.26"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /management-access-policies/roles/permissions": {
       "minVersion": "2.26",
@@ -10684,6 +13124,10 @@
         "sort": "2.26"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get",
         "role_ids": "Management_access_role_ids",
@@ -10702,6 +13146,10 @@
         "actions": "2.26",
         "resource": "2.26"
       },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "role_ids": "Management_access_role_ids",
         "role_names": "Management_access_role_names"
@@ -10715,7 +13163,11 @@
         "ids": "2.26",
         "names": "2.26"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /management-access-policies/roles/permissions": {
       "minVersion": "2.26",
@@ -10727,6 +13179,10 @@
       },
       "bodyProperties": {
         "actions": "2.26"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       }
     },
     "GET /management-access-policies/roles/permissions/supported-resources": {
@@ -10743,6 +13199,10 @@
         "sort": "2.26"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -10764,6 +13224,10 @@
         "sort": "2.26"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -10796,6 +13260,10 @@
         "policy",
         "policy_version"
       ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "versions": "Concurrency_versions"
       }
@@ -10810,6 +13278,10 @@
         "versions": "2.26"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "versions": "Concurrency_versions"
       }
@@ -10842,6 +13314,10 @@
         "policy",
         "policy_version"
       ],
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "versions": "Concurrency_versions"
       }
@@ -10855,7 +13331,11 @@
         "to_topology_group_ids": "2.26",
         "to_topology_group_names": "2.26"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /support/system-manifest": {
       "minVersion": "2.26",
@@ -10871,6 +13351,10 @@
         "total_only": "2.26"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -10891,6 +13375,10 @@
         "total_item_count": "2.26"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "fleet",
+        "provenance": "live-tested"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -10904,7 +13392,11 @@
         "parent_topology_group_ids": "2.26",
         "parent_topology_group_names": "2.26"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /topology-groups": {
       "minVersion": "2.26",
@@ -10918,6 +13410,10 @@
       },
       "bodyProperties": {
         "topology_group": "2.26"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       }
     },
     "DELETE /topology-groups": {
@@ -10928,7 +13424,11 @@
         "ids": "2.26",
         "names": "2.26"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /topology-groups/arrays": {
       "minVersion": "2.26",
@@ -10947,6 +13447,10 @@
         "total_item_count": "2.26"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "fleet",
+        "provenance": "live-tested"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get"
       }
@@ -10969,6 +13473,10 @@
         "total_item_count": "2.26"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "fleet",
+        "provenance": "live-tested"
+      },
       "parameterComponentOverrides": {
         "context_names": "Context_names_get",
         "recursive": "Topology_group_members_recursive"
@@ -10984,6 +13492,10 @@
       },
       "bodyProperties": {
         "members": "2.26"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       }
     },
     "DELETE /topology-groups/members": {
@@ -10996,7 +13508,11 @@
         "topology_group_ids": "2.26",
         "topology_group_names": "2.26"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "PATCH /active-directory/test": {
       "minVersion": "2.27",
@@ -11009,6 +13525,10 @@
       "bodyProperties": {
         "ca_certificate": "2.27",
         "ca_certificate_group": "2.27"
+      },
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
       }
     },
     "POST /fleets/members/batch": {
@@ -11019,7 +13539,11 @@
         "fleet_names": "2.27",
         "validate_target_certificates": "2.27"
       },
-      "bodyProperties": {}
+      "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      }
     },
     "GET /storage-classes/members": {
       "minVersion": "2.27",
@@ -11035,6 +13559,10 @@
         "storage_class_names": "2.27"
       },
       "bodyProperties": {},
+      "contextScope": {
+        "scope": "array",
+        "provenance": "default"
+      },
       "parameterComponentOverrides": {
         "storage_class_names": "Storage_class_names"
       }

--- a/Private/PfbContextConstants.ps1
+++ b/Private/PfbContextConstants.ps1
@@ -1,0 +1,13 @@
+# Fusion context parameter names, shared by the runtime injection path (Phase 1) and the
+# maintainer drift check in tools/lib/PfbContextRuleTools.ps1.
+#
+# These live in Private/ rather than tools/ because tools/ may depend on Private/ and never
+# the reverse -- the same dependency direction issue #74 exists to fix. tools/ dot-sources
+# this file explicitly, since tools/ is not on the module's load path.
+#
+# The 'Context_names_get' component literal is deliberately NOT here: it is the cardinality
+# rule's own business and already lives inside Test-PfbContextMultiValueCapable, which is
+# THE single declared home of that rule. A second definition here would be exactly the
+# duplication #74 is about.
+$script:PfbContextParameterName     = 'context_names'
+$script:PfbAllowErrorsParameterName = 'allow_errors'

--- a/Private/Resolve-PfbParameterComponent.ps1
+++ b/Private/Resolve-PfbParameterComponent.ps1
@@ -62,14 +62,40 @@ function Resolve-PfbParameterComponent {
 
     # Key PRESENCE, never the value's truthiness -- see .DESCRIPTION. A present key whose
     # value is null returns null here and must NOT reach the defaults lookup below.
+    #
+    # Both container shapes must be handled, and they need DIFFERENT operators:
+    #   * PSCustomObject -- what ConvertFrom-Json yields reading Data/PfbCapabilityMap.json.
+    #   * IDictionary ([ordered]@{}) -- what tools/Build-PfbCapabilityMap.ps1 builds IN
+    #     MEMORY before serializing, so any tools/ caller resolving against the map it just
+    #     built passes this shape.
+    # For a Hashtable/OrderedDictionary, .PSObject.Properties.Name does NOT return the keys
+    # -- it returns the adapted CLR surface (Keys, Values, Count, IsReadOnly, ...). A
+    # presence test written only against .PSObject.Properties.Name is therefore ALWAYS FALSE
+    # for dictionary input and silently falls through to the defaults, reproducing the exact
+    # wrong-component defect this function exists to prevent. It is also a false POSITIVE
+    # for an intrinsic name ('Count' would "resolve" to the item count).
+    #
+    # Empty containers are covered by key absence, not truthiness: an empty PSCustomObject
+    # AND an empty hashtable are both truthy, so truthiness carries no information here.
     $overrides = $EndpointEntry.parameterComponentOverrides
-    if ($overrides -and ($overrides.PSObject.Properties.Name -contains $ParameterName)) {
-        return $overrides.$ParameterName
+    if ($null -ne $overrides) {
+        if ($overrides -is [System.Collections.IDictionary]) {
+            if ($overrides.Contains($ParameterName)) { return $overrides[$ParameterName] }
+        }
+        elseif ($overrides.PSObject.Properties.Name -contains $ParameterName) {
+            return $overrides.$ParameterName
+        }
     }
 
-    if ($ParameterComponentDefaults -and
-        ($ParameterComponentDefaults.PSObject.Properties.Name -contains $ParameterName)) {
-        return $ParameterComponentDefaults.$ParameterName
+    if ($null -ne $ParameterComponentDefaults) {
+        if ($ParameterComponentDefaults -is [System.Collections.IDictionary]) {
+            if ($ParameterComponentDefaults.Contains($ParameterName)) {
+                return $ParameterComponentDefaults[$ParameterName]
+            }
+        }
+        elseif ($ParameterComponentDefaults.PSObject.Properties.Name -contains $ParameterName) {
+            return $ParameterComponentDefaults.$ParameterName
+        }
     }
 
     return $null

--- a/Private/Resolve-PfbParameterComponent.ps1
+++ b/Private/Resolve-PfbParameterComponent.ps1
@@ -1,0 +1,76 @@
+function Resolve-PfbParameterComponent {
+    <#
+    .SYNOPSIS
+        Resolves which OpenAPI component backs a named parameter on one capability-map
+        endpoint entry, per the map's three-step resolution contract.
+    .DESCRIPTION
+        THE single runtime home of the contract documented in
+        tools/Build-PfbCapabilityMap.ps1's second pass. Three ordered steps:
+
+          1. If the endpoint's parameterComponentOverrides CONTAINS THE KEY for this
+             parameter, that value is authoritative -- EVEN WHEN IT IS JSON null, which
+             means "this endpoint's parameter has no component". Defaults are not consulted.
+          2. Otherwise, if the map's top-level parameterComponentDefaults contains the
+             parameter name, use that.
+          3. Otherwise, there is no known component.
+
+        WHY THIS IS ITS OWN FUNCTION. Steps 1-with-null and 3 both return $null, so the
+        distinction is NOT observable in the return value -- it is entirely about whether
+        step 2 is allowed to run. An implementation that tests the override's VALUE
+        (`if ($overrides.$name)`) rather than the KEY's PRESENCE silently falls through to
+        the default for a null override, yielding a component name the endpoint does not
+        actually have. Only 7 of 4109 parameter declarations in fb2.27 are inline/no-$ref,
+        so a wrong implementation is right almost everywhere -- and wrong precisely on the
+        endpoints the Fusion cardinality rule (Test-PfbContextMultiValueCapable) depends on.
+
+        Extracted from tools/lib/PfbContextRuleTools.ps1 per issue #74: the module could not
+        feed its own declared cardinality rule, because the code producing the rule's
+        -ContextComponent input lived in tools/, which the module never loads. tools/ may
+        depend on Private/; never the reverse.
+
+        Deliberately parameterised on -ParameterName rather than hardcoded to
+        'context_names': the contract is a property of the capability map's shape, not of
+        Fusion, and allow_errors needs the same resolution in Phase 2.
+
+        PURE -- no map loading, no file I/O. The caller supplies the entry and the defaults
+        table, exactly like Test-PfbContextMultiValueCapable.
+    .PARAMETER EndpointEntry
+        One capability-map endpoints.<key> object, as parsed from
+        Data/PfbCapabilityMap.json.
+    .PARAMETER ParameterName
+        The API parameter name to resolve, e.g. 'context_names'.
+    .PARAMETER ParameterComponentDefaults
+        The map's top-level parameterComponentDefaults object. Pass $null when unavailable;
+        resolution then stops after step 1.
+    .OUTPUTS
+        [string] the resolved component name, or $null when the endpoint's parameter has no
+        component (step 1 with a null override) or no component is known (step 3). These two
+        outcomes are deliberately indistinguishable to the caller.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)]
+        $EndpointEntry,
+
+        [Parameter(Mandatory)]
+        [string]$ParameterName,
+
+        [AllowNull()]
+        $ParameterComponentDefaults
+    )
+
+    # Key PRESENCE, never the value's truthiness -- see .DESCRIPTION. A present key whose
+    # value is null returns null here and must NOT reach the defaults lookup below.
+    $overrides = $EndpointEntry.parameterComponentOverrides
+    if ($overrides -and ($overrides.PSObject.Properties.Name -contains $ParameterName)) {
+        return $overrides.$ParameterName
+    }
+
+    if ($ParameterComponentDefaults -and
+        ($ParameterComponentDefaults.PSObject.Properties.Name -contains $ParameterName)) {
+        return $ParameterComponentDefaults.$ParameterName
+    }
+
+    return $null
+}

--- a/Private/Test-PfbCapabilityMapCoverage.ps1
+++ b/Private/Test-PfbCapabilityMapCoverage.ps1
@@ -1,0 +1,61 @@
+function Test-PfbCapabilityMapCoverage {
+    <#
+    .SYNOPSIS
+        Does the connected array's negotiated REST version exceed the range the bundled
+        capability map was generated from?
+    .DESCRIPTION
+        The honesty half of Assert-PfbApiCapability's permissive fallback. When the array is
+        newer than the map, the module has no evidence either way and deliberately proceeds
+        rather than blocking -- a cmdlet caller never chose the negotiated version, so
+        refusing a call because the BUNDLED MAP is behind punishes a packaging lag they
+        cannot see. Telling them is what makes that trade honest.
+
+        This function contributes POLICY, not arithmetic. The comparison is delegated to
+        Test-PfbVersionAtLeast -- the same comparator Assert-PfbApiCapability uses -- so the
+        warning and the capability check can never disagree about what is in range. Finding
+        the highest scanned version is delegated to ConvertTo-PfbVersionObject, which
+        returns its results sorted Major,Minor DESCENDING, so element [0] is the maximum.
+        Do not reimplement either; a naive string compare ranks '2.9' above '2.26', a bug
+        already found twice in this repo.
+
+        The policy: return $false whenever the answer cannot be established -- a missing
+        map, an empty generatedFrom, or an unparseable version string. "Nothing to check
+        against" must never become a warning, exactly as it never becomes a hard failure in
+        Get-PfbCapabilityMap.
+    .PARAMETER NegotiatedVersion
+        The REST version Connect-PfbArray negotiated with the array, e.g. '2.28'.
+    .PARAMETER CapabilityMap
+        The parsed capability map, or $null when it could not be loaded.
+    .OUTPUTS
+        [bool]
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory)]
+        [string]$NegotiatedVersion,
+
+        [AllowNull()]
+        $CapabilityMap
+    )
+
+    if ($null -eq $CapabilityMap) { return $false }
+
+    $scanned = @($CapabilityMap.generatedFrom)
+    if ($scanned.Count -eq 0) { return $false }
+
+    # Both helpers cast their split parts with [int] and do not guard the input, so a
+    # malformed version string throws rather than returning a verdict. Per the policy above
+    # that must be silence, not a warning and not a failed Connect-PfbArray.
+    try {
+        $highestScanned = (ConvertTo-PfbVersionObject -Versions $scanned)[0].Version
+
+        # "At least" is >=, and an exact match must NOT warn. So the question is whether the
+        # map fails to reach the array: NOT (highest >= negotiated).
+        return -not (Test-PfbVersionAtLeast -Have $highestScanned -Need $NegotiatedVersion)
+    }
+    catch {
+        Write-Verbose "Test-PfbCapabilityMapCoverage: could not compare '$NegotiatedVersion' against the map's generatedFrom ($($scanned -join ', ')): $($_.Exception.Message)"
+        return $false
+    }
+}

--- a/Private/Test-PfbCapabilityMapCoverage.ps1
+++ b/Private/Test-PfbCapabilityMapCoverage.ps1
@@ -19,13 +19,29 @@ function Test-PfbCapabilityMapCoverage {
         already found twice in this repo.
 
         The policy: return $false whenever the answer cannot be established -- a missing
-        map, an empty generatedFrom, or an unparseable version string. "Nothing to check
-        against" must never become a warning, exactly as it never becomes a hard failure in
-        Get-PfbCapabilityMap.
+        map, a generatedFrom that is absent/null/empty, or an unparseable version string.
+        "Nothing to check against" must never become a warning, exactly as it never becomes a
+        hard failure in Get-PfbCapabilityMap.
+
+        Note which guard catches what: the .Count check below only short-circuits a literal
+        empty array. An ABSENT or $null generatedFrom becomes @($null), whose Count is 1, so
+        it falls through to the try and is caught there. Both routes return $false; the
+        guards are defence in depth rather than the only cover, and neither is individually
+        load-bearing.
+
+        -HighestScanned exists so the CALLER never has to re-parse. The warning text needs
+        the maximum, and computing it a second time at the call site would put an unguarded
+        copy of this function's own throwing expression outside this try/catch -- safe only
+        by an invariant living in a different file. Handing it back keeps one parse, inside
+        one guard. This mirrors Assert-PfbConnection's existing [ref] idiom.
     .PARAMETER NegotiatedVersion
         The REST version Connect-PfbArray negotiated with the array, e.g. '2.28'.
     .PARAMETER CapabilityMap
         The parsed capability map, or $null when it could not be loaded.
+    .PARAMETER HighestScanned
+        Optional [ref]. Receives the highest version in generatedFrom when that could be
+        determined. Only meaningful when this function returns $true; left untouched
+        otherwise.
     .OUTPUTS
         [bool]
     #>
@@ -36,7 +52,10 @@ function Test-PfbCapabilityMapCoverage {
         [string]$NegotiatedVersion,
 
         [AllowNull()]
-        $CapabilityMap
+        $CapabilityMap,
+
+        [AllowNull()]
+        [ref]$HighestScanned
     )
 
     if ($null -eq $CapabilityMap) { return $false }
@@ -48,11 +67,16 @@ function Test-PfbCapabilityMapCoverage {
     # malformed version string throws rather than returning a verdict. Per the policy above
     # that must be silence, not a warning and not a failed Connect-PfbArray.
     try {
-        $highestScanned = (ConvertTo-PfbVersionObject -Versions $scanned)[0].Version
+        $highest = (ConvertTo-PfbVersionObject -Versions $scanned)[0].Version
 
         # "At least" is >=, and an exact match must NOT warn. So the question is whether the
         # map fails to reach the array: NOT (highest >= negotiated).
-        return -not (Test-PfbVersionAtLeast -Have $highestScanned -Need $NegotiatedVersion)
+        $exceeds = -not (Test-PfbVersionAtLeast -Have $highest -Need $NegotiatedVersion)
+
+        # Publish the max only once the comparison has succeeded, so the caller can never
+        # read a value produced by a half-completed parse.
+        if ($exceeds -and $null -ne $HighestScanned) { $HighestScanned.Value = $highest }
+        return $exceeds
     }
     catch {
         Write-Verbose "Test-PfbCapabilityMapCoverage: could not compare '$NegotiatedVersion' against the map's generatedFrom ($($scanned -join ', ')): $($_.Exception.Message)"

--- a/Public/Connection/Connect-PfbArray.ps1
+++ b/Public/Connection/Connect-PfbArray.ps1
@@ -369,6 +369,34 @@ function Connect-PfbArray {
         throw "Authentication failed: No x-auth-token received from FlashBlade '${Endpoint}'."
     }
 
+    # Capability-map coverage check: run ONCE here, unconditionally, so the result is
+    # cached on the connection for its whole life rather than recomputed per call. Firing
+    # at connect universally also means Phase 1's context cmdlets need no trigger of their
+    # own. Deliberately no Gallery lookup -- this module runs against air-gapped arrays, so
+    # point at the remedy rather than probing for it.
+    # Get-PfbCapabilityMap returns $null for a MISSING file, but it does not guard
+    # ConvertFrom-Json -- a corrupt or truncated shipped map THROWS. Today that surfaces at
+    # request time inside Assert-PfbApiCapability; calling it here unguarded would newly
+    # break Connect-PfbArray itself, so you could not even establish a connection to
+    # diagnose it. A diagnostic warning must never be able to fail the connect path.
+    $capabilityMap = $null
+    try { $capabilityMap = Get-PfbCapabilityMap }
+    catch { Write-Verbose "Connect-PfbArray: capability map could not be loaded for the coverage check: $($_.Exception.Message)" }
+
+    $exceedsCapabilityMapCoverage = Test-PfbCapabilityMapCoverage -NegotiatedVersion $negotiatedVersion -CapabilityMap $capabilityMap
+    if ($exceedsCapabilityMapCoverage) {
+        # Find the maximum the SAME way the helper did -- ConvertTo-PfbVersionObject sorts
+        # descending, so [0] is the max. Reading generatedFrom[-1] instead would be a second
+        # way of answering the same question, correct only while the generator keeps writing
+        # that list in ascending order.
+        $highestScanned = (ConvertTo-PfbVersionObject -Versions @($capabilityMap.generatedFrom))[0].Version
+        Write-Warning ("Connected array is running REST $negotiatedVersion; this module's " +
+            "capability map only covers through REST $highestScanned -- capability checks " +
+            'for anything newer, including context scoping, cannot be fully verified and ' +
+            'may not error even if unsupported. Check the PowerShell Gallery for a newer ' +
+            'release (Update-Module).')
+    }
+
     # Build connection object — properties align with PureRestClientBase (Pfa2)
     $connection = [PSCustomObject]@{
         PSTypeName           = 'PureStorage.FlashBlade.Connection'
@@ -386,6 +414,9 @@ function Connect-PfbArray {
         SkipCertificateCheck = [bool]$IgnoreCertificateError
         HttpTimeoutMs        = $HttpTimeout
         ConnectedAt          = [datetime]::UtcNow
+        # Diagnostic: array outruns the bundled capability map's scanned range. Deliberately
+        # NOT in $defaultProps below -- diagnostic state, not default-display material.
+        ExceedsCapabilityMapCoverage = $exceedsCapabilityMapCoverage
         # Certificate/OAuth2 refresh state — only populated when AuthMethod is 'Certificate'
         ClientId             = $ClientId
         Issuer               = $Issuer

--- a/Public/Connection/Connect-PfbArray.ps1
+++ b/Public/Connection/Connect-PfbArray.ps1
@@ -383,13 +383,14 @@ function Connect-PfbArray {
     try { $capabilityMap = Get-PfbCapabilityMap }
     catch { Write-Verbose "Connect-PfbArray: capability map could not be loaded for the coverage check: $($_.Exception.Message)" }
 
-    $exceedsCapabilityMapCoverage = Test-PfbCapabilityMapCoverage -NegotiatedVersion $negotiatedVersion -CapabilityMap $capabilityMap
+    # The helper hands back the highest scanned version it already computed, so this path
+    # never re-parses generatedFrom. Recomputing here would place an unguarded copy of the
+    # helper's own throwing expression OUTSIDE its try/catch -- safe only by an invariant
+    # living in another file, which is exactly the kind of non-local coupling this phase is
+    # removing. One parse, inside one guard.
+    $highestScanned = $null
+    $exceedsCapabilityMapCoverage = Test-PfbCapabilityMapCoverage -NegotiatedVersion $negotiatedVersion -CapabilityMap $capabilityMap -HighestScanned ([ref]$highestScanned)
     if ($exceedsCapabilityMapCoverage) {
-        # Find the maximum the SAME way the helper did -- ConvertTo-PfbVersionObject sorts
-        # descending, so [0] is the max. Reading generatedFrom[-1] instead would be a second
-        # way of answering the same question, correct only while the generator keeps writing
-        # that list in ascending order.
-        $highestScanned = (ConvertTo-PfbVersionObject -Versions @($capabilityMap.generatedFrom))[0].Version
         Write-Warning ("Connected array is running REST $negotiatedVersion; this module's " +
             "capability map only covers through REST $highestScanned -- capability checks " +
             'for anything newer, including context scoping, cannot be fully verified and ' +

--- a/Public/Replication/Get-PfbFleetMember.ps1
+++ b/Public/Replication/Get-PfbFleetMember.ps1
@@ -59,6 +59,18 @@ function Get-PfbFleetMember {
     # different array once a context is active.
     Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'fleets/members' -QueryParams $queryParams -AutoPaginate |
         ForEach-Object {
+            # Invoke-PfbApiRequest returns a bare { total_item_count = N } sentinel -- not a
+            # member -- when the API reports a count but no items (see its trailing return).
+            # A filter matching nothing takes that path. Decorating it would produce an
+            # object that LOOKS like a fleet member whose name is $null, which is the exact
+            # silent-wrong-binding failure this decoration exists to prevent: piping it into
+            # a context-scoping cmdlet would bind a $null name. Pass it through undecorated
+            # so the absence of MemberName fails loudly instead.
+            if (($_.PSObject.Properties.Name -contains 'total_item_count') -and
+                ($_.PSObject.Properties.Name -notcontains 'member')) {
+                return $_
+            }
+
             Add-Member -InputObject $_ -MemberType NoteProperty -Name 'MemberName' -Value $_.member.name -Force -PassThru |
                 Add-Member -MemberType NoteProperty -Name 'FleetName' -Value $_.fleet.name -Force -PassThru
         }

--- a/Public/Replication/Get-PfbFleetMember.ps1
+++ b/Public/Replication/Get-PfbFleetMember.ps1
@@ -46,5 +46,20 @@ function Get-PfbFleetMember {
     if ($FleetName) { $queryParams['fleet_names'] = $FleetName -join ',' }
     if ($MemberName) { $queryParams['member_names'] = $MemberName -join ',' }
 
-    Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'fleets/members' -QueryParams $queryParams -AutoPaginate
+    # Decorate with top-level MemberName/FleetName. ValueFromPipelineByPropertyName matches
+    # only TOP-LEVEL names, and this endpoint nests the array name at .member.name -- so
+    # without this, piping into a context-scoping cmdlet binds nothing and silently no-ops.
+    # Additive by design: the raw nested member/fleet objects stay, so existing callers
+    # reaching .member.name keep working.
+    #
+    # Runs per emitted item, so -AutoPaginate's later pages are decorated too.
+    #
+    # Deliberately no IsLocal: is_local is relative to the CALL'S CONTEXT rather than the
+    # connection, so a Where-Object { -not $_.IsLocal } idiom would silently select a
+    # different array once a context is active.
+    Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'fleets/members' -QueryParams $queryParams -AutoPaginate |
+        ForEach-Object {
+            Add-Member -InputObject $_ -MemberType NoteProperty -Name 'MemberName' -Value $_.member.name -Force -PassThru |
+                Add-Member -MemberType NoteProperty -Name 'FleetName' -Value $_.fleet.name -Force -PassThru
+        }
 }

--- a/Tests/Build-PfbCapabilityMap.ContextScopeDrift.Tests.ps1
+++ b/Tests/Build-PfbCapabilityMap.ContextScopeDrift.Tests.ps1
@@ -1,0 +1,120 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    $script:repoRoot = Split-Path -Parent $PSScriptRoot
+    . (Join-Path $script:repoRoot 'tools/lib/PfbSpecTools.ps1')
+
+    # The curated table, mirrored from tools/Build-PfbCapabilityMap.ps1. Mirrored
+    # deliberately: this test's job is to detect the table going stale, so it must state
+    # independently what the table is expected to contain. Keep the two in sync by hand --
+    # if they diverge, the 'exactly these' assertion below fails, which is the point.
+    $script:expectedCurated = @{
+        'GET /topology-groups'         = 'fleet'
+        'GET /topology-groups/arrays'  = 'fleet'
+        'GET /topology-groups/members' = 'fleet'
+        'GET /workloads/tags'          = 'array'
+    }
+}
+
+Describe 'contextScope drift against the real specs and the committed map' -Skip:($PSVersionTable.PSVersion.Major -lt 7) {
+
+    BeforeAll {
+        $script:mapPath = Join-Path $script:repoRoot 'Data/PfbCapabilityMap.json'
+        $script:specPath = Join-Path $script:repoRoot 'tools/specs/fb2.28.json'
+        $script:hasBoth = (Test-Path $script:mapPath) -and (Test-Path $script:specPath)
+
+        if ($script:hasBoth) {
+            $script:map = Get-Content -Path $script:mapPath -Raw | ConvertFrom-Json -Depth 20
+            $spec = Get-Content -Path $script:specPath -Raw | ConvertFrom-Json -Depth 64
+            $script:scopeRecords = @(Get-PfbSpecContextScope -Spec $spec)
+            $script:byEndpoint = @{}
+            foreach ($r in $script:scopeRecords) { $script:byEndpoint[$r.Endpoint] = $r }
+        }
+    }
+
+    It 'the committed map is schemaVersion 2' {
+        if (-not $script:hasBoth) { Set-ItResult -Skipped -Because 'map or fb2.28 spec absent'; return }
+        $script:map.schemaVersion | Should -Be 2
+    }
+
+    It 'the five declared overrides still match what the map emits as provenance=declared' {
+        if (-not $script:hasBoth) { Set-ItResult -Skipped -Because 'map or fb2.28 spec absent'; return }
+        $declaredInSpec = @($script:scopeRecords | Where-Object { @($_.DomainsOverride).Count -gt 0 } | ForEach-Object { $_.Endpoint } | Sort-Object)
+        $declaredInMap = @($script:map.endpoints.PSObject.Properties |
+                Where-Object { $_.Value.contextScope.provenance -eq 'declared' } |
+                ForEach-Object { $_.Name } | Sort-Object)
+        $declaredInMap | Should -Be $declaredInSpec
+    }
+
+    It 'REGRESSION GUARD: no curated entry has gained an upstream override' {
+        # This is the assertion that keeps the table shrinking on its own. When upstream
+        # fills in a domains override for one of these, the curated value stops being the
+        # best data available and starts SHADOWING it -- silently, because both produce a
+        # plausible scope. Retire the entry from tools/Build-PfbCapabilityMap.ps1's
+        # $curatedContextScope, regenerate, and remove it from $expectedCurated here.
+        if (-not $script:hasBoth) { Set-ItResult -Skipped -Because 'map or fb2.28 spec absent'; return }
+        foreach ($endpoint in $script:expectedCurated.Keys) {
+            $record = $script:byEndpoint[$endpoint]
+            $record | Should -Not -BeNullOrEmpty -Because "$endpoint should exist in fb2.28"
+            @($record.DomainsOverride).Count | Should -Be 0 -Because "$endpoint has GAINED an upstream override -- retire its curated entry rather than shadowing the declaration"
+        }
+    }
+
+    It 'every curated entry is still flagged x-pure-incomplete-gre' {
+        # A curated value only earns its place where the absent override proves nothing.
+        # If upstream un-flags an endpoint without adding an override, that is a different
+        # signal and deserves a fresh decision, not a stale curated value.
+        if (-not $script:hasBoth) { Set-ItResult -Skipped -Because 'map or fb2.28 spec absent'; return }
+        foreach ($endpoint in $script:expectedCurated.Keys) {
+            $script:byEndpoint[$endpoint].IsIncompleteGre | Should -BeTrue -Because "$endpoint is no longer flagged incomplete"
+        }
+    }
+
+    It 'the map records exactly the expected curated endpoints as provenance=live-tested, with the expected scopes' {
+        if (-not $script:hasBoth) { Set-ItResult -Skipped -Because 'map or fb2.28 spec absent'; return }
+        $liveTested = @($script:map.endpoints.PSObject.Properties |
+                Where-Object { $_.Value.contextScope.provenance -eq 'live-tested' })
+        @($liveTested | ForEach-Object { $_.Name } | Sort-Object) | Should -Be @($script:expectedCurated.Keys | Sort-Object)
+        foreach ($property in $liveTested) {
+            $property.Value.contextScope.scope | Should -Be $script:expectedCurated[$property.Name] -Because "curated scope for $($property.Name)"
+        }
+    }
+
+    It 'the flagged-but-uncurated population is exactly 19 and all record unknown' {
+        # 28 flagged - 5 carrying overrides - 4 curated = 19.
+        if (-not $script:hasBoth) { Set-ItResult -Skipped -Because 'map or fb2.28 spec absent'; return }
+        $unknownInMap = @($script:map.endpoints.PSObject.Properties |
+                Where-Object { $_.Value.contextScope.provenance -eq 'unknown' })
+        $unknownInMap.Count | Should -Be 19
+        foreach ($property in $unknownInMap) {
+            $property.Value.contextScope.scope | Should -Be 'unknown'
+            $script:byEndpoint[$property.Name].IsIncompleteGre | Should -BeTrue -Because "$($property.Name) records unknown, so it must be flagged"
+        }
+    }
+
+    It 'every topology-group WRITE verb falls to the array default, while its reads stay curated fleet' {
+        # Documented, accepted, and verified live on 2026-08-04: those writes DO succeed in
+        # array context, unlike /presets/workload writes, so the fail-safe default is not
+        # merely safe here -- it is correct. Re-check when #38 lands.
+        #
+        # Derived rather than hardcoded: the exact write-verb set across the
+        # topology-groups family is what #38 is still settling, so enumerate whatever the
+        # map holds instead of pinning a count that will move.
+        if (-not $script:hasBoth) { Set-ItResult -Skipped -Because 'map or fb2.28 spec absent'; return }
+
+        $family = @($script:map.endpoints.PSObject.Properties |
+                Where-Object { $_.Name -match '^[A-Z]+ /topology-groups(/|$)' })
+        $family.Count | Should -BeGreaterThan 0 -Because 'the topology-groups family must be present in the map'
+
+        foreach ($property in $family) {
+            # Note the parentheses: `-not $x -contains $y` binds -not to $x FIRST and
+            # silently evaluates to $false for every non-empty $x, making the guard vacuous.
+            if ($script:expectedCurated.ContainsKey($property.Name)) {
+                $property.Value.contextScope.provenance | Should -Be 'live-tested' -Because "$($property.Name) is curated"
+                continue
+            }
+            $property.Value.contextScope.provenance | Should -Be 'default' -Because "$($property.Name) is unflagged and uncurated"
+            $property.Value.contextScope.scope      | Should -Be 'array' -Because "$($property.Name) accepts an array context"
+        }
+    }
+}

--- a/Tests/Build-PfbCapabilityMap.ContextScopeDrift.Tests.ps1
+++ b/Tests/Build-PfbCapabilityMap.ContextScopeDrift.Tests.ps1
@@ -37,6 +37,34 @@ Describe 'contextScope drift against the real specs and the committed map' -Skip
         $script:map.schemaVersion | Should -Be 2
     }
 
+    It 'the GENERATOR''s curated table matches this mirror, so an un-regenerated edit cannot hide' {
+        # Every other assertion in this file compares the mirror against the committed MAP.
+        # That leaves a hole: edit $curatedContextScope in the generator and forget to
+        # regenerate, and the map still holds the old values, the mirror still holds the old
+        # values, and the generator has silently diverged from both.
+        #
+        # Scraping the generator's literal closes it WITHOUT reintroducing the problem the
+        # mirror exists to avoid -- the scope values and flag state are still validated
+        # against the real spec and the committed map independently, above and below. This
+        # assertion only proves the three copies agree.
+        $generatorPath = Join-Path $script:repoRoot 'tools/Build-PfbCapabilityMap.ps1'
+        if (-not (Test-Path $generatorPath)) { Set-ItResult -Skipped -Because 'generator absent'; return }
+
+        $generatorSource = Get-Content -Path $generatorPath -Raw
+        $blockMatch = [regex]::Match($generatorSource, '\$curatedContextScope\s*=\s*@\{(?<body>[^}]*)\}')
+        $blockMatch.Success | Should -BeTrue -Because 'the $curatedContextScope literal must be findable; if it was restructured, update this scrape deliberately'
+
+        $scraped = @{}
+        foreach ($entryMatch in [regex]::Matches($blockMatch.Groups['body'].Value, "'(?<key>[^']+)'\s*=\s*'(?<value>[^']+)'")) {
+            $scraped[$entryMatch.Groups['key'].Value] = $entryMatch.Groups['value'].Value
+        }
+
+        @($scraped.Keys | Sort-Object) | Should -Be @($script:expectedCurated.Keys | Sort-Object) -Because 'the generator table and this mirror have diverged'
+        foreach ($key in $scraped.Keys) {
+            $scraped[$key] | Should -Be $script:expectedCurated[$key] -Because "curated scope for $key disagrees between the generator and this mirror"
+        }
+    }
+
     It 'the five declared overrides still match what the map emits as provenance=declared' {
         if (-not $script:hasBoth) { Set-ItResult -Skipped -Because 'map or fb2.28 spec absent'; return }
         $declaredInSpec = @($script:scopeRecords | Where-Object { @($_.DomainsOverride).Count -gt 0 } | ForEach-Object { $_.Endpoint } | Sort-Object)

--- a/Tests/Build-PfbCapabilityMap.Tests.ps1
+++ b/Tests/Build-PfbCapabilityMap.Tests.ps1
@@ -642,7 +642,46 @@ Describe 'Build-PfbCapabilityMap: contextScope' -Skip:($PSVersionTable.PSVersion
         $script:csSpecDir = Join-Path $TestDrive 'cs-specs'
         New-Item -ItemType Directory -Path $script:csSpecDir -Force | Out-Null
 
-        # One spec version is enough: contextScope is deliberately NOT version-gated.
+        # TWO spec versions, deliberately. contextScope is assigned UNCONDITIONALLY
+        # (last-seen-wins), unlike minVersion/parameters/bodyProperties in the same generator
+        # loop, which use a first-sight guard. A ONE-version fixture cannot tell those apart:
+        # every endpoint is first-sighted in the only file present, so a wrongly-guarded
+        # implementation passes everything. In the real specs the annotations exist ONLY in
+        # fb2.28 while every endpoint is first sighted in 2.0-2.27, so a first-sight guard
+        # would silently erase every spec-derived scope and leave only the curated entries.
+        #
+        # So: 2.27 declares the same endpoints with NO annotations, 2.28 adds them. The
+        # newest annotation must win. Mirrors the sibling readOnly/deprecated Describe's
+        # two-version fixture.
+        @'
+{
+  "openapi": "3.0.0",
+  "paths": {
+    "/api/2.27/presets/workload": {
+      "get":  { "responses": { "200": { "description": "ok" } } },
+      "put":  { "responses": { "200": { "description": "ok" } } }
+    },
+    "/api/2.27/topology-groups": {
+      "get": { "responses": { "200": { "description": "ok" } } }
+    },
+    "/api/2.27/workloads/tags": {
+      "get": { "responses": { "200": { "description": "ok" } } }
+    },
+    "/api/2.27/some-uncurated-thing": {
+      "get": { "responses": { "200": { "description": "ok" } } }
+    },
+    "/api/2.27/file-systems": {
+      "get": { "responses": { "200": { "description": "ok" } } }
+    }
+  }
+}
+'@ | Set-Content -Path (Join-Path $script:csSpecDir 'fb2.27.json') -Encoding UTF8
+
+        # fb2.28: same endpoints, now annotated. Note both /presets/workload operations carry
+        # x-pure-incomplete-gre ALONGSIDE their override -- that is what the real fb2.28 does
+        # (all 5 override-bearing operations are also flagged incomplete), and it is the only
+        # place where ladder step 1 (declared) and step 3 (flagged->unknown) actually compete.
+        # Without the flag here, reordering those two branches passes every test.
         @'
 {
   "openapi": "3.0.0",
@@ -650,10 +689,12 @@ Describe 'Build-PfbCapabilityMap: contextScope' -Skip:($PSVersionTable.PSVersion
     "/api/2.28/presets/workload": {
       "get": {
         "x-pure-remote-execution-context-domains-override": ["ARRAY", "FLEET"],
+        "x-pure-incomplete-gre": true,
         "responses": { "200": { "description": "ok" } }
       },
       "put": {
         "x-pure-remote-execution-context-domains-override": ["FLEET"],
+        "x-pure-incomplete-gre": true,
         "responses": { "200": { "description": "ok" } }
       }
     },
@@ -692,6 +733,32 @@ Describe 'Build-PfbCapabilityMap: contextScope' -Skip:($PSVersionTable.PSVersion
         }
     }
 
+    It 'LAST-SEEN-WINS: an annotation added in a NEWER spec beats first sight in an older one' {
+        # The property the whole design rests on, and the one a one-version fixture cannot
+        # see. Every endpoint here is FIRST SIGHTED in 2.27 with no annotations; 2.28 adds
+        # them. If contextScope were assigned under a first-sight guard -- the way minVersion
+        # and parameters are, three lines away in the same loop -- these would all be
+        # array/default, and against the real specs every declared and unknown record would
+        # vanish, leaving only the curated 4.
+        $script:csMap.endpoints.'GET /presets/workload'.contextScope.provenance | Should -Be 'declared' -Because 'the 2.28 override must win over the 2.27 first sight'
+        $script:csMap.endpoints.'PUT /presets/workload'.contextScope.provenance | Should -Be 'declared'
+        $script:csMap.endpoints.'GET /some-uncurated-thing'.contextScope.provenance | Should -Be 'unknown' -Because 'the 2.28 incomplete-gre flag must win over the 2.27 first sight'
+
+        # And confirm minVersion still reflects FIRST sight, proving the two policies coexist
+        # rather than one having been changed into the other.
+        $script:csMap.endpoints.'GET /presets/workload'.minVersion | Should -Be '2.27'
+    }
+
+    It 'a declared override beats the incomplete-gre flag on the SAME operation' {
+        # Both /presets/workload operations carry an override AND x-pure-incomplete-gre, which
+        # is what the real fb2.28 does. Step 1 must win: a declaration is evidence, whereas
+        # the flag only says "absence of a declaration proves nothing" -- and there is no
+        # absence here. Reordering the ladder's branches fails this and nothing else.
+        $get = $script:csMap.endpoints.'GET /presets/workload'.contextScope
+        $get.provenance | Should -Be 'declared' -Because 'the override is present, so the flag is irrelevant'
+        $get.scope      | Should -Be 'array'
+    }
+
     It 'trusts a declared override: ARRAY+FLEET is array-scoped, FLEET-only is fleet-scoped' {
         $get = $script:csMap.endpoints.'GET /presets/workload'.contextScope
         $get.scope      | Should -Be 'array'
@@ -724,5 +791,37 @@ Describe 'Build-PfbCapabilityMap: contextScope' -Skip:($PSVersionTable.PSVersion
         $cs = $script:csMap.endpoints.'GET /file-systems'.contextScope
         $cs.scope      | Should -Be 'array'
         $cs.provenance | Should -Be 'default'
+    }
+
+    It 'records unknown, NOT fleet, for an override declaring an unrecognised domain' {
+        # Unreachable against today's specs -- only ARRAY and FLEET occur across all 29 --
+        # so this is the one case that needs its own fixture. Treating an uninterpretable
+        # token as 'fleet' would assert a scope on no evidence and label it
+        # provenance='declared', which tells Phase 1 upstream said so. Recording ignorance
+        # is the honest answer.
+        $oddDir = Join-Path $TestDrive 'odd-domain-specs'
+        New-Item -ItemType Directory -Path $oddDir -Force | Out-Null
+        @'
+{
+  "openapi": "3.0.0",
+  "paths": {
+    "/api/2.28/future-thing": {
+      "get": {
+        "x-pure-remote-execution-context-domains-override": ["REALM"],
+        "responses": { "200": { "description": "ok" } }
+      }
+    }
+  }
+}
+'@ | Set-Content -Path (Join-Path $oddDir 'fb2.28.json') -Encoding UTF8
+
+        $oddOut = Join-Path $TestDrive 'odd-map.json'
+        & (Join-Path $script:csRepoRoot 'tools/Build-PfbCapabilityMap.ps1') `
+            -SpecsDirectory $oddDir -OutputPath $oddOut | Out-Null
+        $oddMap = Get-Content -Path $oddOut -Raw | ConvertFrom-Json -Depth 20
+
+        $cs = $oddMap.endpoints.'GET /future-thing'.contextScope
+        $cs.scope      | Should -Be 'unknown'
+        $cs.provenance | Should -Be 'unknown' -Because 'an uninterpretable token is not a declaration we can act on'
     }
 }

--- a/Tests/Build-PfbCapabilityMap.Tests.ps1
+++ b/Tests/Build-PfbCapabilityMap.Tests.ps1
@@ -634,3 +634,95 @@ Describe 'Real committed capability map (skips gracefully if not yet generated)'
         $missing | Should -BeNullOrEmpty -Because "these endpoints exist in the newest spec but are missing from the manifest: $($missing -join ', ')"
     }
 }
+
+Describe 'Build-PfbCapabilityMap: contextScope' -Skip:($PSVersionTable.PSVersion.Major -lt 7) {
+
+    BeforeAll {
+        $script:csRepoRoot = Split-Path -Parent $PSScriptRoot
+        $script:csSpecDir = Join-Path $TestDrive 'cs-specs'
+        New-Item -ItemType Directory -Path $script:csSpecDir -Force | Out-Null
+
+        # One spec version is enough: contextScope is deliberately NOT version-gated.
+        @'
+{
+  "openapi": "3.0.0",
+  "paths": {
+    "/api/2.28/presets/workload": {
+      "get": {
+        "x-pure-remote-execution-context-domains-override": ["ARRAY", "FLEET"],
+        "responses": { "200": { "description": "ok" } }
+      },
+      "put": {
+        "x-pure-remote-execution-context-domains-override": ["FLEET"],
+        "responses": { "200": { "description": "ok" } }
+      }
+    },
+    "/api/2.28/topology-groups": {
+      "get": { "x-pure-incomplete-gre": true, "responses": { "200": { "description": "ok" } } }
+    },
+    "/api/2.28/workloads/tags": {
+      "get": { "x-pure-incomplete-gre": true, "responses": { "200": { "description": "ok" } } }
+    },
+    "/api/2.28/some-uncurated-thing": {
+      "get": { "x-pure-incomplete-gre": true, "responses": { "200": { "description": "ok" } } }
+    },
+    "/api/2.28/file-systems": {
+      "get": { "responses": { "200": { "description": "ok" } } }
+    }
+  }
+}
+'@ | Set-Content -Path (Join-Path $script:csSpecDir 'fb2.28.json') -Encoding UTF8
+
+        $script:csOut = Join-Path $TestDrive 'cs-map.json'
+        & (Join-Path $script:csRepoRoot 'tools/Build-PfbCapabilityMap.ps1') `
+            -SpecsDirectory $script:csSpecDir -OutputPath $script:csOut | Out-Null
+        $script:csMap = Get-Content -Path $script:csOut -Raw | ConvertFrom-Json -Depth 20
+    }
+
+    It 'bumps schemaVersion to 2' {
+        $script:csMap.schemaVersion | Should -Be 2
+    }
+
+    It 'gives EVERY endpoint a contextScope with both scope and provenance' {
+        foreach ($key in $script:csMap.endpoints.PSObject.Properties.Name) {
+            $cs = $script:csMap.endpoints.$key.contextScope
+            $cs | Should -Not -BeNullOrEmpty -Because "$key must carry contextScope"
+            $cs.scope      | Should -BeIn @('fleet', 'array', 'unknown') -Because "$key scope"
+            $cs.provenance | Should -BeIn @('declared', 'live-tested', 'unknown', 'default') -Because "$key provenance"
+        }
+    }
+
+    It 'trusts a declared override: ARRAY+FLEET is array-scoped, FLEET-only is fleet-scoped' {
+        $get = $script:csMap.endpoints.'GET /presets/workload'.contextScope
+        $get.scope      | Should -Be 'array'
+        $get.provenance | Should -Be 'declared'
+
+        $put = $script:csMap.endpoints.'PUT /presets/workload'.contextScope
+        $put.scope      | Should -Be 'fleet'
+        $put.provenance | Should -Be 'declared'
+    }
+
+    It 'applies the curated value for a flagged, curated endpoint' {
+        $tg = $script:csMap.endpoints.'GET /topology-groups'.contextScope
+        $tg.scope      | Should -Be 'fleet'
+        $tg.provenance | Should -Be 'live-tested'
+
+        $wt = $script:csMap.endpoints.'GET /workloads/tags'.contextScope
+        $wt.scope      | Should -Be 'array'
+        $wt.provenance | Should -Be 'live-tested'
+    }
+
+    It 'records unknown for a flagged endpoint with no curated entry -- NOT the array default' {
+        # This is the fail-safe half: a flagged endpoint's ABSENT override carries no
+        # information, so defaulting it to array would assert something unevidenced.
+        $cs = $script:csMap.endpoints.'GET /some-uncurated-thing'.contextScope
+        $cs.scope      | Should -Be 'unknown'
+        $cs.provenance | Should -Be 'unknown'
+    }
+
+    It 'defaults an unflagged, unannotated endpoint to array' {
+        $cs = $script:csMap.endpoints.'GET /file-systems'.contextScope
+        $cs.scope      | Should -Be 'array'
+        $cs.provenance | Should -Be 'default'
+    }
+}

--- a/Tests/Connect-PfbArray.CapabilityMapStaleness.Tests.ps1
+++ b/Tests/Connect-PfbArray.CapabilityMapStaleness.Tests.ps1
@@ -36,8 +36,12 @@ Describe 'Connect-PfbArray - capability-map staleness warning' {
             # per connection" is the actual contract, and a per-call implementation would
             # pass a mere-presence assertion.
             @($warnings).Count | Should -Be 1
-            $warnings[0].ToString() | Should -BeLike '*2.29*'
-            $warnings[0].ToString() | Should -BeLike '*2.28*'
+            # Pin each version to its ROLE, not merely its presence. Asserting only that
+            # '2.29' and '2.28' both appear somewhere lets the two be SWAPPED -- yielding
+            # "running REST 2.28 ... covers through REST 2.29", which is backwards and
+            # actively misleading -- while every test still passes.
+            $warnings[0].ToString() | Should -BeLike '*running REST 2.29*'
+            $warnings[0].ToString() | Should -BeLike '*covers through REST 2.28*'
             $warnings[0].ToString() | Should -BeLike '*Update-Module*'
             $conn | Should -Not -BeNullOrEmpty -Because 'a warning must not suppress the connection object'
         }
@@ -45,6 +49,20 @@ Describe 'Connect-PfbArray - capability-map staleness warning' {
         It 'caches the verdict on the connection object' {
             $conn = Connect-PfbArray -Endpoint 'fb.test' -ApiToken 'T-fake' -WarningAction SilentlyContinue
             $conn.ExceedsCapabilityMapCoverage | Should -BeTrue
+            $conn.ExceedsCapabilityMapCoverage | Should -BeOfType [bool] -Because 'never $null -- callers may test it directly'
+        }
+
+        It 'keeps the verdict OUT of the default display set' {
+            # Deliberate: diagnostic state, not something every user should see when they type
+            # $conn at the prompt, and adding it would change the default Format-List view for
+            # every existing connection. Asserted because nothing else pins it -- adding the
+            # property to $defaultProps otherwise passes the whole suite.
+            $conn = Connect-PfbArray -Endpoint 'fb.test' -ApiToken 'T-fake' -WarningAction SilentlyContinue
+
+            $displaySet = $conn.PSStandardMembers.DefaultDisplayPropertySet.ReferencedPropertyNames
+            $displaySet | Should -Not -Contain 'ExceedsCapabilityMapCoverage'
+            # ...but it must still be reachable programmatically.
+            $conn.PSObject.Properties.Name | Should -Contain 'ExceedsCapabilityMapCoverage'
         }
 
         It 'is suppressible with -WarningAction SilentlyContinue and emits nothing to the pipeline but the connection' {
@@ -54,22 +72,36 @@ Describe 'Connect-PfbArray - capability-map staleness warning' {
         }
 
         It 'makes no Gallery lookup to discover whether an update exists' {
-            # Asserted statically rather than with a Mock: Mock requires the command to
-            # exist, and PowerShellGet is not guaranteed to be loaded in a bare Windows
-            # PowerShell 5.1 host, so mocking Find-Module fails there for reasons that have
-            # nothing to do with this feature. Reading the source is also the stronger
-            # claim -- it proves absence rather than merely non-invocation on one path.
+            # Asserted over the AST's INVOKED COMMAND NAMES, not the source text. Two earlier
+            # forms were both wrong:
+            #   * Mock Find-Module -- Mock requires the command to EXIST, and PowerShellGet
+            #     is not guaranteed loaded in a bare Windows PowerShell 5.1 host, so it fails
+            #     there for reasons unrelated to this feature.
+            #   * A raw text grep -- it fails on a harmless COMMENT mentioning Find-Module or
+            #     a doc link to the Gallery. This very test's comment would trip it.
+            # The AST sees only real command invocations, so comments and strings cannot
+            # produce a false positive, and it is identical on both editions.
             # This module runs against air-gapped lab and customer arrays, so the warning
-            # names the remedy instead of probing for it.
-            $connectSource = Get-Content -Path (Join-Path (Split-Path -Parent $PSScriptRoot) 'Public/Connection/Connect-PfbArray.ps1') -Raw
-            $connectSource | Should -Not -Match 'Find-Module'
-            $connectSource | Should -Not -Match 'Find-PSResource'
-            $connectSource | Should -Not -Match 'powershellgallery'
+            # names the remedy rather than probing for it.
+            $moduleRoot = Split-Path -Parent $PSScriptRoot
+            $filesInCallGraph = @(
+                'Public/Connection/Connect-PfbArray.ps1'
+                'Private/Test-PfbCapabilityMapCoverage.ps1'
+                'Private/Get-PfbCapabilityMap.ps1'
+                'Private/ConvertTo-PfbVersionObject.ps1'
+                'Private/Test-PfbVersionAtLeast.ps1'
+            )
 
-            $coverageSource = Get-Content -Path (Join-Path (Split-Path -Parent $PSScriptRoot) 'Private/Test-PfbCapabilityMapCoverage.ps1') -Raw
-            $coverageSource | Should -Not -Match 'Find-Module'
-            $coverageSource | Should -Not -Match 'Invoke-WebRequest'
-            $coverageSource | Should -Not -Match 'Invoke-RestMethod'
+            foreach ($relativePath in $filesInCallGraph) {
+                $fullPath = Join-Path $moduleRoot $relativePath
+                $ast = [System.Management.Automation.Language.Parser]::ParseFile($fullPath, [ref]$null, [ref]$null)
+                $invoked = @($ast.FindAll({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $true) |
+                        ForEach-Object { $_.GetCommandName() })
+
+                $invoked | Should -Not -Contain 'Find-Module' -Because "$relativePath must not probe the Gallery"
+                $invoked | Should -Not -Contain 'Find-PSResource' -Because "$relativePath must not probe the Gallery"
+                $invoked | Should -Not -Contain 'Update-Module' -Because "$relativePath must name the remedy, not perform it"
+            }
         }
     }
 

--- a/Tests/Connect-PfbArray.CapabilityMapStaleness.Tests.ps1
+++ b/Tests/Connect-PfbArray.CapabilityMapStaleness.Tests.ps1
@@ -1,0 +1,199 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    $moduleRoot = Split-Path -Parent $PSScriptRoot
+    $manifest = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
+    Import-Module $manifest -Force
+}
+
+Describe 'Connect-PfbArray - capability-map staleness warning' {
+
+    BeforeEach {
+        # Negotiation + login mocks, shared by every case. The negotiated version is what
+        # varies, so each It re-mocks the api_version call.
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-WebRequest {
+            [PSCustomObject]@{ Headers = @{ 'x-auth-token' = 'tok' } }
+        }
+    }
+
+    Context 'Array version exceeds the map coverage' {
+
+        BeforeEach {
+            Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
+                [PSCustomObject]@{ versions = @('2.28', '2.29') }
+            } -ParameterFilter { $Uri -like '*api_version*' }
+
+            Mock -ModuleName PureStorageFlashBladePowerShell Get-PfbCapabilityMap {
+                [PSCustomObject]@{ schemaVersion = 2; generatedFrom = @('2.0', '2.27', '2.28') }
+            }
+        }
+
+        It 'warns exactly once, naming both versions and the Update-Module remedy' {
+            $warnings = @()
+            $conn = Connect-PfbArray -Endpoint 'fb.test' -ApiToken 'T-fake' -WarningVariable warnings -WarningAction SilentlyContinue
+
+            # Assert the COUNT, not merely that a warning appeared -- "fires exactly once
+            # per connection" is the actual contract, and a per-call implementation would
+            # pass a mere-presence assertion.
+            @($warnings).Count | Should -Be 1
+            $warnings[0].ToString() | Should -BeLike '*2.29*'
+            $warnings[0].ToString() | Should -BeLike '*2.28*'
+            $warnings[0].ToString() | Should -BeLike '*Update-Module*'
+            $conn | Should -Not -BeNullOrEmpty -Because 'a warning must not suppress the connection object'
+        }
+
+        It 'caches the verdict on the connection object' {
+            $conn = Connect-PfbArray -Endpoint 'fb.test' -ApiToken 'T-fake' -WarningAction SilentlyContinue
+            $conn.ExceedsCapabilityMapCoverage | Should -BeTrue
+        }
+
+        It 'is suppressible with -WarningAction SilentlyContinue and emits nothing to the pipeline but the connection' {
+            $output = @(Connect-PfbArray -Endpoint 'fb.test' -ApiToken 'T-fake' -WarningAction SilentlyContinue)
+            $output.Count | Should -Be 1
+            $output[0].PSObject.TypeNames | Should -Contain 'PureStorage.FlashBlade.Connection'
+        }
+
+        It 'makes no Gallery lookup to discover whether an update exists' {
+            # Asserted statically rather than with a Mock: Mock requires the command to
+            # exist, and PowerShellGet is not guaranteed to be loaded in a bare Windows
+            # PowerShell 5.1 host, so mocking Find-Module fails there for reasons that have
+            # nothing to do with this feature. Reading the source is also the stronger
+            # claim -- it proves absence rather than merely non-invocation on one path.
+            # This module runs against air-gapped lab and customer arrays, so the warning
+            # names the remedy instead of probing for it.
+            $connectSource = Get-Content -Path (Join-Path (Split-Path -Parent $PSScriptRoot) 'Public/Connection/Connect-PfbArray.ps1') -Raw
+            $connectSource | Should -Not -Match 'Find-Module'
+            $connectSource | Should -Not -Match 'Find-PSResource'
+            $connectSource | Should -Not -Match 'powershellgallery'
+
+            $coverageSource = Get-Content -Path (Join-Path (Split-Path -Parent $PSScriptRoot) 'Private/Test-PfbCapabilityMapCoverage.ps1') -Raw
+            $coverageSource | Should -Not -Match 'Find-Module'
+            $coverageSource | Should -Not -Match 'Invoke-WebRequest'
+            $coverageSource | Should -Not -Match 'Invoke-RestMethod'
+        }
+    }
+
+    Context 'Array version is within the map coverage' {
+
+        It 'is silent when the negotiated version equals the map maximum' {
+            Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
+                [PSCustomObject]@{ versions = @('2.26') }
+            } -ParameterFilter { $Uri -like '*api_version*' }
+            Mock -ModuleName PureStorageFlashBladePowerShell Get-PfbCapabilityMap {
+                [PSCustomObject]@{ generatedFrom = @('2.0', '2.26') }
+            }
+
+            $warnings = @()
+            $conn = Connect-PfbArray -Endpoint 'fb.test' -ApiToken 'T-fake' -WarningVariable warnings -WarningAction SilentlyContinue
+
+            @($warnings).Count | Should -Be 0
+            $conn.ExceedsCapabilityMapCoverage | Should -BeFalse
+        }
+
+        It 'compares major/minor numerically, so 2.9 does not read as newer than 2.28' {
+            # A string compare puts '2.9' above '2.28' -- a bug already found twice in this
+            # repo. The arithmetic is Test-PfbVersionAtLeast's, not this feature's; this
+            # asserts the delegation is actually wired up, since a hand-rolled comparison
+            # would pass every other test in this file and fail only here.
+            Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
+                [PSCustomObject]@{ versions = @('2.9') }
+            } -ParameterFilter { $Uri -like '*api_version*' }
+            Mock -ModuleName PureStorageFlashBladePowerShell Get-PfbCapabilityMap {
+                [PSCustomObject]@{ generatedFrom = @('2.0', '2.28') }
+            }
+
+            $warnings = @()
+            $conn = Connect-PfbArray -Endpoint 'fb.test' -ApiToken 'T-fake' -WarningVariable warnings -WarningAction SilentlyContinue
+
+            @($warnings).Count | Should -Be 0
+            $conn.ExceedsCapabilityMapCoverage | Should -BeFalse
+        }
+
+        It 'finds the highest scanned version regardless of generatedFrom ordering' {
+            # ConvertTo-PfbVersionObject sorts descending, so [0] is the max -- but do not
+            # let that be satisfied incidentally by generatedFrom already being ascending.
+            Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
+                [PSCustomObject]@{ versions = @('2.28') }
+            } -ParameterFilter { $Uri -like '*api_version*' }
+            Mock -ModuleName PureStorageFlashBladePowerShell Get-PfbCapabilityMap {
+                [PSCustomObject]@{ generatedFrom = @('2.28', '2.9', '2.0', '2.10') }
+            }
+
+            $warnings = @()
+            $conn = Connect-PfbArray -Endpoint 'fb.test' -ApiToken 'T-fake' -WarningVariable warnings -WarningAction SilentlyContinue
+
+            @($warnings).Count | Should -Be 0 -Because '2.28 is the max and equals the negotiated version'
+            $conn.ExceedsCapabilityMapCoverage | Should -BeFalse
+        }
+    }
+
+    Context 'The map is unavailable' {
+
+        It 'is silent and reports $false when the map cannot be loaded' {
+            # Get-PfbCapabilityMap returns $null for a missing manifest rather than
+            # throwing; a missing map is "nothing to check against", never a hard failure,
+            # and it must not become a warning either.
+            Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
+                [PSCustomObject]@{ versions = @('2.28') }
+            } -ParameterFilter { $Uri -like '*api_version*' }
+            Mock -ModuleName PureStorageFlashBladePowerShell Get-PfbCapabilityMap { $null }
+
+            $warnings = @()
+            $conn = Connect-PfbArray -Endpoint 'fb.test' -ApiToken 'T-fake' -WarningVariable warnings -WarningAction SilentlyContinue
+
+            @($warnings).Count | Should -Be 0
+            $conn.ExceedsCapabilityMapCoverage | Should -BeFalse
+        }
+
+        It 'is silent when generatedFrom is present but empty' {
+            Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
+                [PSCustomObject]@{ versions = @('2.28') }
+            } -ParameterFilter { $Uri -like '*api_version*' }
+            Mock -ModuleName PureStorageFlashBladePowerShell Get-PfbCapabilityMap {
+                [PSCustomObject]@{ generatedFrom = @() }
+            }
+
+            $warnings = @()
+            Connect-PfbArray -Endpoint 'fb.test' -ApiToken 'T-fake' -WarningVariable warnings -WarningAction SilentlyContinue | Out-Null
+            @($warnings).Count | Should -Be 0
+        }
+
+        It 'REGRESSION: still connects when loading the capability map THROWS' {
+            # Get-PfbCapabilityMap returns $null for a missing file but does NOT guard
+            # ConvertFrom-Json, so a corrupt shipped map throws. Before this feature that
+            # surfaced at request time; it must not become a connect-time failure, or a bad
+            # map would leave the user unable to connect at all to diagnose it.
+            Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
+                [PSCustomObject]@{ versions = @('2.28') }
+            } -ParameterFilter { $Uri -like '*api_version*' }
+            Mock -ModuleName PureStorageFlashBladePowerShell Get-PfbCapabilityMap { throw 'corrupt manifest' }
+
+            $warnings = @()
+            $conn = Connect-PfbArray -Endpoint 'fb.test' -ApiToken 'T-fake' -WarningVariable warnings -WarningAction SilentlyContinue
+
+            $conn | Should -Not -BeNullOrEmpty -Because 'a broken capability map must not break connecting'
+            $conn.ExceedsCapabilityMapCoverage | Should -BeFalse
+            @($warnings).Count | Should -Be 0
+        }
+
+        It 'is silent, and still connects, when generatedFrom holds an unparseable version' {
+            # Both shared version helpers cast with [int] and do not guard their input, so a
+            # garbage entry throws. That must degrade to silence -- never a warning, and
+            # never a failed Connect-PfbArray, since the map is diagnostic and the
+            # connection is the user's actual goal.
+            Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
+                [PSCustomObject]@{ versions = @('2.28') }
+            } -ParameterFilter { $Uri -like '*api_version*' }
+            Mock -ModuleName PureStorageFlashBladePowerShell Get-PfbCapabilityMap {
+                [PSCustomObject]@{ generatedFrom = @('not-a-version') }
+            }
+
+            $warnings = @()
+            $conn = Connect-PfbArray -Endpoint 'fb.test' -ApiToken 'T-fake' -WarningVariable warnings -WarningAction SilentlyContinue
+
+            @($warnings).Count | Should -Be 0
+            $conn | Should -Not -BeNullOrEmpty
+            $conn.ExceedsCapabilityMapCoverage | Should -BeFalse
+        }
+    }
+}

--- a/Tests/Get-PfbCapabilityMap.Tests.ps1
+++ b/Tests/Get-PfbCapabilityMap.Tests.ps1
@@ -19,7 +19,7 @@ Describe 'Get-PfbCapabilityMap' {
     It 'loads and returns the manifest from Data/PfbCapabilityMap.json under the module root' {
         New-Item -ItemType Directory -Path 'TestDrive:\Data' -Force | Out-Null
         [PSCustomObject]@{
-            schemaVersion = 1
+            schemaVersion = 2
             endpoints     = [PSCustomObject]@{ 'GET /widgets' = [PSCustomObject]@{ minVersion = '9.0' } }
         } | ConvertTo-Json -Depth 10 | Set-Content -Path 'TestDrive:\Data\PfbCapabilityMap.json'
 
@@ -32,7 +32,7 @@ Describe 'Get-PfbCapabilityMap' {
 
     It 'caches the loaded manifest -- a second call does not re-read the file' {
         New-Item -ItemType Directory -Path 'TestDrive:\Data' -Force | Out-Null
-        [PSCustomObject]@{ schemaVersion = 1; endpoints = [PSCustomObject]@{} } |
+        [PSCustomObject]@{ schemaVersion = 2; endpoints = [PSCustomObject]@{} } |
             ConvertTo-Json -Depth 10 | Set-Content -Path 'TestDrive:\Data\PfbCapabilityMap.json'
 
         InModuleScope PureStorageFlashBladePowerShell -Parameters @{ root = 'TestDrive:\' } {

--- a/Tests/Get-PfbFleetMember.Tests.ps1
+++ b/Tests/Get-PfbFleetMember.Tests.ps1
@@ -80,9 +80,14 @@ Describe 'Get-PfbFleetMember - top-level MemberName/FleetName decoration' {
         $result[2].FleetName | Should -BeNullOrEmpty
     }
 
-    It 'decorates every item across an AutoPaginate multi-page result, not just the first' {
-        # -AutoPaginate hands back the accumulated items; a decorate-the-first-page
-        # implementation would leave later pages bare.
+    It 'decorates every item in a multi-item result, not just the first' {
+        # Deliberately NOT named "multi-page": Invoke-PfbApiRequest is mocked here, so no
+        # continuation_token is ever followed and this exercises one multi-item return, not
+        # pagination. What makes paging safe is that -AutoPaginate accumulates every page
+        # into ONE array before returning (Private/Invoke-PfbApiRequest.ps1, trailing
+        # return), which then unrolls item-by-item into the ForEach-Object -- a property of
+        # that function, tested there, not here. Claiming pagination coverage from this
+        # fixture would be dishonest.
         Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest {
             @(1..7 | ForEach-Object {
                     [PSCustomObject]@{
@@ -120,6 +125,25 @@ Describe 'Get-PfbFleetMember - top-level MemberName/FleetName decoration' {
     It 'returns nothing and does not throw when the API returns no members' {
         Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { @() }
         @(Get-PfbFleetMember -Array $script:fakeConnection).Count | Should -Be 0
+    }
+
+    It 'REGRESSION: does not decorate the total_item_count sentinel into a nameless member' {
+        # Invoke-PfbApiRequest returns a bare { total_item_count = N } object -- NOT a member
+        # -- when the API reports a count but no items, which is what a filter matching
+        # nothing produces. Decorating it would emit something that looks like a fleet member
+        # with a $null name, and piping THAT into a context-scoping cmdlet would bind $null:
+        # the precise silent-wrong-binding failure this whole decoration exists to prevent.
+        # It must pass through WITHOUT MemberName, so the absence fails loudly instead.
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest {
+            [PSCustomObject]@{ total_item_count = 0 }
+        }
+
+        $result = @(Get-PfbFleetMember -Array $script:fakeConnection -FleetName 'no-such-fleet')
+
+        $result.Count | Should -Be 1 -Because 'the sentinel is still passed through, unchanged'
+        $result[0].total_item_count | Should -Be 0
+        $result[0].PSObject.Properties.Name | Should -Not -Contain 'MemberName' -Because 'a countless sentinel must not masquerade as a member'
+        $result[0].PSObject.Properties.Name | Should -Not -Contain 'FleetName'
     }
 
     It 'still forwards fleet_names and member_names as query parameters' {

--- a/Tests/Get-PfbFleetMember.Tests.ps1
+++ b/Tests/Get-PfbFleetMember.Tests.ps1
@@ -1,0 +1,135 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    $moduleRoot = Split-Path -Parent $PSScriptRoot
+    $manifest = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
+    Import-Module $manifest -Force
+
+    $script:fakeConnection = [PSCustomObject]@{
+        PSTypeName   = 'PureStorage.FlashBlade.Connection'
+        HttpEndpoint = 'https://fb.test'
+        Endpoint     = 'fb.test'
+        AuthToken    = 'tok'
+        ApiVersion   = '2.26'
+    }
+}
+
+Describe 'Get-PfbFleetMember - top-level MemberName/FleetName decoration' {
+
+    It 'adds MemberName and FleetName from the nested member/fleet objects' {
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest {
+            @(
+                [PSCustomObject]@{
+                    member = [PSCustomObject]@{ name = 'fb-a'; id = 'm1'; resource_type = 'arrays' }
+                    fleet  = [PSCustomObject]@{ name = 'cc-test-fleet'; id = 'f1' }
+                    status = 'connected'
+                },
+                [PSCustomObject]@{
+                    member = [PSCustomObject]@{ name = 'fb-c'; id = 'm2'; resource_type = 'arrays' }
+                    fleet  = [PSCustomObject]@{ name = 'cc-test-fleet'; id = 'f1' }
+                    status = 'connected'
+                }
+            )
+        }
+
+        $result = @(Get-PfbFleetMember -Array $script:fakeConnection)
+
+        $result.Count | Should -Be 2
+        @($result | ForEach-Object { $_.MemberName }) | Should -Be @('fb-a', 'fb-c')
+        @($result | ForEach-Object { $_.FleetName })  | Should -Be @('cc-test-fleet', 'cc-test-fleet')
+    }
+
+    It 'is ADDITIVE: the raw nested member/fleet objects survive untouched' {
+        # Existing callers reach .member.name directly. This must not become a reshape.
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest {
+            [PSCustomObject]@{
+                member         = [PSCustomObject]@{ name = 'fb-a'; id = 'm1' }
+                fleet          = [PSCustomObject]@{ name = 'cc-test-fleet'; id = 'f1' }
+                status         = 'connected'
+                status_details = 'all good'
+                coordinator_of = @()
+            }
+        }
+
+        $result = Get-PfbFleetMember -Array $script:fakeConnection
+
+        $result.member.name | Should -Be 'fb-a'
+        $result.member.id | Should -Be 'm1'
+        $result.fleet.name | Should -Be 'cc-test-fleet'
+        $result.status | Should -Be 'connected'
+        $result.status_details | Should -Be 'all good'
+        $result.PSObject.Properties.Name | Should -Contain 'coordinator_of'
+    }
+
+    It 'yields $null rather than throwing when the nested data is absent or partial' {
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest {
+            @(
+                [PSCustomObject]@{ fleet = [PSCustomObject]@{ name = 'f' }; status = 'x' }, # no member
+                [PSCustomObject]@{ member = [PSCustomObject]@{ id = 'm3' }; status = 'x' }, # member, no name
+                [PSCustomObject]@{ status = 'x' }                                              # neither
+            )
+        }
+
+        $result = @(Get-PfbFleetMember -Array $script:fakeConnection)
+
+        $result.Count | Should -Be 3
+        $result[0].MemberName | Should -BeNullOrEmpty
+        $result[0].FleetName | Should -Be 'f'
+        $result[1].MemberName | Should -BeNullOrEmpty
+        $result[2].MemberName | Should -BeNullOrEmpty
+        $result[2].FleetName | Should -BeNullOrEmpty
+    }
+
+    It 'decorates every item across an AutoPaginate multi-page result, not just the first' {
+        # -AutoPaginate hands back the accumulated items; a decorate-the-first-page
+        # implementation would leave later pages bare.
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest {
+            @(1..7 | ForEach-Object {
+                    [PSCustomObject]@{
+                        member = [PSCustomObject]@{ name = "fb-$_" }
+                        fleet  = [PSCustomObject]@{ name = 'cc-test-fleet' }
+                    }
+                })
+        }
+
+        $result = @(Get-PfbFleetMember -Array $script:fakeConnection)
+
+        $result.Count | Should -Be 7
+        @($result | Where-Object { $_.MemberName }).Count | Should -Be 7
+        @($result | Where-Object { $_.FleetName }).Count  | Should -Be 7
+        $result[6].MemberName | Should -Be 'fb-7'
+    }
+
+    It 'does NOT add IsLocal' {
+        # is_local is relative to the CALL'S CONTEXT, not the connection: a documented
+        # Where-Object { -not $_.IsLocal } idiom would silently select a different array
+        # once a context is active. Determining the local array belongs to the connection.
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest {
+            [PSCustomObject]@{
+                member   = [PSCustomObject]@{ name = 'fb-a' }
+                fleet    = [PSCustomObject]@{ name = 'cc-test-fleet' }
+                is_local = $true
+            }
+        }
+
+        $result = Get-PfbFleetMember -Array $script:fakeConnection
+
+        $result.PSObject.Properties.Name | Should -Not -Contain 'IsLocal'
+    }
+
+    It 'returns nothing and does not throw when the API returns no members' {
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { @() }
+        @(Get-PfbFleetMember -Array $script:fakeConnection).Count | Should -Be 0
+    }
+
+    It 'still forwards fleet_names and member_names as query parameters' {
+        # Regression guard: the decoration must not disturb the existing query building.
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { @() }
+
+        Get-PfbFleetMember -Array $script:fakeConnection -FleetName 'cc-test-fleet' -MemberName 'fb-a', 'fb-c' | Out-Null
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['fleet_names'] -eq 'cc-test-fleet' -and $QueryParams['member_names'] -eq 'fb-a,fb-c'
+        }
+    }
+}

--- a/Tests/PfbSpecTools.ContextScope.Tests.ps1
+++ b/Tests/PfbSpecTools.ContextScope.Tests.ps1
@@ -1,0 +1,152 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    $script:repoRoot = Split-Path -Parent $PSScriptRoot
+    . (Join-Path $script:repoRoot 'tools/lib/PfbSpecTools.ps1')
+}
+
+Describe 'Get-PfbSpecContextScope (synthetic spec)' -Skip:($PSVersionTable.PSVersion.Major -lt 7) {
+
+    BeforeAll {
+        $script:syntheticSpec = @'
+{
+  "openapi": "3.0.0",
+  "paths": {
+    "/api/2.28/presets/workload": {
+      "get": {
+        "x-pure-remote-execution-context-domains-override": ["ARRAY", "FLEET"],
+        "responses": { "200": { "description": "ok" } }
+      },
+      "put": {
+        "x-pure-remote-execution-context-domains-override": ["FLEET"],
+        "responses": { "200": { "description": "ok" } }
+      }
+    },
+    "/api/2.28/topology-groups": {
+      "get": {
+        "x-pure-incomplete-gre": true,
+        "responses": { "200": { "description": "ok" } }
+      }
+    },
+    "/api/2.28/arrays": {
+      "get": {
+        "x-pure-block-remote-execution": true,
+        "responses": { "200": { "description": "ok" } }
+      }
+    },
+    "/api/2.28/file-systems": {
+      "get": { "responses": { "200": { "description": "ok" } } }
+    }
+  }
+}
+'@ | ConvertFrom-Json -Depth 32
+
+        $script:records = @(Get-PfbSpecContextScope -Spec $script:syntheticSpec)
+        $script:byEndpoint = @{}
+        foreach ($r in $script:records) { $script:byEndpoint[$r.Endpoint] = $r }
+    }
+
+    It 'emits one record per operation, sorted by endpoint key' {
+        $script:records.Count | Should -Be 5
+        $sorted = @($script:records | ForEach-Object { $_.Endpoint } | Sort-Object)
+        @($script:records | ForEach-Object { $_.Endpoint }) | Should -Be $sorted
+    }
+
+    It 'normalizes the path, stripping the /api/<version> prefix' {
+        $script:byEndpoint.Keys | Should -Contain 'GET /presets/workload'
+        $script:byEndpoint.Keys | Should -Not -Contain 'GET /api/2.28/presets/workload'
+    }
+
+    It 'captures a multi-domain override as an array, preserving both values' {
+        $record = $script:byEndpoint['GET /presets/workload']
+        @($record.DomainsOverride) | Should -Be @('ARRAY', 'FLEET')
+    }
+
+    It 'captures a single-domain override as a one-element array' {
+        $record = $script:byEndpoint['PUT /presets/workload']
+        @($record.DomainsOverride) | Should -Be @('FLEET')
+    }
+
+    It 'reports an EMPTY override array, never $null, when the extension is absent' {
+        # Absent must be distinguishable from present-but-empty by the caller without a
+        # null check, and an empty array is what the generator's default branch tests.
+        $record = $script:byEndpoint['GET /file-systems']
+        $null -ne $record.DomainsOverride | Should -BeTrue -Because 'it should be an array object, not $null'
+        @($record.DomainsOverride).Count | Should -Be 0
+    }
+
+    It 'flags x-pure-incomplete-gre' {
+        $script:byEndpoint['GET /topology-groups'].IsIncompleteGre | Should -BeTrue
+        $script:byEndpoint['GET /file-systems'].IsIncompleteGre    | Should -BeFalse
+    }
+
+    It 'flags x-pure-block-remote-execution' {
+        $script:byEndpoint['GET /arrays'].BlocksRemoteExec       | Should -BeTrue
+        $script:byEndpoint['GET /file-systems'].BlocksRemoteExec | Should -BeFalse
+    }
+
+    It 'returns an empty collection for a spec with no paths' {
+        $empty = '{ "openapi": "3.0.0" }' | ConvertFrom-Json
+        @(Get-PfbSpecContextScope -Spec $empty).Count | Should -Be 0
+    }
+
+    It 'ignores non-HTTP-method keys on a path item' {
+        $withParams = @'
+{ "openapi": "3.0.0", "paths": { "/api/2.28/x": {
+    "parameters": [ { "name": "ignored" } ],
+    "get": { "responses": { "200": { "description": "ok" } } } } } }
+'@ | ConvertFrom-Json -Depth 32
+        @(Get-PfbSpecContextScope -Spec $withParams).Count | Should -Be 1
+    }
+}
+
+Describe 'Get-PfbSpecContextScope (real fb2.28 spec, skips gracefully if absent)' -Skip:($PSVersionTable.PSVersion.Major -lt 7) {
+
+    BeforeAll {
+        $script:specPath = Join-Path $script:repoRoot 'tools/specs/fb2.28.json'
+        $script:hasSpec = Test-Path $script:specPath
+        if ($script:hasSpec) {
+            $spec = Get-Content -Path $script:specPath -Raw | ConvertFrom-Json -Depth 64
+            $script:realRecords = @(Get-PfbSpecContextScope -Spec $spec)
+        }
+    }
+
+    It 'finds exactly 5 operations carrying a domains override, all /presets/workload' {
+        if (-not $script:hasSpec) { Set-ItResult -Skipped -Because 'tools/specs/fb2.28.json absent'; return }
+        $withOverride = @($script:realRecords | Where-Object { @($_.DomainsOverride).Count -gt 0 })
+        $withOverride.Count | Should -Be 5
+        @($withOverride | ForEach-Object { $_.Path } | Sort-Object -Unique) | Should -Be @('/presets/workload')
+    }
+
+    It 'reads the preset overrides as ARRAY+FLEET for GET and FLEET for every write verb' {
+        if (-not $script:hasSpec) { Set-ItResult -Skipped -Because 'tools/specs/fb2.28.json absent'; return }
+        $byKey = @{}
+        foreach ($r in $script:realRecords) { $byKey[$r.Endpoint] = $r }
+        @($byKey['GET /presets/workload'].DomainsOverride    | Sort-Object) | Should -Be @('ARRAY', 'FLEET')
+        foreach ($verb in 'PUT', 'POST', 'DELETE', 'PATCH') {
+            @($byKey["$verb /presets/workload"].DomainsOverride) | Should -Be @('FLEET') -Because "$verb is fleet-only on the wire"
+        }
+    }
+
+    It 'CANARY: the three extension counts are 5 / 28 / 266 at fb2.28' {
+        # Not a correctness assertion -- a tripwire on the upstream annotation pass
+        # advancing. When this fails, upstream has filled in more annotations: re-derive
+        # the curated table in tools/Build-PfbCapabilityMap.ps1 and retire any entry that
+        # has gained an override, then update these numbers deliberately.
+        if (-not $script:hasSpec) { Set-ItResult -Skipped -Because 'tools/specs/fb2.28.json absent'; return }
+        @($script:realRecords | Where-Object { @($_.DomainsOverride).Count -gt 0 }).Count | Should -Be 5
+        @($script:realRecords | Where-Object { $_.IsIncompleteGre }).Count                | Should -Be 28
+        @($script:realRecords | Where-Object { $_.BlocksRemoteExec }).Count               | Should -Be 266
+    }
+
+    It 'confirms all four curated endpoints are in fact flagged incomplete' {
+        # The curated table in the generator only earns its place for FLAGGED endpoints.
+        # If one of these ever stops being flagged, its curated value is shadowing data
+        # the generator should now be trusting instead.
+        if (-not $script:hasSpec) { Set-ItResult -Skipped -Because 'tools/specs/fb2.28.json absent'; return }
+        $flagged = @($script:realRecords | Where-Object { $_.IsIncompleteGre } | ForEach-Object { $_.Endpoint })
+        foreach ($curated in 'GET /topology-groups', 'GET /topology-groups/arrays', 'GET /topology-groups/members', 'GET /workloads/tags') {
+            $flagged | Should -Contain $curated
+        }
+    }
+}

--- a/Tests/PfbSpecTools.ContextScope.Tests.ps1
+++ b/Tests/PfbSpecTools.ContextScope.Tests.ps1
@@ -5,8 +5,11 @@ BeforeAll {
     . (Join-Path $script:repoRoot 'tools/lib/PfbSpecTools.ps1')
 }
 
-Describe 'Get-PfbSpecContextScope (synthetic spec)' -Skip:($PSVersionTable.PSVersion.Major -lt 7) {
+Describe 'Get-PfbSpecContextScope (synthetic spec)' {
 
+    # No edition guard: Get-PfbSpecContextScope is a pure PSObject walk with no pwsh-7
+    # dependency, and these fixtures are shallow enough that Windows PowerShell 5.1's
+    # ConvertFrom-Json parses them without -Depth (which it does not support).
     BeforeAll {
         $script:syntheticSpec = @'
 {
@@ -34,12 +37,24 @@ Describe 'Get-PfbSpecContextScope (synthetic spec)' -Skip:($PSVersionTable.PSVer
         "responses": { "200": { "description": "ok" } }
       }
     },
+    "/api/2.28/hardware": {
+      "get": {
+        "x-pure-incomplete-gre": false,
+        "responses": { "200": { "description": "ok" } }
+      }
+    },
+    "/api/2.28/alerts": {
+      "get": {
+        "x-pure-block-remote-execution": false,
+        "responses": { "200": { "description": "ok" } }
+      }
+    },
     "/api/2.28/file-systems": {
       "get": { "responses": { "200": { "description": "ok" } } }
     }
   }
 }
-'@ | ConvertFrom-Json -Depth 32
+'@ | ConvertFrom-Json
 
         $script:records = @(Get-PfbSpecContextScope -Spec $script:syntheticSpec)
         $script:byEndpoint = @{}
@@ -47,7 +62,7 @@ Describe 'Get-PfbSpecContextScope (synthetic spec)' -Skip:($PSVersionTable.PSVer
     }
 
     It 'emits one record per operation, sorted by endpoint key' {
-        $script:records.Count | Should -Be 5
+        $script:records.Count | Should -Be 7
         $sorted = @($script:records | ForEach-Object { $_.Endpoint } | Sort-Object)
         @($script:records | ForEach-Object { $_.Endpoint }) | Should -Be $sorted
     }
@@ -85,6 +100,15 @@ Describe 'Get-PfbSpecContextScope (synthetic spec)' -Skip:($PSVersionTable.PSVer
         $script:byEndpoint['GET /file-systems'].BlocksRemoteExec | Should -BeFalse
     }
 
+    It 'reads the VALUE of both flags, not merely the presence of the key' {
+        # Upstream emits these only as literal true today, so key-presence alone happens to
+        # give the right answer and a presence-only implementation survives every other
+        # assertion here. An explicit false must still resolve to false, or an endpoint
+        # upstream has deliberately UN-flagged would be forced to unknown/unknown.
+        $script:byEndpoint['GET /hardware'].IsIncompleteGre | Should -BeFalse -Because 'x-pure-incomplete-gre is present but false'
+        $script:byEndpoint['GET /alerts'].BlocksRemoteExec  | Should -BeFalse -Because 'x-pure-block-remote-execution is present but false'
+    }
+
     It 'returns an empty collection for a spec with no paths' {
         $empty = '{ "openapi": "3.0.0" }' | ConvertFrom-Json
         @(Get-PfbSpecContextScope -Spec $empty).Count | Should -Be 0
@@ -95,11 +119,13 @@ Describe 'Get-PfbSpecContextScope (synthetic spec)' -Skip:($PSVersionTable.PSVer
 { "openapi": "3.0.0", "paths": { "/api/2.28/x": {
     "parameters": [ { "name": "ignored" } ],
     "get": { "responses": { "200": { "description": "ok" } } } } } }
-'@ | ConvertFrom-Json -Depth 32
+'@ | ConvertFrom-Json
         @(Get-PfbSpecContextScope -Spec $withParams).Count | Should -Be 1
     }
 }
 
+# Edition guard is load-bearing here and must stay: the real fb2.28 spec needs
+# ConvertFrom-Json -Depth 64 to parse, and -Depth does not exist before PowerShell 6.2.
 Describe 'Get-PfbSpecContextScope (real fb2.28 spec, skips gracefully if absent)' -Skip:($PSVersionTable.PSVersion.Major -lt 7) {
 
     BeforeAll {

--- a/Tests/Resolve-PfbParameterComponent.Tests.ps1
+++ b/Tests/Resolve-PfbParameterComponent.Tests.ps1
@@ -104,6 +104,139 @@ Describe 'Resolve-PfbParameterComponent' {
         }
     }
 
+    Context 'Key matching is exact, and works on multi-key containers' {
+
+        # These close mutation gaps found in review: four plausible wrong implementations
+        # passed every test above. Each It below kills at least one of them.
+
+        It 'MUTATION GUARD: honours a present key on an overrides object holding SEVERAL keys' {
+            # Kills reversed operands -- ($ParameterName -contains $overrides.PSObject.Properties.Name).
+            # With a single-key overrides object that accidentally works (scalar vs scalar);
+            # with two or more keys the right-hand side becomes an array, the test is never
+            # true, and the override is silently discarded in favour of the default. The real
+            # Data/PfbCapabilityMap.json has 40 multi-key overrides objects, 18 of them
+            # containing context_names -- so this is the original bug class on real endpoints.
+            $entry = [PSCustomObject]@{
+                parameterComponentOverrides = [PSCustomObject]@{
+                    sort          = 'Sort'
+                    context_names = $null
+                    limit         = 'Limit'
+                }
+            }
+
+            $result = InModuleScope PureStorageFlashBladePowerShell -Parameters @{ E = $entry; D = $script:defaults } {
+                param($E, $D)
+                Resolve-PfbParameterComponent -EndpointEntry $E -ParameterName 'context_names' -ParameterComponentDefaults $D
+            }
+
+            $result | Should -BeNullOrEmpty
+            $result | Should -Not -Be 'Context_names_get'
+        }
+
+        It 'MUTATION GUARD: does not treat a substring/regex-adjacent key name as a match' {
+            # Kills -match and -like. 'ids' regex-matches the key name 'ids_or_names', which
+            # would wrongly enter step 1 and return that key's $null instead of the default.
+            # Both names are real API parameters; 'ids' is in the real defaults table.
+            $entry = [PSCustomObject]@{
+                parameterComponentOverrides = [PSCustomObject]@{ ids_or_names = $null }
+            }
+            $defaults = [PSCustomObject]@{ ids = 'Ids' }
+
+            $result = InModuleScope PureStorageFlashBladePowerShell -Parameters @{ E = $entry; D = $defaults } {
+                param($E, $D)
+                Resolve-PfbParameterComponent -EndpointEntry $E -ParameterName 'ids' -ParameterComponentDefaults $D
+            }
+
+            $result | Should -Be 'Ids'
+        }
+
+        It 'falls through to the default when parameterComponentOverrides is present but NULL' {
+            # Kills a guard written as
+            # ($EndpointEntry.PSObject.Properties.Name -contains 'parameterComponentOverrides'),
+            # which treats a null overrides object as authoritative.
+            $entry = [PSCustomObject]@{ parameterComponentOverrides = $null }
+
+            $result = InModuleScope PureStorageFlashBladePowerShell -Parameters @{ E = $entry; D = $script:defaults } {
+                param($E, $D)
+                Resolve-PfbParameterComponent -EndpointEntry $E -ParameterName 'context_names' -ParameterComponentDefaults $D
+            }
+
+            $result | Should -Be 'Context_names_get'
+        }
+
+        It 'falls through to the default when the overrides object is present but EMPTY' {
+            # An empty PSCustomObject is TRUTHY, so a truthiness guard would not save this.
+            $entry = [PSCustomObject]@{ parameterComponentOverrides = [PSCustomObject]@{} }
+
+            $result = InModuleScope PureStorageFlashBladePowerShell -Parameters @{ E = $entry; D = $script:defaults } {
+                param($E, $D)
+                Resolve-PfbParameterComponent -EndpointEntry $E -ParameterName 'context_names' -ParameterComponentDefaults $D
+            }
+
+            $result | Should -Be 'Context_names_get'
+        }
+    }
+
+    Context 'Dictionary-shaped input (the in-memory generator shape)' {
+
+        # tools/Build-PfbCapabilityMap.ps1 builds parameterComponentDefaults and
+        # parameterComponentOverrides as [ordered]@{}. Any tools/ caller resolving against
+        # the map it just built -- rather than the JSON round-trip -- passes dictionaries.
+        # .PSObject.Properties.Name returns the CLR surface for those, not the keys, so a
+        # PSCustomObject-only implementation is wrong for every such caller.
+
+        It 'honours a present-but-null key in an ORDERED DICTIONARY overrides object' {
+            $overrides = [ordered]@{ sort = 'Sort'; context_names = $null }
+            $entry = [PSCustomObject]@{ parameterComponentOverrides = $overrides }
+
+            $result = InModuleScope PureStorageFlashBladePowerShell -Parameters @{ E = $entry; D = $script:defaults } {
+                param($E, $D)
+                Resolve-PfbParameterComponent -EndpointEntry $E -ParameterName 'context_names' -ParameterComponentDefaults $D
+            }
+
+            $result | Should -BeNullOrEmpty
+            $result | Should -Not -Be 'Context_names_get'
+        }
+
+        It 'returns the override value from a HASHTABLE overrides object' {
+            $entry = @{ parameterComponentOverrides = @{ context_names = 'Context_names' } }
+
+            $result = InModuleScope PureStorageFlashBladePowerShell -Parameters @{ E = $entry; D = $script:defaults } {
+                param($E, $D)
+                Resolve-PfbParameterComponent -EndpointEntry $E -ParameterName 'context_names' -ParameterComponentDefaults $D
+            }
+
+            $result | Should -Be 'Context_names'
+        }
+
+        It 'resolves against a DICTIONARY defaults table' {
+            $entry = [PSCustomObject]@{ minVersion = '2.23' }
+            $defaults = [ordered]@{ context_names = 'Context_names_get' }
+
+            $result = InModuleScope PureStorageFlashBladePowerShell -Parameters @{ E = $entry; D = $defaults } {
+                param($E, $D)
+                Resolve-PfbParameterComponent -EndpointEntry $E -ParameterName 'context_names' -ParameterComponentDefaults $D
+            }
+
+            $result | Should -Be 'Context_names_get'
+        }
+
+        It 'does not mistake a dictionary INTRINSIC member for a parameter key' {
+            # A hashtable's .PSObject.Properties.Name exposes Count/Keys/Values/... A
+            # PSObject-only presence test would report 'Count' as present and return the
+            # item count -- an [int], violating the declared [string] output.
+            $entry = @{ parameterComponentOverrides = @{ a = 1; b = 2 } }
+
+            $result = InModuleScope PureStorageFlashBladePowerShell -Parameters @{ E = $entry } {
+                param($E)
+                Resolve-PfbParameterComponent -EndpointEntry $E -ParameterName 'Count' -ParameterComponentDefaults $null
+            }
+
+            $result | Should -BeNullOrEmpty
+            $result | Should -Not -Be 2
+        }
+    }
+
     Context 'Parameter-name independence' {
 
         It 'resolves a parameter other than context_names through the same contract' {

--- a/Tests/Resolve-PfbParameterComponent.Tests.ps1
+++ b/Tests/Resolve-PfbParameterComponent.Tests.ps1
@@ -1,0 +1,123 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    $moduleRoot = Split-Path -Parent $PSScriptRoot
+    $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
+    Import-Module $manifest -Force
+}
+
+Describe 'Resolve-PfbParameterComponent' {
+
+    # Fixtures mimic ConvertFrom-Json output: PSCustomObject, where a JSON null becomes a
+    # PRESENT property whose value is $null. That is the case the whole function exists for.
+    BeforeAll {
+        $script:defaults = [PSCustomObject]@{
+            context_names = 'Context_names_get'
+            limit         = 'Limit'
+        }
+    }
+
+    Context 'Step 1: the override key is present' {
+
+        It 'returns the override value and ignores a differing default' {
+            $entry = [PSCustomObject]@{
+                parameterComponentOverrides = [PSCustomObject]@{ context_names = 'Context_names' }
+            }
+
+            $result = InModuleScope PureStorageFlashBladePowerShell -Parameters @{ E = $entry; D = $script:defaults } {
+                param($E, $D)
+                Resolve-PfbParameterComponent -EndpointEntry $E -ParameterName 'context_names' -ParameterComponentDefaults $D
+            }
+
+            $result | Should -Be 'Context_names'
+        }
+
+        It 'REGRESSION: a key present with a NULL value returns $null and does NOT fall through to a matching default' {
+            # This is the defect the extraction exists to prevent. A naive
+            # `if ($overrides.$name)` implementation passes every other test in this file
+            # and fails only this one.
+            $entry = [PSCustomObject]@{
+                parameterComponentOverrides = [PSCustomObject]@{ context_names = $null }
+            }
+
+            $result = InModuleScope PureStorageFlashBladePowerShell -Parameters @{ E = $entry; D = $script:defaults } {
+                param($E, $D)
+                Resolve-PfbParameterComponent -EndpointEntry $E -ParameterName 'context_names' -ParameterComponentDefaults $D
+            }
+
+            $result | Should -BeNullOrEmpty
+            # Assert the SPECIFIC wrong answer is absent, not merely that the result is falsy --
+            # 'returns $null' alone cannot distinguish this case from step 3.
+            $result | Should -Not -Be 'Context_names_get'
+        }
+    }
+
+    Context 'Step 2: the override key is absent' {
+
+        It 'falls through to the default when the endpoint has an overrides object without this key' {
+            $entry = [PSCustomObject]@{
+                parameterComponentOverrides = [PSCustomObject]@{ sort = 'Sort' }
+            }
+
+            $result = InModuleScope PureStorageFlashBladePowerShell -Parameters @{ E = $entry; D = $script:defaults } {
+                param($E, $D)
+                Resolve-PfbParameterComponent -EndpointEntry $E -ParameterName 'context_names' -ParameterComponentDefaults $D
+            }
+
+            $result | Should -Be 'Context_names_get'
+        }
+
+        It 'falls through to the default when the endpoint has no overrides object at all' {
+            $entry = [PSCustomObject]@{ minVersion = '2.23' }
+
+            $result = InModuleScope PureStorageFlashBladePowerShell -Parameters @{ E = $entry; D = $script:defaults } {
+                param($E, $D)
+                Resolve-PfbParameterComponent -EndpointEntry $E -ParameterName 'context_names' -ParameterComponentDefaults $D
+            }
+
+            $result | Should -Be 'Context_names_get'
+        }
+    }
+
+    Context 'Step 3: no signal anywhere' {
+
+        It 'returns $null when neither the override nor the default has the parameter' {
+            $entry = [PSCustomObject]@{ minVersion = '2.23' }
+
+            $result = InModuleScope PureStorageFlashBladePowerShell -Parameters @{ E = $entry; D = $script:defaults } {
+                param($E, $D)
+                Resolve-PfbParameterComponent -EndpointEntry $E -ParameterName 'not_a_real_parameter' -ParameterComponentDefaults $D
+            }
+
+            $result | Should -BeNullOrEmpty
+        }
+
+        It 'returns $null without throwing when the defaults table is $null' {
+            $entry = [PSCustomObject]@{ minVersion = '2.23' }
+
+            $result = InModuleScope PureStorageFlashBladePowerShell -Parameters @{ E = $entry } {
+                param($E)
+                Resolve-PfbParameterComponent -EndpointEntry $E -ParameterName 'context_names' -ParameterComponentDefaults $null
+            }
+
+            $result | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'Parameter-name independence' {
+
+        It 'resolves a parameter other than context_names through the same contract' {
+            # allow_errors needs this in Phase 2; the function must not be context_names-specific.
+            $entry = [PSCustomObject]@{
+                parameterComponentOverrides = [PSCustomObject]@{ limit = $null }
+            }
+
+            $result = InModuleScope PureStorageFlashBladePowerShell -Parameters @{ E = $entry; D = $script:defaults } {
+                param($E, $D)
+                Resolve-PfbParameterComponent -EndpointEntry $E -ParameterName 'limit' -ParameterComponentDefaults $D
+            }
+
+            $result | Should -BeNullOrEmpty
+        }
+    }
+}

--- a/docs/design/fusion-context-phase-0-spec.md
+++ b/docs/design/fusion-context-phase-0-spec.md
@@ -3,7 +3,13 @@
 Status: proposed
 Design doc: `docs/design/fusion-context-injection.md` (rev 4)
 Tracking: #25 (Fusion `context_names` injection), #74 (component-resolution move)
+Coordinates with: #84 (capability-map generator/schema tracker) — see item 2
 Branch: `feat/fusion-context-phase-0`
+
+> **One decision is required before implementation starts.** Item 2 needs
+> `Data/PfbCapabilityMap.json`'s `schemaVersion` bumped to 2, and so does issue #83. Tracking
+> issue #84 plans them as a single bump in a single PR. See "Coordination with #84" for the
+> three options and a recommendation.
 
 ---
 
@@ -132,9 +138,12 @@ interactive session that already has the module imported.
 - `Resolve-PfbParameterComponent` is reachable inside the module (`internal: True`).
 - `Get-PfbContextParameterFact` remains internal to `tools/` and is **not** exported.
 - `Tests/PfbContextRuleTools.Tests.ps1` (54 tests) stays green.
-- `Tests/Build-PfbApiDriftReport.Tests.ps1` (60 tests) stays green — including its check that
-  the committed `Reports/` artifacts still reproduce byte-for-byte. A behaviour change in
-  resolution would surface here as a report diff.
+- `Tests/Build-PfbApiDriftReport.Tests.ps1` (60 tests) stays green. Note what this does and does
+  not prove: its byte-identical assertions (`:351-391`) check **determinism across two runs on
+  the same synthetic fixtures**, not that the committed artifacts reproduce. The real-artifact
+  checks are a separate `Describe` that **skips gracefully when `tools/specs/` is absent** — and
+  `tools/specs/` is gitignored, so in a fresh worktree they silently do not run. Confirm they
+  actually executed rather than reading a green result as coverage.
 - New unit tests for the resolver covering all three steps, with **key-present-but-`null` and
   key-absent as separate explicit cases**. This is the regression the move exists to prevent;
   a test that only exercises "returns `$null`" does not distinguish them. Assert that a
@@ -221,9 +230,26 @@ default is not merely safe here, it is correct. Re-check when #38 lands.
 2. **`contextScope` becomes an additive per-endpoint field**, alongside `minVersion`,
    `parameters`, `bodyProperties`, `parameterComponentOverrides`. It records the value and its
    provenance (`declared` / `live-tested` / `unknown`).
-3. **Bump `schemaVersion` 1 -> 2** (`tools/Build-PfbCapabilityMap.ps1:317`). Additive changes
-   would not strictly require it, but `Get-PfbCapabilityMap` is the single gate every consumer
-   sees the map through, so the shape should not grow silently.
+3. **Bump `schemaVersion` 1 -> 2** (`tools/Build-PfbCapabilityMap.ps1:317`) — but see
+   "Coordination with #84" below, because this bump is **not this spec's to make alone.**
+
+   Two facts about `schemaVersion` that are easy to get wrong in both directions. It is
+   **per-artifact, not global**: five generators each write their own independent value, and all
+   five artifacts currently read `1`.
+
+   | Artifact | Generator |
+   |---|---|
+   | `Data/PfbCapabilityMap.json` | `tools/Build-PfbCapabilityMap.ps1:317` |
+   | `Data/PfbResponseShapeMap.json` | `tools/Build-PfbResponseShapeMap.ps1:173` |
+   | `Reports/PfbApiDriftReport.json` | `tools/Build-PfbApiDriftReport.ps1:637` |
+   | `Reports/PfbFieldCmdletMap.json` | `tools/Build-PfbFieldCmdletMap.ps1:98` |
+   | `Reports/PfbValueEnumMap.json` | `tools/Build-PfbValueEnumMap.ps1:153` |
+
+   So bumping the capability map's value does **not** implicate the other four. And **nothing
+   in `Private/` or `Public/` reads `schemaVersion` at all** (verified) — it is a label for
+   maintainers, not a migration gate. The bump is therefore nearly free, which is precisely why
+   it must not be spent carelessly: the cost of a bump is not compatibility, it is that two
+   pending changes needing "version 2" cannot both claim it independently.
 4. **The curated table lives in the generator**, not in `Private/`. Runtime code reads scope
    from the shipped map and nowhere else. A curated list consulted at runtime would be a
    second source of truth for the same fact — the exact failure mode #74 exists to fix.
@@ -237,6 +263,62 @@ default is not merely safe here, it is correct. Re-check when #38 lands.
 
 This rides the existing `.github/workflows/update-api-capability-map.yml`. One generator
 change, one schema bump, one test — no new pipeline.
+
+### Coordination with #84 — `contextScope` does not own `schemaVersion 2`
+
+**This is the part the design doc does not cover, because it is not a Fusion concern.**
+`Data/PfbCapabilityMap.json` was reopened as tracking issue **#84**, which coordinates four
+pending generator changes that converge on one tracked file and, for two of them, on one
+`schemaVersion` bump:
+
+| Issue | Change | Schema impact |
+|---|---|---|
+| #71 | `MaxDepth=8` truncation records 5 body fields one release too late | none |
+| #82 | Schema walk never descends through `items`, so all four array-bodied endpoints record `bodyProperties: {}` — 23 fields invisible | none |
+| #83 | Array-body cardinality (`minItems`/`maxItems`/`uniqueItems`) has nowhere to live | **needs `schemaVersion 2`** |
+| #25 | `contextScope` (this spec) | **needs `schemaVersion 2`** |
+
+#84's plan is **PR 1** = #71 + #82 (no schema change), then **PR 2** = #83 + `contextScope`,
+sharing a single bump. #83's title says "needs schemaVersion 2" outright.
+
+The hard constraint is not the version label — it is that **every one of these regenerates the
+same 632-endpoint generated artifact.** Two open PRs both touching `Data/PfbCapabilityMap.json`
+conflict on the artifact regardless of whether their generator changes touch the same code.
+(They largely do not: #83 lives in `Add-PfbSchemaPropertyNodes` in `tools/lib/PfbSpecTools.ps1`,
+walking request-body schemas, while `contextScope` reads operation-level `x-pure-*` extensions.)
+
+**#85 — the phantom-diff blocker — is now CLOSED**, so the sequencing hazard it created is
+gone. Previously, report generators emitted in filesystem-enumeration order, and regenerating on
+a Linux runner instead of a Windows workstation produced a 10,218-line diff in
+`Reports/PfbFieldCmdletMap.json` with zero semantic change. That would have buried this work.
+Note the capability map itself was never affected — `Build-PfbCapabilityMap.ps1` never walks
+`Public/`/`Private/`, and its spec enumeration is explicitly sorted — but Phase 0 regenerates
+the derived reports too, so it would have dragged the phantom diff along.
+
+**Decision required before implementation** (three options, and this spec does not pick one):
+
+1. **Sequence behind #84's PR 2.** Phase 0 drops the map work entirely and waits. Cleanest for
+   #84, but it makes Phase 0 — and therefore all of Phase 1 — blocked on unrelated generator
+   work with no timeline.
+2. **Phase 0 absorbs #83.** One PR, one bump, both fields. Matches #84's intent exactly and
+   removes the artifact conflict, at the cost of putting array-body cardinality work inside a
+   Fusion PR where a reviewer will not expect it.
+3. **Phase 0 takes `schemaVersion 2` and #83 takes 3.** Technically harmless, since nothing
+   reads the field. Contradicts #84's "one bump" intent and means two regenerations of the same
+   artifact in sequence, whichever order they land.
+
+Recommendation: **option 2** if #83 is small enough to review alongside, otherwise **option 3** —
+the "one bump" goal in #84 is bookkeeping tidiness, and it should not be what gates the Fusion
+work. What must not happen is Phase 0 silently claiming `schemaVersion 2` without #83 knowing,
+which is the default outcome if this is not decided.
+
+Also worth re-checking at implementation time: the regeneration path itself has been failing.
+`update-api-capability-map.yml` has failed on every run since 2026-07-24 at the final
+`Open pull request` step (`GitHub Actions is not permitted to create or approve pull requests`
+— a repo setting, not a code fault). Generation and tests pass and the branch is still
+force-pushed, so `origin/automated/update-api-capability-map` holds regenerations `main` has
+never received. **Check that branch before regenerating by hand**, or Phase 0 may re-derive work
+that already exists. Fixing the workflow needs repo-admin access.
 
 ### Drift test
 
@@ -257,9 +339,13 @@ A test asserting:
   (Note its 5.1 branch deliberately calls `ConvertFrom-Json` without `-Depth`, which does not
   exist before PS6 — do not "fix" that into a single call.)
 - `Tests/Build-PfbCapabilityMap.Tests.ps1` and `Tests/Get-PfbCapabilityMap.Tests.ps1` green.
-- `Tests/Build-PfbApiDriftReport.Tests.ps1` green, including byte-for-byte `Reports/`
-  reproduction. **If regenerating the map changes a tracked report, that is a finding to
-  explain, not a file to quietly re-baseline.**
+- `Tests/Build-PfbApiDriftReport.Tests.ps1` green. **There is no byte-identical regeneration
+  gate on the committed map** — `update-api-capability-map.yml` regenerates and opens a PR, it
+  does not fail on a diff. The actual enforcement is the "nothing vanishes" invariant in this
+  test file, and it is guarded on gitignored `tools/specs/`, so it skips in a fresh worktree.
+  Verify the specs directory is populated before treating a pass as meaningful.
+- If regenerating changes a tracked report, that is still a finding to explain rather than a file
+  to quietly re-baseline — but the guard rail is review, not CI.
 
 ---
 
@@ -439,9 +525,11 @@ Item 1 has no live surface — it is a refactor with no runtime caller until Pha
 
 | Risk | Handling |
 |---|---|
-| Regenerating the map perturbs a tracked `Reports/` artifact | The drift test catches it byte-for-byte. Explain any diff; do not re-baseline silently |
-| The resolver move changes resolution behaviour subtly | Covered by the explicit key-present-`null` vs key-absent tests, plus the `Reports/` reproduction check as an independent witness |
-| `schemaVersion` 2 breaks an unknown consumer | The field is additive and `Get-PfbCapabilityMap` is the only gate. In-repo consumers are enumerable; check them |
+| Regenerating the map perturbs a tracked `Reports/` artifact | No CI gate catches this byte-for-byte. Diff the regenerated artifacts by hand and explain any change; do not re-baseline silently |
+| The drift tests pass without running | They skip on gitignored `tools/specs/`. Confirm the directory is populated — it is in both Fusion worktrees (29 files) |
+| The resolver move changes resolution behaviour subtly | Covered by the explicit key-present-`null` vs key-absent tests. Note the `Reports/` reproduction check is **not** an independent witness here, contrary to how it is often cited |
+| **`schemaVersion 2` claimed twice** — by this spec and by #83 | The real risk, and the reason the "Coordination with #84" decision must be made first. Not a compatibility problem: nothing reads the field |
+| Regenerating by hand duplicates work already on `origin/automated/update-api-capability-map` | Check that branch first; its auto-PR step has been failing since 2026-07-24 |
 | Curated `contextScope` entries outlive the upstream fix | The drift test flags any curated entry that has gained an override |
 | Phase 1 needs a scope value Phase 0 marked `unknown` | `unknown` suppresses validation and leaves today's behaviour, so Phase 1 degrades rather than breaking. Adding an entry later is a generator-table edit plus a regenerate |
 

--- a/docs/design/fusion-context-phase-0-spec.md
+++ b/docs/design/fusion-context-phase-0-spec.md
@@ -6,10 +6,10 @@ Tracking: #25 (Fusion `context_names` injection), #74 (component-resolution move
 Coordinates with: #84 (capability-map generator/schema tracker) — see item 2
 Branch: `feat/fusion-context-phase-0`
 
-> **One decision is required before implementation starts.** Item 2 needs
-> `Data/PfbCapabilityMap.json`'s `schemaVersion` bumped to 2, and so does issue #83. Tracking
-> issue #84 plans them as a single bump in a single PR. See "Coordination with #84" for the
-> three options and a recommendation.
+> **Settled:** item 2 needs `Data/PfbCapabilityMap.json`'s `schemaVersion` bumped to 2, and so
+> does issue #83. Tracking issue #84 originally planned them as a single bump in a single PR.
+> **That pairing is dissolved** — Phase 0 ships `contextScope` and takes `schemaVersion 2`;
+> #84's generator work moves to its own PR. See "Coordination with #84."
 
 ---
 
@@ -295,22 +295,38 @@ Note the capability map itself was never affected — `Build-PfbCapabilityMap.ps
 `Public/`/`Private/`, and its spec enumeration is explicitly sorted — but Phase 0 regenerates
 the derived reports too, so it would have dragged the phantom diff along.
 
-**Decision required before implementation** (three options, and this spec does not pick one):
+#### Decision: the pairing is dissolved
 
-1. **Sequence behind #84's PR 2.** Phase 0 drops the map work entirely and waits. Cleanest for
-   #84, but it makes Phase 0 — and therefore all of Phase 1 — blocked on unrelated generator
-   work with no timeline.
-2. **Phase 0 absorbs #83.** One PR, one bump, both fields. Matches #84's intent exactly and
-   removes the artifact conflict, at the cost of putting array-body cardinality work inside a
-   Fusion PR where a reviewer will not expect it.
-3. **Phase 0 takes `schemaVersion 2` and #83 takes 3.** Technically harmless, since nothing
-   reads the field. Contradicts #84's "one bump" intent and means two regenerations of the same
-   artifact in sequence, whichever order they land.
+**Phase 0 ships `contextScope` and takes `schemaVersion 2`. #84's generator work — #71, #82,
+#83 — moves to its own PR, and #83 takes the next `schemaVersion` it finds.**
 
-Recommendation: **option 2** if #83 is small enough to review alongside, otherwise **option 3** —
-the "one bump" goal in #84 is bookkeeping tidiness, and it should not be what gates the Fusion
-work. What must not happen is Phase 0 silently claiming `schemaVersion 2` without #83 knowing,
-which is the default outcome if this is not decided.
+The test applied was whether Phase 0 could absorb *all* of #84, which would have preserved
+#84's one-bump intent. It cannot, for a structural reason rather than a size one: **#71, #82 and
+#83 all land in `Add-PfbSchemaPropertyNodes`** (`tools/lib/PfbSpecTools.ps1:191`), a recursive
+schema walker whose `MaxDepth` is threaded through five call sites and which feeds **both**
+`Data/PfbCapabilityMap.json` and `Data/PfbResponseShapeMap.json`. Changing it perturbs two
+runtime artifacts and every derived report at once. It also has a downstream consumer with
+nothing to do with Fusion — **#44 (batch cmdlets) is blocked on PR 1**, because its four
+endpoints are exactly the ones #82 makes visible.
+
+Folding that into a Fusion prerequisites PR would put a delicate shared refactor in front of a
+reviewer who is there to evaluate context plumbing, and would couple Phase 1's timeline to it.
+`contextScope`, by contrast, reads operation-level `x-pure-*` extensions and does not touch the
+body-schema walk at all — the two changes are genuinely independent in code.
+
+What this costs: two sequential regenerations of `Data/PfbCapabilityMap.json`, and #84's
+"one bump" bookkeeping goal. Both are acceptable, because **nothing reads `schemaVersion`** — it
+is a label. What it buys is that neither PR gates the other.
+
+Consequences to honour:
+
+- **#84 must be updated** so its PR 2 no longer claims `contextScope`. Leaving that stale
+  misleads whoever picks the tracker up.
+- **Whichever PR lands second regenerates the artifact** and resolves the conflict on it. That
+  is a mechanical regeneration, not a merge — do not hand-resolve a 632-endpoint generated file.
+- **#83 increments from whatever it finds**, rather than being pre-assigned 3. If Phase 0 slips
+  and #83 lands first, #83 takes 2 and Phase 0 takes 3. The number carries no meaning; only
+  "newer than what I read" does.
 
 Also worth re-checking at implementation time: the regeneration path itself has been failing.
 `update-api-capability-map.yml` has failed on every run since 2026-07-24 at the final
@@ -528,7 +544,8 @@ Item 1 has no live surface — it is a refactor with no runtime caller until Pha
 | Regenerating the map perturbs a tracked `Reports/` artifact | No CI gate catches this byte-for-byte. Diff the regenerated artifacts by hand and explain any change; do not re-baseline silently |
 | The drift tests pass without running | They skip on gitignored `tools/specs/`. Confirm the directory is populated — it is in both Fusion worktrees (29 files) |
 | The resolver move changes resolution behaviour subtly | Covered by the explicit key-present-`null` vs key-absent tests. Note the `Reports/` reproduction check is **not** an independent witness here, contrary to how it is often cited |
-| **`schemaVersion 2` claimed twice** — by this spec and by #83 | The real risk, and the reason the "Coordination with #84" decision must be made first. Not a compatibility problem: nothing reads the field |
+| **`schemaVersion 2` claimed twice** — by this spec and by #83 | Settled: Phase 0 takes 2, #83 increments from what it finds. Not a compatibility problem either way, since nothing reads the field. Requires updating #84 so its PR 2 stops claiming `contextScope` |
+| Both PRs regenerate the same 632-endpoint artifact | Expected. Whichever lands second regenerates rather than hand-resolving the conflict |
 | Regenerating by hand duplicates work already on `origin/automated/update-api-capability-map` | Check that branch first; its auto-PR step has been failing since 2026-07-24 |
 | Curated `contextScope` entries outlive the upstream fix | The drift test flags any curated entry that has gained an override |
 | Phase 1 needs a scope value Phase 0 marked `unknown` | `unknown` suppresses validation and leaves today's behaviour, so Phase 1 degrades rather than breaking. Adding an entry later is a generator-table edit plus a regenerate |

--- a/docs/design/fusion-context-phase-0-spec.md
+++ b/docs/design/fusion-context-phase-0-spec.md
@@ -1,0 +1,462 @@
+# Spec: Fusion context support, Phase 0 (prerequisites)
+
+Status: proposed
+Design doc: `docs/design/fusion-context-injection.md` (rev 4)
+Tracking: #25 (Fusion `context_names` injection), #74 (component-resolution move)
+Branch: `feat/fusion-context-phase-0`
+
+---
+
+## Purpose
+
+Phase 0 lands the four things that must exist **before** the Fusion `context_names`
+injection path can be built, and lands them as one PR that ships no user-visible context
+surface at all.
+
+The design doc's Phasing section originally folded all four into Phase 1. They are split out
+because each one is independently justifiable, each is reviewable without holding the whole
+context design in mind, and two of them are load-bearing for Phase 1 in a way that is easy to
+get wrong if built at the same time as the feature that consumes them:
+
+| # | Work item | Why it must precede Phase 1 |
+|---|---|---|
+| 1 | Move `context_names` component resolution from `tools/lib` into `Private/` | Phase 1 needs resolved component names to call the cardinality predicate at all. Built in the obvious order it will silently reimplement the rule, producing two copies (#74) |
+| 2 | `contextScope` per-endpoint field in the capability map, `schemaVersion` 2 | Kind-vs-scope validation and every scope-aware error message are map lookups. They cannot be written before the map carries the field |
+| 3 | Connect-time capability-map staleness warning | It is the honesty half of the design's decision to stay permissive beyond the map's scanned range. Not context-specific |
+| 4 | `Get-PfbFleetMember` top-level `MemberName` / `FleetName` | Worth doing on its own merits; Phase 1's `Set-PfbContext` pipeline binding depends on it |
+
+Items 3 and 4 are improvements this module wants regardless of Fusion. Fusion is only where
+their absence bites hardest.
+
+**Nothing in Phase 0 introduces `-Context`, `Set-PfbContext`, `Invoke-PfbInContext`,
+`-AllArrays`, or any injection behaviour.** A user upgrading to this cannot tell the context
+work is coming, except that `Get-PfbFleetMember` output is more readable and a warning may
+appear at connect time.
+
+---
+
+## Out of scope
+
+Explicitly deferred, listed because a reviewer will reasonably wonder:
+
+- The `PfbContext` object, connection context state, and the injection path — Phase 1.
+- Consuming `contextScope` for validation or error messages — Phase 1. Phase 0 **populates
+  and ships the field, and nothing reads it at runtime.**
+- `allow_errors` surfacing and the HTTP 207 response branch — Phase 2.
+- `context_ids`, a multi-value mutating fan-out helper, context display in
+  `Get-PfbArrayConnection` — Phase 3.
+- Topology-group and fleet/realm object-management cmdlets — #38.
+- **Module version bump and CHANGELOG.** Per project convention these are the maintainer's
+  own decision and are not part of feature PRs. Note this is unrelated to item 2's
+  `schemaVersion` bump, which is a field inside the capability-map data file, not the
+  module version.
+
+---
+
+## Item 1 — Move `context_names` component resolution into `Private/`
+
+Closes #74.
+
+### Problem
+
+`Private/Test-PfbContextMultiValueCapable.ps1` shipped in PR #73 as the single declared home
+of the cardinality rule. The code producing its `-ContextComponent` input did not ship with
+it. `PureStorageFlashBladePowerShell.psm1` dot-sources only `Private/` and `Public/`; `tools/`
+is never loaded. So the predicate is loaded into the module and **cannot be fed from inside
+it** — it currently has zero runtime callers and is inert.
+
+The resolution logic lives in `Get-PfbContextParameterFact`
+(`tools/lib/PfbContextRuleTools.ps1`, the `CapabilityMap` branch), which also does record
+shaping and HTTP 207 merging. Those two are maintainer-toolchain concerns and stay in
+`tools/`. Untangling the three responsibilities is the actual work; the move is small.
+
+### The contract being moved
+
+Three steps, in order, and the ordering is the whole point:
+
+1. If the endpoint's `parameterComponentOverrides` **contains the key** for the parameter,
+   that value is authoritative **even when it is JSON `null`** — `null` means "this
+   endpoint's parameter has no component." Do not consult defaults.
+2. Otherwise, if top-level `parameterComponentDefaults` contains the parameter name, use it.
+3. Otherwise, no known component.
+
+Steps 1-with-`null` and 3 both yield `$null`, so the distinction is **not visible in the
+return value** — it is entirely about whether step 2 is allowed to run. That is precisely why
+#74 flags it as the part most likely to be reimplemented subtly wrong: both cases look like
+"no value" to a casual reading, and a reimplementation that checks
+`if ($overrides.$name)` instead of `if ($overrides.PSObject.Properties.Name -contains $name)`
+silently falls through to the default for a `null` override and produces a wrong component
+name for exactly the endpoints the cardinality rule cares about.
+
+### Change
+
+Add `Private/Resolve-PfbParameterComponent.ps1`:
+
+```powershell
+function Resolve-PfbParameterComponent {
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)] $EndpointEntry,          # one capability-map endpoints.<key> object
+        [Parameter(Mandatory)] [string]$ParameterName,
+        [AllowNull()] $ParameterComponentDefaults        # the map's top-level table
+    )
+    # returns the resolved component name, or $null
+}
+```
+
+Deliberately parameterised on `-ParameterName` rather than hardcoded to `context_names`: the
+three-step contract is a property of the capability map's shape, not of Fusion, and
+`allow_errors` will need the same resolution in Phase 2.
+
+Pure, like `Test-PfbContextMultiValueCapable` — no map loading, no file I/O. The caller
+supplies the entry and the defaults table.
+
+Then:
+
+- `Get-PfbContextParameterFact` calls it instead of inlining the resolution. Behaviour
+  unchanged. It keeps record shaping and 207 merging.
+- `tools/lib/PfbContextRuleTools.ps1` gains a dependency on `Private/`. **This direction is
+  the fix** — `tools/` may depend on `Private/`, never the reverse. Relocating without
+  inverting the dependency would not resolve #74.
+- The tools lib currently defines `$script:PfbContextParameterName = 'context_names'` and
+  `$script:PfbAllowErrorsParameterName = 'allow_errors'` at lines 51/53. Decide one home for
+  these rather than duplicating them; a `Private/` constant that `tools/` consumes matches
+  the dependency direction.
+
+`tools/` is not on the module's load path, so it must dot-source the `Private/` file
+explicitly. Verify this works from the drift-report entry point and not merely from an
+interactive session that already has the module imported.
+
+### Acceptance
+
+- `Resolve-PfbParameterComponent` is reachable inside the module (`internal: True`).
+- `Get-PfbContextParameterFact` remains internal to `tools/` and is **not** exported.
+- `Tests/PfbContextRuleTools.Tests.ps1` (54 tests) stays green.
+- `Tests/Build-PfbApiDriftReport.Tests.ps1` (60 tests) stays green — including its check that
+  the committed `Reports/` artifacts still reproduce byte-for-byte. A behaviour change in
+  resolution would surface here as a report diff.
+- New unit tests for the resolver covering all three steps, with **key-present-but-`null` and
+  key-absent as separate explicit cases**. This is the regression the move exists to prevent;
+  a test that only exercises "returns `$null`" does not distinguish them. Assert that a
+  `null` override does **not** fall through to a default that would otherwise match.
+
+---
+
+## Item 2 — `contextScope` in the capability map
+
+Implements design doc section 12, "Encoding it in the shipped map."
+
+### Problem
+
+Phase 1's kind-vs-scope validation and all of its scope-aware error messages need to know
+whether an endpoint is fleet-scoped or array-scoped. The capability map has no field for it,
+and `tools/Build-PfbCapabilityMap.ps1` reads **none** of the `x-pure-*` vendor extensions
+(verified: zero occurrences in the generator).
+
+Neither operation `tags` nor cardinality is a usable proxy. Cardinality is close enough to be
+a trap: a fleet-scoped endpoint is necessarily size-1, but so is every array-scoped mutation,
+so size-1 is implied by fleet scope and does not imply it back.
+
+### Where the signal comes from
+
+Three vendor extensions, measured against `tools/specs/fb2.28.json`:
+
+| Extension | Count at 2.28 | Meaning |
+|---|---|---|
+| `x-pure-remote-execution-context-domains-override` | **5** | The context domains this operation accepts |
+| `x-pure-incomplete-gre` | **28** | Remote-execution annotation is known incomplete here |
+| `x-pure-block-remote-execution` | **266** | Remote execution unsupported |
+
+The override covers exactly five operations, all `/presets/workload`, and agrees with live
+testing without qualification:
+
+```
+GET    /presets/workload  ->  ARRAY, FLEET
+PUT    /presets/workload  ->  FLEET
+POST   /presets/workload  ->  FLEET
+DELETE /presets/workload  ->  FLEET
+PATCH  /presets/workload  ->  FLEET
+```
+
+Reads legal in either domain, writes fleet-only — precisely what the wire does. The
+declaration and the measurement are independent derivations of the same fact.
+
+These are not three independent signals. They are a partially-completed annotation pass plus a
+flag marking where it is unfinished. So:
+
+| Endpoint state | Scope source |
+|---|---|
+| Has an override | **Trust it** |
+| No override, not flagged incomplete | Default `array` |
+| Flagged `x-pure-incomplete-gre` | **Do not trust the absence of an override.** Curated value where live evidence exists, else `unknown` |
+
+### The curated table is four entries
+
+Of the 28 flagged operations, nine already have evidence: the five preset operations carry the
+override and need no curation, and four were established by live testing. Verified that all
+four are in fact flagged:
+
+| Entry | `contextScope` | Provenance |
+|---|---|---|
+| `GET /topology-groups` | `fleet` | live-tested |
+| `GET /topology-groups/arrays` | `fleet` | live-tested |
+| `GET /topology-groups/members` | `fleet` | live-tested |
+| `GET /workloads/tags` | `array` | live-tested |
+
+The remaining 19 flagged operations record `unknown`, which suppresses kind-vs-scope
+validation in Phase 1 and leaves today's behaviour. Each curated entry retires as upstream
+fills in its override.
+
+**Verified gap worth writing down:** the five topology-group **write** verbs are not flagged
+and carry no override, so they fall to the `array` default even though the family's reads are
+fleet-scoped. That is the fail-safe direction — it costs guidance rather than blocking a call.
+Live testing on 2026-08-04 confirmed those writes do in fact succeed in array context, so the
+default is not merely safe here, it is correct. Re-check when #38 lands.
+
+### Change
+
+1. **Generator reads the three extensions.** The map is already built across 2.0-2.28 with
+   last-seen-wins, so a value present only in the 2.28 document lands correctly with no change
+   to the version-merging logic.
+2. **`contextScope` becomes an additive per-endpoint field**, alongside `minVersion`,
+   `parameters`, `bodyProperties`, `parameterComponentOverrides`. It records the value and its
+   provenance (`declared` / `live-tested` / `unknown`).
+3. **Bump `schemaVersion` 1 -> 2** (`tools/Build-PfbCapabilityMap.ps1:317`). Additive changes
+   would not strictly require it, but `Get-PfbCapabilityMap` is the single gate every consumer
+   sees the map through, so the shape should not grow silently.
+4. **The curated table lives in the generator**, not in `Private/`. Runtime code reads scope
+   from the shipped map and nowhere else. A curated list consulted at runtime would be a
+   second source of truth for the same fact — the exact failure mode #74 exists to fix.
+5. **Default `array`**, the fail-safe direction. Mis-marking a fleet-scoped endpoint as
+   array-scoped costs guidance and leaves today's behaviour; the reverse would throw on a call
+   that would have worked.
+6. **Not version-gated.** A resource does not migrate between the fleet database and an array,
+   so last-seen-wins is correct here in a way it is not for component identity. The 2.28
+   annotations describe 2.23-era endpoints accurately.
+7. **Regenerate `Data/PfbCapabilityMap.json`** and commit it. 632 endpoints today.
+
+This rides the existing `.github/workflows/update-api-capability-map.yml`. One generator
+change, one schema bump, one test — no new pipeline.
+
+### Drift test
+
+A test asserting:
+
+- The five declared overrides still match what the generator emits.
+- **Any curated entry whose endpoint has since gained an override is flagged**, so the curated
+  set shrinks on its own instead of quietly shadowing better data. This is the part that keeps
+  the table honest; without it a curated `fleet` would outlive the upstream fix indefinitely.
+- The three extension counts, as a canary on the annotation pass advancing.
+
+### Acceptance
+
+- Every map endpoint has a `contextScope` with a provenance value.
+- The five preset operations read `declared`; the four curated entries read `live-tested`; 19
+  flagged operations read `unknown`; everything else `array`.
+- `schemaVersion` is 2 and `Get-PfbCapabilityMap` still loads the map on both PS editions.
+  (Note its 5.1 branch deliberately calls `ConvertFrom-Json` without `-Depth`, which does not
+  exist before PS6 — do not "fix" that into a single call.)
+- `Tests/Build-PfbCapabilityMap.Tests.ps1` and `Tests/Get-PfbCapabilityMap.Tests.ps1` green.
+- `Tests/Build-PfbApiDriftReport.Tests.ps1` green, including byte-for-byte `Reports/`
+  reproduction. **If regenerating the map changes a tracked report, that is a finding to
+  explain, not a file to quietly re-baseline.**
+
+---
+
+## Item 3 — Connect-time capability-map staleness warning
+
+Implements design doc section "Connect-time staleness warning."
+
+### Why
+
+`Assert-PfbApiCapability`'s founding principle is that a capability check must never be the
+reason a call that would otherwise succeed gets blocked. The design keeps a **permissive**
+fallback when the connected array's REST version exceeds the map's scanned range: no evidence
+either way, so proceed without injecting or throwing.
+
+Wes argued the opposite — that permissiveness trades away safety, since the module cannot
+distinguish "never supported" from "supported in a version we have not scanned." The decision
+is to stay permissive, for a reason specific to this module: a REST caller names a version in
+the URL and can reason about it; a cmdlet caller has not, because the module negotiates the
+version for them. Blocking a call because the *bundled map* is older than the array punishes
+a packaging lag the user cannot see and did not choose. The remedy is to tell them the map is
+behind.
+
+**This warning is what makes that trade honest, and is therefore a required part of the
+decision rather than a nicety.** It is not context-specific; `context_names` is only the
+sharpest instance, because its lag fails silently rather than with a clean wire 400.
+
+### Change
+
+- **Check once, unconditionally, in `Connect-PfbArray`** — regardless of any context
+  parameter. Compare the negotiated version against the maximum of the map's `generatedFrom`
+  (29 entries today, `2.0`-`2.28`).
+- **Cache the result on the connection object** (e.g. `.ExceedsCapabilityMapCoverage`) rather
+  than recomputing per call. The connection is built at
+  `Public/Connection/Connect-PfbArray.ps1:373`; note it already exposes the negotiated version
+  as **both** `RestApiVersion` and `ApiVersion` (same value), and maintains an explicit
+  property list at `:405` that a new property must be added to.
+- **One-shot per connection** — fires once for the connection's life however many calls or
+  context changes follow.
+- Because it fires at connect universally, Phase 1's `Set-PfbContext` /
+  `Invoke-PfbInContext` need no trigger of their own. A defensive re-check there is cheap
+  insurance for a connection cached from before an upgrade.
+- **Message**, naming the sharp case:
+
+  > Connected array is running REST 2.29; this module's capability map only covers through
+  > REST 2.28 — capability checks for anything newer, including context scoping, cannot be
+  > fully verified and may not error even if unsupported. Check the PowerShell Gallery for a
+  > newer release (`Update-Module`).
+
+- **No live Gallery lookup.** `Find-Module` is a network dependency with real latency and
+  failure modes, and this module runs against air-gapped lab and customer arrays. Point at the
+  mechanism; do not auto-detect whether an update exists.
+
+### Acceptance
+
+- Fires when negotiated version > `max(generatedFrom)`; silent when within range.
+- Fires **exactly once** per connection — assert the count, not merely that it appeared.
+- Uses `Write-Warning`, so `-WarningAction SilentlyContinue` suppresses it and it never
+  contaminates the pipeline. A connection object is still returned.
+- No network call is made to determine it.
+
+---
+
+## Item 4 — `Get-PfbFleetMember` top-level `MemberName` / `FleetName`
+
+Implements design doc section "Make `Get-PfbFleetMember | Set-PfbContext` first-class,"
+piece (a) only. Pieces (b) and (c) are `Set-PfbContext`'s own parameter shape and belong to
+Phase 1.
+
+### Problem
+
+`Get-PfbFleetMember` (`Public/Replication/Get-PfbFleetMember.ps1`) returns the raw
+`FleetMember` objects from `fleets/members`, whose top-level properties are `coordinator_of`,
+`fleet`, `member`, `status`, `status_details`. The array name is nested at `.member.name`.
+
+`ValueFromPipelineByPropertyName` matches only top-level names, so in Phase 1 the natural
+form binds nothing and the pipe **silently no-ops** — the same silent-wrong-scope family the
+whole context design exists to fight.
+
+### Change
+
+Decorate each emitted object with top-level:
+
+- `MemberName` = `.member.name`
+- `FleetName`  = `.fleet.name`
+
+Worth doing on its own merits: it makes the object readable at the console and gives the
+pipeline something to bind. The cmdlet already uses `-AutoPaginate`, so decoration must apply
+to every page's items, not just the first.
+
+### Deliberately not added: `IsLocal`
+
+The obvious third property — filter out the local array before scoping a context — is a trap.
+`is_local` is relative to **the call's context**, not to the connection: call
+`/fleets/members` with context ArrayB and ArrayB reports `is_local = true` while ArrayA
+reports `false`. A documented `Where-Object { -not $_.IsLocal }` idiom would therefore select
+a different array once a context is active, silently.
+
+Determining the local array should use the connection, not a per-call response field.
+`/fleets/members` may not accept `context_names` at all yet, which masks the problem today
+but does not fix it.
+
+### Acceptance
+
+- Both properties present on every emitted object, across pagination.
+- Raw nested `member` / `fleet` objects still present — this is additive, not a reshape.
+  Existing callers reaching `.member.name` keep working.
+- Absent or partial API data (a member with no `.member.name`) yields `$null`, not a throw.
+- No `IsLocal`.
+- New `Tests/Get-PfbFleetMember.Tests.ps1` — the cmdlet has no test file today.
+
+---
+
+## Testing
+
+Per this repo's testing rule: **scope every run, and run both PowerShell editions.** CI gates
+on Windows PowerShell 5.1 as well as pwsh 7, and a scoped pwsh-7-only run cannot see a
+container failure on 5.1. Use
+`.claude/skills/run-pester-tests/scripts/Invoke-ScopedPester.ps1 -Path <files>`, which runs
+both concurrently and fails if either does. Read the `Container` column, not the counts — a
+healthy skip run and a `#requires`-killed file both read `0 / 0`.
+
+Do **not** run the aggregate suite as a completion check; that is CI's job.
+
+Baseline for this branch, already captured at `ad00aae`: pwsh 7 `135/0/0`, WinPS 5.1
+`96/0/39 skipped`, `Container ok` both.
+
+Files in scope:
+
+| File | Items |
+|---|---|
+| `Tests/PfbContextRuleTools.Tests.ps1` | 1 |
+| `Tests/Resolve-PfbParameterComponent.Tests.ps1` (new) | 1 |
+| `Tests/Build-PfbApiDriftReport.Tests.ps1` | 1, 2 |
+| `Tests/Build-PfbCapabilityMap.Tests.ps1` | 2 |
+| `Tests/Get-PfbCapabilityMap.Tests.ps1` | 2 |
+| `Tests/Connect-PfbArray.*.Tests.ps1` | 3 |
+| `Tests/Get-PfbFleetMember.Tests.ps1` (new) | 4 |
+| `Tests/ModuleManifest.Tests.ps1` | 1 (new `Private/` file) |
+
+Two 5.1 traps that have each already broken CI here: adding a `Describe` to an existing file
+without matching the guard its siblings carry, and editing anything under `tools/`. Item 1 and
+item 2 both touch `tools/`.
+
+Do not test a mandatory parameter by `Should -Throw` alone — `[Parameter(Mandatory)]` prompts
+and hangs under `-NonInteractive` instead of throwing. Use an optional parameter with an
+explicit throw.
+
+---
+
+## Live verification
+
+Required before this branch opens a PR — mocked unit tests are necessary but not sufficient
+sign-off here.
+
+Target FB-A (`cc-test-fleet` coordinator, Purity//FB 4.8.2, REST 2.26), reusing existing lab
+resources. Preconditions from the design doc's Appendix D still apply to anything touching
+context: probe as a **dynamic**-authorization-model admin, never static `pureuser`, which
+returns `code 20` on everything fleet-scoped and produces confident wrong conclusions.
+
+Phase 0 ships no injection, so the surface to verify live is small:
+
+1. **Item 4** — `Get-PfbFleetMember` against the real 3-member fleet emits `MemberName` and
+   `FleetName` populated for all three.
+2. **Item 3** — the negative case is the one that matters: FB-A at REST 2.26 is **within**
+   the map's range, so the warning must **not** fire. Force the positive case by stubbing the
+   map's `generatedFrom` maximum below the negotiated version rather than by waiting for a
+   newer array.
+3. **Item 2** — spot-check that the shipped map's `contextScope` for the four curated entries
+   and the five preset operations matches what the array actually does. This is re-confirming
+   already-measured facts against the regenerated artifact, not new discovery.
+
+Item 1 has no live surface — it is a refactor with no runtime caller until Phase 1.
+
+---
+
+## Risks
+
+| Risk | Handling |
+|---|---|
+| Regenerating the map perturbs a tracked `Reports/` artifact | The drift test catches it byte-for-byte. Explain any diff; do not re-baseline silently |
+| The resolver move changes resolution behaviour subtly | Covered by the explicit key-present-`null` vs key-absent tests, plus the `Reports/` reproduction check as an independent witness |
+| `schemaVersion` 2 breaks an unknown consumer | The field is additive and `Get-PfbCapabilityMap` is the only gate. In-repo consumers are enumerable; check them |
+| Curated `contextScope` entries outlive the upstream fix | The drift test flags any curated entry that has gained an override |
+| Phase 1 needs a scope value Phase 0 marked `unknown` | `unknown` suppresses validation and leaves today's behaviour, so Phase 1 degrades rather than breaking. Adding an entry later is a generator-table edit plus a regenerate |
+
+---
+
+## Open questions
+
+None blocking. Two carried from the design doc and settled for Phase 0's purposes:
+
+- **Whether `x-pure-incomplete-gre` should become a third signal in the maintainer drift
+  report** (design doc section 12, "Consequences for section 8"). It is not a cardinality
+  predicate, but it is upstream telling us where two-signal comparison is blind, and all four
+  endpoints the withdrawn verb rule got wrong carry it. Phase 0 records the count as a canary;
+  promoting it to a full signal is deferred, not rejected.
+- **`x-pure-block-remote-execution` contradicts `context_names` on 11 endpoints.** All 11 are
+  inside the 28 flagged incomplete, which is self-consistent. It means `block` cannot be used
+  as a runtime signal without excluding the flagged set first. Phase 0 reads the extension but
+  does not act on it.

--- a/tools/Build-PfbCapabilityMap.ps1
+++ b/tools/Build-PfbCapabilityMap.ps1
@@ -229,9 +229,26 @@ foreach ($entry in $specFiles) {
             # Declared domains are authoritative. FLEET-only means fleet-scoped; anything
             # that also accepts ARRAY is usable array-scoped, which is what Phase 1 needs
             # to know.
+            #
+            # An unrecognised domain token falls to unknown/unknown rather than to 'fleet'.
+            # Only ARRAY and FLEET occur across all 29 cached specs today (measured), so this
+            # branch is unreachable -- but treating a token we cannot interpret as 'fleet'
+            # would assert a scope on no evidence AND stamp it provenance='declared', which
+            # reads as "upstream told us" to Phase 1. Recording ignorance is the honest
+            # failure mode, and it is the same one the flagged-but-uncurated case uses.
             $declaredDomains = @($scopeRecord.DomainsOverride | ForEach-Object { "$_".ToUpperInvariant() })
-            $scopeValue = if ($declaredDomains -contains 'ARRAY') { 'array' } else { 'fleet' }
-            $scopeProvenance = 'declared'
+            if ($declaredDomains -contains 'ARRAY') {
+                $scopeValue = 'array'
+                $scopeProvenance = 'declared'
+            }
+            elseif ($declaredDomains -contains 'FLEET') {
+                $scopeValue = 'fleet'
+                $scopeProvenance = 'declared'
+            }
+            else {
+                $scopeValue = 'unknown'
+                $scopeProvenance = 'unknown'
+            }
         }
         elseif ($curatedContextScope.ContainsKey($epKey)) {
             $scopeValue = $curatedContextScope[$epKey]

--- a/tools/Build-PfbCapabilityMap.ps1
+++ b/tools/Build-PfbCapabilityMap.ps1
@@ -118,6 +118,26 @@ if ($MaxVersion) {
     Write-Host "MaxVersion $MaxVersion applied: including $($specFiles.Count) of $beforeCount cached specs." -ForegroundColor Yellow
 }
 
+# ---- Fusion context scope ----
+#
+# Curated scope values for endpoints upstream has flagged x-pure-incomplete-gre, where the
+# ABSENCE of a domains override carries no information. Every entry here was established by
+# live testing, not inference.
+#
+# This table lives in the GENERATOR, never in Private/. Runtime code reads scope from the
+# shipped map and nowhere else -- a curated list consulted at runtime would be a second
+# source of truth for the same fact, which is the failure mode issue #74 exists to fix.
+#
+# Each entry retires as upstream fills in the corresponding override. The drift test in
+# Tests/Build-PfbCapabilityMap.ContextScopeDrift.Tests.ps1 fails when that happens, so the
+# table shrinks on its own instead of quietly shadowing better data.
+$curatedContextScope = @{
+    'GET /topology-groups'         = 'fleet'
+    'GET /topology-groups/arrays'  = 'fleet'
+    'GET /topology-groups/members' = 'fleet'
+    'GET /workloads/tags'          = 'array'
+}
+
 $endpoints = [ordered]@{}
 $processedVersions = [System.Collections.Generic.List[string]]::new()
 
@@ -127,6 +147,15 @@ foreach ($entry in $specFiles) {
 
     $spec = Get-Content -Path $entry.File.FullName -Raw | ConvertFrom-Json -Depth 64
     $capabilities = Get-PfbSpecCapabilities -Spec $spec
+
+    # Index this version's remote-execution annotations by endpoint key. Read per version
+    # and applied last-seen-wins, same as readOnlyBodyProperties -- a resource does not
+    # migrate between the fleet database and an array, so the newest annotation is simply
+    # the best one, and no first-sight guard is wanted here.
+    $contextScopeByEndpoint = @{}
+    foreach ($scopeRecord in (Get-PfbSpecContextScope -Spec $spec)) {
+        $contextScopeByEndpoint[$scopeRecord.Endpoint] = $scopeRecord
+    }
 
     foreach ($cap in $capabilities) {
         $epKey = "$($cap.Method) $($cap.Path)"
@@ -187,6 +216,37 @@ foreach ($entry in $specFiles) {
         }
         elseif ($entryRecord.Contains('deprecatedBodyProperties')) {
             $entryRecord.Remove('deprecatedBodyProperties')
+        }
+
+        # contextScope: fleet-scoped vs array-scoped, plus where the answer came from.
+        # Assigned UNCONDITIONALLY (last-seen-wins), not first-sight -- see the indexing
+        # comment above. Phase 0 SHIPS this field and nothing reads it at runtime; Phase 1's
+        # kind-vs-scope validation and scope-aware error messages consume it.
+        $scopeRecord = $contextScopeByEndpoint[$epKey]
+        $scopeValue = 'array'
+        $scopeProvenance = 'default'
+        if ($scopeRecord -and @($scopeRecord.DomainsOverride).Count -gt 0) {
+            # Declared domains are authoritative. FLEET-only means fleet-scoped; anything
+            # that also accepts ARRAY is usable array-scoped, which is what Phase 1 needs
+            # to know.
+            $declaredDomains = @($scopeRecord.DomainsOverride | ForEach-Object { "$_".ToUpperInvariant() })
+            $scopeValue = if ($declaredDomains -contains 'ARRAY') { 'array' } else { 'fleet' }
+            $scopeProvenance = 'declared'
+        }
+        elseif ($curatedContextScope.ContainsKey($epKey)) {
+            $scopeValue = $curatedContextScope[$epKey]
+            $scopeProvenance = 'live-tested'
+        }
+        elseif ($scopeRecord -and $scopeRecord.IsIncompleteGre) {
+            # Flagged incomplete and not curated: the absent override proves nothing, so
+            # recording 'array' would assert something unevidenced. 'unknown' suppresses
+            # kind-vs-scope validation in Phase 1 and leaves today's behaviour.
+            $scopeValue = 'unknown'
+            $scopeProvenance = 'unknown'
+        }
+        $entryRecord.contextScope = [ordered]@{
+            scope      = $scopeValue
+            provenance = $scopeProvenance
         }
 
         # parameterComponents bookkeeping -- which $ref component backs each parameter
@@ -314,7 +374,7 @@ foreach ($epKey in $endpoints.get_Keys()) {
 }
 
 $manifest = [ordered]@{
-    schemaVersion              = 1
+    schemaVersion              = 2
     generatedFrom              = $processedVersions
     endpointCount              = $endpoints.Count
     parameterComponentDefaults = $parameterComponentDefaults

--- a/tools/README.md
+++ b/tools/README.md
@@ -50,6 +50,11 @@ Run in this order:
    calibrated against assumes a specific version ceiling, and an uncapped rebuild would
    silently move those numbers.
 
+   The manifest carries a top-level `schemaVersion`, currently **2** (raised from 1 when
+   `contextScope` was added). It is a maintainer label only — nothing in `Private/` or
+   `Public/` reads it, and each generated artifact versions itself independently, so
+   bumping one does not implicate the others.
+
    Besides `minVersion`/`parameters`/`bodyProperties` (each `{ name: introducedInVersion }`,
    monotonic first-sight), each endpoint also carries, where non-empty:
    - `readOnlyBodyProperties` / `deprecatedBodyProperties` (string arrays) — **last-seen-wins**,
@@ -60,10 +65,29 @@ Run in this order:
    - `parameterComponentOverrides` (`{ paramName: componentName }`, sorted by key) — see
      below.
 
+   And **unconditionally on every endpoint** (unlike the list above, this key is never
+   omitted):
+   - `contextScope` — the Fusion remote-execution scope, `{ scope, provenance }`. `scope`
+     is `array`, `fleet`, or `unknown`; `provenance` is `default`, `declared`,
+     `live-tested`, or `unknown`. Also **last-seen-wins**, for the same reason as
+     `readOnlyBodyProperties`: it is a property of the current API surface, not of when
+     something was introduced. Derived by `Get-PfbSpecContextScope` from three
+     operation-level extensions — `x-pure-remote-execution-context-domains-override`
+     (authoritative when present → `declared`), `x-pure-incomplete-gre`, and
+     `x-pure-block-remote-execution` — overlaid with a small curated table in
+     `Build-PfbCapabilityMap.ps1` for endpoints flagged incomplete upstream but verified
+     on the wire (→ `live-tested`). An endpoint flagged incomplete with neither an
+     override nor a curated entry resolves to `unknown`/`unknown`, which is a **designed
+     degradation**: consumers are expected to treat it as "no opinion" and fall back to
+     existing behaviour rather than failing.
+
    **`parameterComponentDefaults`/`parameterComponentOverrides` resolution contract:**
    which named OpenAPI `components/parameters/*` component backs a given
    `(endpoint, parameter)` pair is recorded across two places instead of once per
-   endpoint, because the vast majority of parameters share one of a small set of common
+   endpoint. **The prose below describes the contract; the single implementation of it is
+   `Private/Resolve-PfbParameterComponent.ps1`** — call that rather than reimplementing
+   the three steps, and update it and this section together. The split exists because the
+   vast majority of parameters share one of a small set of common
    components (`Filter`, `Limit`, `Sort`, …) — measured on fb2.0-2.27: 4102 total
    `(endpoint, parameter) -> component` pairs, but only 224 distinct pairs and 179
    distinct parameter names, so a naive full per-endpoint map is ~90% duplication. To

--- a/tools/lib/PfbContextRuleTools.ps1
+++ b/tools/lib/PfbContextRuleTools.ps1
@@ -48,22 +48,27 @@
     signal is wrong, each time.
 #>
 
-$script:PfbContextParameterName = 'context_names'
 $script:PfbContextMultiValueComponent = 'Context_names_get'
-$script:PfbAllowErrorsParameterName = 'allow_errors'
 
-# Execute the module's own rule rather than copying it. Failing loudly here is correct:
-# silently falling back to a local copy of the rule is the one outcome that would make
-# this whole check meaningless.
+# Execute the module's own rule and its own resolution contract rather than copying them.
+# Failing loudly here is correct: silently falling back to a local copy is the one outcome
+# that would make this whole check meaningless.
 $script:PfbContextRuleRepoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
-$script:PfbContextRulePredicatePath = Join-Path $script:PfbContextRuleRepoRoot 'Private/Test-PfbContextMultiValueCapable.ps1'
-if (-not (Test-Path $script:PfbContextRulePredicatePath)) {
-    throw ("PfbContextRuleTools: cannot locate the module's declared context-cardinality " +
-        "rule at '$script:PfbContextRulePredicatePath'. This check must execute the " +
-        'module rule, never re-implement it -- refusing to load rather than silently ' +
-        'verifying a private copy of the rule against itself.')
+$script:PfbContextRuleRequiredPath = @(
+    'Private/PfbContextConstants.ps1'
+    'Private/Test-PfbContextMultiValueCapable.ps1'
+    'Private/Resolve-PfbParameterComponent.ps1'
+)
+foreach ($relativePath in $script:PfbContextRuleRequiredPath) {
+    $absolutePath = Join-Path $script:PfbContextRuleRepoRoot $relativePath
+    if (-not (Test-Path $absolutePath)) {
+        throw ("PfbContextRuleTools: cannot locate the module's declared context rule/" +
+            "resolution contract at '$absolutePath'. This check must execute the module's " +
+            'own code, never re-implement it -- refusing to load rather than silently ' +
+            'verifying a private copy against itself.')
+    }
+    . $absolutePath
 }
-. $script:PfbContextRulePredicatePath
 
 function Get-PfbContextHttp207Endpoint {
     <#
@@ -197,15 +202,9 @@ function Get-PfbContextParameterFact {
             $paramNames = $entry.parameters.PSObject.Properties.Name
             if ($paramNames -notcontains $script:PfbContextParameterName) { continue }
 
-            $component = $null
-            $overrides = $entry.parameterComponentOverrides
-            if ($overrides -and ($overrides.PSObject.Properties.Name -contains $script:PfbContextParameterName)) {
-                # Key present -- authoritative, even when its value is null.
-                $component = $overrides.$($script:PfbContextParameterName)
-            }
-            elseif ($defaults -and ($defaults.PSObject.Properties.Name -contains $script:PfbContextParameterName)) {
-                $component = $defaults.$($script:PfbContextParameterName)
-            }
+            $component = Resolve-PfbParameterComponent -EndpointEntry $entry `
+                -ParameterName $script:PfbContextParameterName `
+                -ParameterComponentDefaults $defaults
 
             # Endpoint keys are "<METHOD> /<path>"; split once on the first space only, so
             # a path can never be truncated.

--- a/tools/lib/PfbSpecTools.ps1
+++ b/tools/lib/PfbSpecTools.ps1
@@ -803,3 +803,104 @@ function Get-PfbSwaggerIndexVersions {
         }
     } | Sort-Object Major, Minor | Select-Object -ExpandProperty Version
 }
+
+function Get-PfbSpecContextScope {
+    <#
+    .SYNOPSIS
+        Flattens one FlashBlade OpenAPI document into per-operation Fusion remote-execution
+        annotations: the context-domains override, and the two flags qualifying it.
+    .DESCRIPTION
+        Reads three operation-level vendor extensions. They are NOT three independent
+        signals -- they are a partially-completed annotation pass plus a flag marking where
+        it is unfinished:
+
+          x-pure-remote-execution-context-domains-override
+              The context domains this operation accepts. Authoritative where present.
+              5 operations at fb2.28, all /presets/workload, and it agrees with live
+              testing without qualification: GET accepts ARRAY+FLEET, every write verb
+              FLEET only -- exactly what the wire does.
+
+          x-pure-incomplete-gre
+              Upstream telling us the remote-execution annotation is known incomplete on
+              this operation. 28 at fb2.28. Its presence means the ABSENCE of an override
+              carries no information and must not be read as "array-scoped".
+
+          x-pure-block-remote-execution
+              Remote execution unsupported. 266 at fb2.28. Recorded but deliberately NOT
+              acted upon: it contradicts context_names on 11 endpoints, all of which are
+              inside the 28 flagged incomplete. Self-consistent, but it means `block`
+              cannot be used as a signal without excluding the flagged set first.
+
+        WHY A SEPARATE FUNCTION FROM Get-PfbSpecCapabilities. Two reasons. Issue #84's PR 1
+        edits Get-PfbSpecCapabilities' request-body walk, so adding fields to its record
+        would collide for no benefit. And that record's shape is consumed by
+        Get-PfbParameterCoverageGaps and the drift report's "nothing vanishes" invariant --
+        extending it risks a ripple into gap accounting unrelated to Fusion. This follows
+        Get-PfbSpecResponseShapes' precedent: an independent second view of the same
+        document, walking $Spec.paths itself.
+
+        Deliberately does NOT touch Add-PfbSchemaPropertyNodes. That recursive walker feeds
+        both Data/PfbCapabilityMap.json and Data/PfbResponseShapeMap.json and is where
+        issues #71/#82/#83 all land. Operation-level extensions have no business there.
+
+        NOT version-gated by design. A resource does not migrate between the fleet database
+        and an array, so last-seen-wins across spec versions is correct here in a way it is
+        not for component identity -- the 2.28 annotations describe 2.23-era endpoints
+        accurately.
+    .PARAMETER Spec
+        One parsed OpenAPI document (ConvertFrom-Json output).
+    .OUTPUTS
+        [PSCustomObject[]] sorted by Endpoint, one per operation:
+            Endpoint            "<METHOD> /<normalized-path>"
+            Method              HTTP method, upper-case
+            Path                normalized path
+            DomainsOverride     [string[]] declared domains; EMPTY ARRAY when absent,
+                                never $null
+            IsIncompleteGre     [bool]
+            BlocksRemoteExec    [bool]
+    #>
+    [CmdletBinding()]
+    [OutputType([PSCustomObject[]])]
+    param(
+        [Parameter(Mandatory)]
+        $Spec
+    )
+
+    $results = [System.Collections.Generic.List[object]]::new()
+    if (-not $Spec.paths) { return @() }
+
+    $overrideKey = 'x-pure-remote-execution-context-domains-override'
+    $incompleteKey = 'x-pure-incomplete-gre'
+    $blockKey = 'x-pure-block-remote-execution'
+
+    foreach ($rawPath in $Spec.paths.PSObject.Properties.Name) {
+        $pathItem = $Spec.paths.$rawPath
+        $normalizedPath = ConvertTo-PfbNormalizedPath -Path $rawPath
+
+        foreach ($methodName in $pathItem.PSObject.Properties.Name) {
+            if ($script:PfbHttpMethods -notcontains $methodName) { continue }
+            $op = $pathItem.$methodName
+            $opKeys = $op.PSObject.Properties.Name
+
+            # Empty array, not $null, when absent: the generator's scope decision tests
+            # .Count, and a $null would make "absent" and "declared empty" both crash or
+            # both look like zero depending on the call site.
+            $domains = @()
+            if (($opKeys -contains $overrideKey) -and $null -ne $op.$overrideKey) {
+                $domains = @($op.$overrideKey)
+            }
+
+            $upperMethod = $methodName.ToUpperInvariant()
+            $results.Add([PSCustomObject]@{
+                    Endpoint         = "$upperMethod $normalizedPath"
+                    Method           = $upperMethod
+                    Path             = $normalizedPath
+                    DomainsOverride  = $domains
+                    IsIncompleteGre  = [bool](($opKeys -contains $incompleteKey) -and $op.$incompleteKey)
+                    BlocksRemoteExec = [bool](($opKeys -contains $blockKey) -and $op.$blockKey)
+                })
+        }
+    }
+
+    return @($results | Sort-Object Endpoint)
+}

--- a/tools/lib/PfbSpecTools.ps1
+++ b/tools/lib/PfbSpecTools.ps1
@@ -885,9 +885,11 @@ function Get-PfbSpecContextScope {
             # Empty array, not $null, when absent: the generator's scope decision tests
             # .Count, and a $null would make "absent" and "declared empty" both crash or
             # both look like zero depending on the call site.
-            $domains = @()
+            # [string[]] rather than a bare @(): the .OUTPUTS contract promises string[], and
+            # a bare @() yields Object[]. Coercing here makes the declared type true.
+            $domains = [string[]]@()
             if (($opKeys -contains $overrideKey) -and $null -ne $op.$overrideKey) {
-                $domains = @($op.$overrideKey)
+                $domains = [string[]]@($op.$overrideKey)
             }
 
             $upperMethod = $methodName.ToUpperInvariant()


### PR DESCRIPTION
Phase 0 of the Fusion `context_names` work (#25, design spec rev 3 in #72). Prerequisites
only — **nothing in this PR injects a context or changes any request on the wire.** It
populates the data and centralises the contracts that Phase 1's injection path needs.

Closes the `contextScope` half of #25's Phase 0 scope. Sequencing agreed in
[#84](https://github.com/dmann000/fb-powershell/issues/84#issuecomment-5186733418).

## What shipped

18 files across 15 commits (3 docs, 10 code, 2 from the whole-branch review).

| Task | Deliverable |
|---|---|
| 1 | `Resolve-PfbParameterComponent` — the single runtime home of the three-step component-resolution contract (`Private/Resolve-PfbParameterComponent.ps1`, `Private/PfbContextConstants.ps1`) |
| 2 | `tools/lib` consumes that `Private/` resolver instead of inlining its own copy |
| 3 | `Get-PfbSpecContextScope` — reads the three `x-pure-*` remote-execution annotations |
| 4 | Per-endpoint `contextScope` emitted; capability map `schemaVersion` 1 → 2 |
| 5 | Drift guard on the curated `contextScope` table |
| 6 | `Connect-PfbArray` warns once when the array outruns the bundled capability map |
| 7 | Top-level `MemberName`/`FleetName` on `Get-PfbFleetMember` |

Five new test files, two modified.

### The regenerated artifact

```
SHA-256       2E59D07D49B70A7CE90CBA2C6D5C243A6FECA199B4CE7E1C800DFEC4AA56A875
schemaVersion 2      versions 29      endpoints 632
provenance    default 604 | unknown 19 | declared 5 | live-tested 4
scope         array 606   | unknown 19 | fleet 7
```

Both distributions sum to 632. The full cross-tab:

| scope | provenance | count |
|---|---|---|
| array | default | 604 |
| array | declared | 1 |
| array | live-tested | 1 |
| fleet | declared | 4 |
| fleet | live-tested | 3 |
| unknown | unknown | 19 |

**A `contextScope` of `unknown` is a designed degradation, not a gap.** It suppresses
validation and leaves today's behaviour intact, so Phase 1 degrades rather than breaks.
Adding an entry later is a generator-table edit plus a regenerate — deliberately cheap.

### Two things about the data worth not generalising

**The `/presets/workload` read/write asymmetry is intentional.** `GET` is `array`-scoped;
all four write verbs on the same path are `fleet`-scoped. Both sides are `declared`
provenance — curated deliberately, each individually evidenced. This is **not** a
"reads array, writes fleet" verb rule. That rule was proposed, tested against the wire,
and falsified in #73. It should not be reintroduced.

**Every `/fleets/*` endpoint takes `array`/`default`.** That is correct: scope describes
remote-execution context, not resource family, and fleet membership is array-local. The 7
fleet-scoped entries are the 4 `/presets/workload` writes plus the 3 `/topology-groups*`
reads.

## Review history

Two rounds. **Eight substantive issues found, all fixed and each mutation-verified.** No
correctness defect survives in shipped code and there is no 5.1 compatibility break.

Folded below rather than cut: the round-1 findings existed only in conversation context
that has since been compacted, so this PR body is now their only durable home.

<details>
<summary><b>Round 1 — five defects found during per-task review</b></summary>

None of these were caught by the original testing.

| # | Finding | Fixed in |
|---|---|---|
| 1 | Component keys resolved on `PSCustomObject` only. The generator builds `[ordered]@{}` in memory, and on an `IDictionary` `.PSObject.Properties.Name` returns the CLR surface (`Keys`, `Count`, …) — **not** the keys — so resolution silently missed every in-memory lookup | `b5bd095` |
| 2 | Four **wrong** resolver implementations survived mutation — the tests did not pin the contract. Killed by adding multi-key overrides (the real map has 40 such objects, 18 carrying `context_names`) and an `ids`/`ids_or_names` decoy | `b5bd095` |
| 3 | **Zero** last-seen-wins coverage. `contextScope` is assigned unconditionally per spec iteration while `minVersion`/`parameters`/`bodyProperties` use a first-sight guard three lines away. The fixture was a single spec version — precisely what cannot demonstrate non-version-gating | `4241778` |
| 4 | Fixture inverted reality on declared-vs-flagged precedence | `4241778` |
| 5 | The `total_item_count` sentinel was decorated into a nameless member, producing an object that *looks* like a fleet member whose name is `$null` — the exact silent-wrong-binding failure the decoration exists to prevent | `dd6041a` |

### Task 6's review changed the design

25 mutations, 21 killed. The question was whether an unguarded version parse in the warning
branch could break connecting. It could not — that line was a byte-for-byte replay of the
helper's own expression, so a `$true` return was itself proof the expression had succeeded.

But that safety rested on an invariant in a **different file**, with nothing at the call
site saying so. One mutation proved it fragile: making the helper's `catch` return `$true`
sent the call site throwing outside any `try`, and no connection was returned. Given the
asymmetry — the warning is worth little, a broken connect costs everything — the duplicate
parse was removed and the helper now returns the maximum via a `[ref]` out-param. That
mutation now degrades to a spurious warning.

Three survivors were genuine test gaps, all closed: a swapped-version warning
(`"running REST 2.28 … covers through REST 2.29"` — backwards and actively misleading)
passed all 11 tests because each version was only asserted to appear *somewhere*; an
excluded property could be added to `$defaultProps` undetected; and a `Find-Module` source
grep was brittle in exactly the way it had been claimed strong — it trips on a harmless
comment and missed 3 of the 5 files in the call graph. Replaced with an AST walk over
invoked command names.

</details>

<details>
<summary><b>Round 2 — whole-branch review across all 13 commits (three findings)</b></summary>

Three gaps, all fixed in `6ae04e8` and `4f07080`:

- **A test was withholding 9 assertions from Windows PowerShell 5.1 for no reason of its
  own.** `Tests/PfbSpecTools.ContextScope.Tests.ps1`'s synthetic `Describe` carried an
  edition skip, but `Get-PfbSpecContextScope` is a pure `PSObject` walk with no pwsh-7
  dependency — the only 5.1 blocker was the fixtures' own `ConvertFrom-Json -Depth 32`,
  and those fixtures are four levels deep. Dropped `-Depth`, removed the skip; the block
  now runs on both editions. The sibling `Describe` keeps its guard, which is genuine
  (the real fb2.28 spec does need `-Depth 64`), and now states why. This matters because
  on 5.1 the file reported `0 passed` for that block — indistinguishable from health.
- **One more surviving mutation, now killed.** `IsIncompleteGre`/`BlocksRemoteExec` test
  key presence *and* value, but all 304 occurrences of those extensions across the 29
  cached specs are literal `true`, so a presence-only implementation passed everything.
  An endpoint upstream deliberately un-flagged would have been forced to
  `unknown`/`unknown` silently. Now pinned, and the mutation fails on both editions.
- **`tools/README.md`, the tracked contract doc for the map's shape, was stale.** It did
  not mention `contextScope` or `schemaVersion 2`, and its parameter-component resolution
  prose was the one remaining copy of that contract not pointing at
  `Private/Resolve-PfbParameterComponent.ps1` — the prose form of exactly the drift #74
  exists to close.

Five mutations were run with hash-verified application and restore plus dual-edition
parse checks. Four were killed by existing tests: first-sight-wins substituted for
last-seen-wins on `contextScope`; min-scanned substituted for max in the staleness helper;
and the `total_item_count` sentinel guard neutralised. The three load-bearing behaviours
are each genuinely defended by a test that dies when you break it.

</details>

## Verification

**Live, against FB-A (REST 2.26 / Purity//FB 4.8.2).** 7 ledger rows for
`Get-PfbFleetMember`, all at `feat/fusion-context-phase-0@33fbd32`, 185–1217ms.

- Unfiltered: 3 members, stable over 3 repeats. Decoration correct on all rows; nested
  `member`/`fleet` preserved.
- `-MemberName 'FB-A'` → **exactly 1 row**, decorated, 208ms. Never → 0.
- Bogus name → `HTTP 400 "Fleet member does not exist."` A *specific* rejection is
  positive evidence the key was parsed and acted on; an empty set would prove nothing.
- **Control against `main`:** identical filter counts, and `PropertyNotFoundException` on
  `MemberName` for every row. Property absent before, present after, same array, same
  call. This is the strongest single piece of evidence for Task 7.

Task 6 negative case: connect produced **0 warnings**, and the silence is provably correct
rather than accidental — the shipped map's max is 2.28, so 2.26 is in range. Helper
verdicts against the real artifact: `2.26`→False, `2.28`→False (exact match must not warn),
`2.29`→True/`2.28`, `3.0`→True/`2.28`, unparseable→False with `HighestScanned` untouched.

**Tests.** All seven of the branch's test files, scoped run, both editions:
pwsh 7 **108 passed / 0 failed / 0 skipped**; Windows PowerShell 5.1
**48 / 0 / 60**. `Container ok` on both. (The 60 skips on 5.1 are the `tools/Build-*`
suites, which carry a deliberate edition guard.)

**One pre-existing failure you will hit locally, which this branch does not cause.**
With real specs present, `Tests/Build-PfbApiDriftReport.Tests.ps1` fails one assertion on
pwsh 7 — the "nothing vanishes" invariant, on
`POST /file-system-replica-links|query|remote_default_exports`. This was verified as
pre-existing by exporting the merge base with `git archive` into a clean tree with the same
29 specs and reproducing the identical 1757-vs-1756 result. Structurally confirmed too:
parsing both capability maps and comparing `endpoints` with `contextScope` stripped gives
byte-identical output. `Reports/PfbApiDriftReport.json` on `main` is one gap stale and has
been since before this branch — it is #84 PR 1's to fix, and is deliberately untouched here
(see limit 6).

## Limits — please read these before reviewing the artifact

Stated plainly rather than buried, because overstating any of them is the specific way
this PR could mislead.

1. **The drift guard gives ZERO CI protection.** `tools/specs/` is gitignored, and
   `cross-platform-tests.yml` — the only PR-triggered workflow — never fetches it, so every
   real-artifact assertion skips. Locally "7 passed" and in CI "7 skipped" look identical in
   a summary line. It is a maintainer gate only.
2. **The artifact diff review is the actual verification for `contextScope`**, not the live
   check. Do not overstate the live item.
3. **Task 6's positive case is not lab-reachable.** FB-A caps at 2.26, below the 2.29 needed
   to fire the warning. Verified at helper level against the real map, not on the wire.
4. **Task 6 has no ledger row.** Hand-connect plus helper probe. Sound, but weaker *in kind*
   than Task 7's evidence, not merely narrower.
5. **The `total_item_count` guard is unreachable from this cmdlet** — `Get-PfbFleetMember`
   has no `TotalOnly` parameter. Purely defensive, resting on its unit test.
6. **`Reports/` drift-report delta is pre-existing on `main`**, established by reverting
   `tools/lib/PfbContextRuleTools.ps1` to HEAD and re-running (identical 64/1), and confirmed
   independently. `contextScope` provably does not reach drift accounting: reports generated
   from the before- and after-maps are byte-identical, `contextScope` string count 0 in both.
7. **3 of the 4 curated `contextScope` entries are not live-checkable** — no topology-group
   cmdlets exist on this branch.

**Restating limit 2, because it is the one that matters for reviewing this PR:** the
`Data/PfbCapabilityMap.json` diff *is* the verification for `contextScope`. There is no CI
gate comparing the committed artifact to what the generator produces (limit 1), and the live
check covers Task 7, not the map. Reading that diff is the review.

## Sequencing — this is the first of two consecutive map regenerations

`Data/PfbCapabilityMap.json` will be regenerated **again**, immediately, by #84's PR 1
(the #71/#82 schema-walk fix). That is deliberate and agreed in
[#84](https://github.com/dmann000/fb-powershell/issues/84#issuecomment-5186733418) — not
churn, and not someone undoing this work.

The order is Phase 0 first because its verification is the artifact diff (limit 2), which
only holds against an unmoved base. PR 1's verification is unit fixtures plus a diff
characterised in advance, which survives being re-derived on a moved base.

`schemaVersion` 1 → 2 is claimed here. PR 1 does not contest it; #83 will increment from
whatever it finds.

## Deliberately not in this PR

- **No `Reports/` changes, and no claim to fix the 64/1 drift-report red.** That belongs to
  PR 1, which owns the whole `Reports/` diff.
- **No version bump, no `CHANGELOG.md`.** Maintainer's call.
- **No fix for the CI gap in limit 1** — deferred until after Phase 0.
- **Nothing reads `contextScope` at runtime yet.** Kind-vs-scope validation and scope-aware
  error messages are Phase 1, which is the field's first consumer.

<details>
<summary><b>What this unblocks</b></summary>

| Phase | Work |
|---|---|
| **1** | The `PfbContext` object, connection context state, and the injection path — needs resolved component names to call the cardinality predicate at all |
| **1** | Kind-vs-scope validation and scope-aware error messages — the first runtime consumer of `contextScope` |
| **1** | `Set-PfbContext` pipeline binding — depends on Task 7's top-level `MemberName`/`FleetName`, because `ValueFromPipelineByPropertyName` matches top-level names only |
| **2** | `allow_errors` surfacing and the HTTP 207 branch — will need the same component resolution Task 1 centralised |
| **#38** | Topology-group and fleet/realm cmdlets — **not** blocked on this; measured, those writes succeed with no `context_names` from the coordinator |

</details>
