### PR TITLE
fix(admin): stop the API-token cmdlets sending dead query keys

### DIFF
--- a/Private/Assert-PfbAdminNameNotCoerced.ps1
+++ b/Private/Assert-PfbAdminNameNotCoerced.ps1
@@ -8,9 +8,10 @@ function Assert-PfbAdminNameNotCoerced {
 
         A Get-PfbApiToken row exposes only `admin`, `api_token` and `context` at the top
         level -- the administrator's name is nested at .admin.name -- so piping one into
-        New-PfbApiToken or Remove-PfbApiToken matches neither pass 1 nor pass 2, and the
-        entire PSCustomObject is ToString()-ed into [string]$Name at pass 3. The result is
-        a garbage filter such as
+        Get-PfbApiToken, New-PfbApiToken or Remove-PfbApiToken matches neither pass 1 nor
+        pass 2, and the entire PSCustomObject is ToString()-ed into $Name at pass 3 (into
+        the single element of [string[]]$Name on Get-). The result is a garbage filter such
+        as
 
             admin_names=@{admin=; api_token=}
 
@@ -19,6 +20,11 @@ function Assert-PfbAdminNameNotCoerced {
 
         Plain strings ('ops-admin','svc' | Remove-PfbApiToken) are unaffected, as is
         binding by property name from a Get-PfbAdmin object.
+
+        Called by all three /admins/api-tokens cmdlets. New- and Remove- take a scalar
+        [string]$Name and call it once per pipeline item; Get- takes [string[]]$Name and
+        calls it per element. -Value therefore accepts either a scalar or a collection and
+        checks each member.
 
         Deliberately called imperatively from each cmdlet's process block rather than wired
         as [ValidateScript({ ... })]. That was tried and reverted under issue #64: a

--- a/Private/Assert-PfbAdminNameNotCoerced.ps1
+++ b/Private/Assert-PfbAdminNameNotCoerced.ps1
@@ -1,0 +1,45 @@
+function Assert-PfbAdminNameNotCoerced {
+    <#
+    .SYNOPSIS
+        Reject a -Name value that is the ToString() of a whole piped object.
+    .DESCRIPTION
+        PowerShell resolves pipeline binding in three passes: ByValue-without-coercion,
+        then ByPropertyName-without-coercion, then ByValue-WITH-coercion.
+
+        A Get-PfbApiToken row exposes only `admin`, `api_token` and `context` at the top
+        level -- the administrator's name is nested at .admin.name -- so piping one into
+        New-PfbApiToken or Remove-PfbApiToken matches neither pass 1 nor pass 2, and the
+        entire PSCustomObject is ToString()-ed into [string]$Name at pass 3. The result is
+        a garbage filter such as
+
+            admin_names=@{admin=; api_token=}
+
+        On Remove-PfbApiToken that reaches a DELETE with ConfirmImpact High, which is why
+        this is worth a module-level failure rather than a confusing server-side one.
+
+        Plain strings ('ops-admin','svc' | Remove-PfbApiToken) are unaffected, as is
+        binding by property name from a Get-PfbAdmin object.
+
+        Deliberately called imperatively from each cmdlet's process block rather than wired
+        as [ValidateScript({ ... })]. That was tried and reverted under issue #64: a
+        ValidateScript failure on a PIPELINE-bound argument is a NON-terminating per-item
+        binding error, so the cmdlet continues and still issues the request -- reinstating
+        the silent-misbinding class this guard exists to remove. The imperative throw
+        terminates the pipeline, which is the required behaviour.
+
+        Unlike Assert-PfbRemoteNameNotCoerced this returns NOTHING on success. That helper
+        ends with `return $true` and its callers invoke it bare, so it leaks a stray True
+        into each cmdlet's success stream. Do not reintroduce that here.
+    #>
+    param([Parameter(Mandatory)] [object]$Value)
+
+    foreach ($v in @($Value)) {
+        if ($v -is [string] -and $v.Contains('@{')) {
+            throw ("-Name received a stringified object ('{0}') instead of an administrator name. " -f $v) +
+                  'Get-PfbApiToken output has no top-level name property -- the administrator name is ' +
+                  'nested at .admin.name -- so a piped API-token object is coerced whole into -Name. ' +
+                  'Pipe the name instead, e.g. Get-PfbApiToken | ForEach-Object { $_.admin.name } | ' +
+                  'Remove-PfbApiToken, or pass -Name explicitly.'
+        }
+    }
+}

--- a/Public/Admin/Get-PfbApiToken.ps1
+++ b/Public/Admin/Get-PfbApiToken.ps1
@@ -19,11 +19,12 @@ function Get-PfbApiToken {
         One or more administrator account names whose API tokens to retrieve. Sent as the
         `admin_names` query parameter. Also accepts the alias -AdminNames. Accepts pipeline input.
 
-        -Name is optional, so an EMPTY array is a legal "no filter" value: -Name @() (or a
-        variable that happens to be empty, or a pipeline that produced nothing) emits no
-        `admin_names` key and therefore returns EVERY administrator's row, exactly as a bare
-        Get-PfbApiToken does. If a caller builds the name list dynamically and an empty list
-        should mean "nothing", test for that before calling.
+        -Name is optional, so any value that is falsy in PowerShell is a legal "no filter":
+        -Name @(), -Name '', a variable that happens to be empty, or a pipeline that produced
+        nothing. All of them emit no `admin_names` key and therefore return EVERY
+        administrator's row, exactly as a bare Get-PfbApiToken does. If a caller builds the
+        name list dynamically and an empty list should mean "nothing", test for that before
+        calling.
 
         A piped Get-PfbApiToken row is rejected rather than silently misbound: the object has
         no top-level name property (the administrator name is nested at .admin.name), so it

--- a/Public/Admin/Get-PfbApiToken.ps1
+++ b/Public/Admin/Get-PfbApiToken.ps1
@@ -18,6 +18,16 @@ function Get-PfbApiToken {
     .PARAMETER Name
         One or more administrator account names whose API tokens to retrieve. Sent as the
         `admin_names` query parameter. Also accepts the alias -AdminNames. Accepts pipeline input.
+
+        -Name is optional, so an EMPTY array is a legal "no filter" value: -Name @() (or a
+        variable that happens to be empty, or a pipeline that produced nothing) emits no
+        `admin_names` key and therefore returns EVERY administrator's row, exactly as a bare
+        Get-PfbApiToken does. If a caller builds the name list dynamically and an empty list
+        should mean "nothing", test for that before calling.
+
+        A piped Get-PfbApiToken row is rejected rather than silently misbound: the object has
+        no top-level name property (the administrator name is nested at .admin.name), so it
+        would otherwise be ToString()-ed whole into -Name. Pipe $_.admin.name instead.
     .PARAMETER Id
         One or more administrator account IDs whose API tokens to retrieve. Sent as the
         `admin_ids` query parameter. Also accepts the alias -AdminIds.
@@ -77,7 +87,7 @@ function Get-PfbApiToken {
         $allIds = [System.Collections.Generic.List[string]]::new()
     }
     process {
-        if ($Name) { foreach ($n in $Name) { $allNames.Add($n) } }
+        if ($Name) { foreach ($n in $Name) { Assert-PfbAdminNameNotCoerced -Value $n; $allNames.Add($n) } }
         if ($Id)   { foreach ($i in $Id)   { $allIds.Add($i) } }
     }
     end {

--- a/Public/Admin/Get-PfbApiToken.ps1
+++ b/Public/Admin/Get-PfbApiToken.ps1
@@ -4,28 +4,51 @@ function Get-PfbApiToken {
         Retrieves FlashBlade administrator API tokens.
     .DESCRIPTION
         The Get-PfbApiToken cmdlet returns one or more administrator API tokens from the connected
-        Pure Storage FlashBlade. Results can be filtered by name, ID, or a server-side filter
+        Everpure FlashBlade. Results can be filtered by name, ID, or a server-side filter
         expression. Supports pipeline input for batch lookups and automatic pagination.
+
+        GET /admins/api-tokens selects with admin_names / admin_ids and accepts no generic
+        names / ids key in any spec version. Because FlashBlade silently drops an undeclared
+        query parameter, this cmdlet's pre-#99 -Name returned EVERY administrator's row rather
+        than the one asked for, with no error to indicate it.
+
+        The selector cannot go through Add-PfbCommonQueryParams, which hardcodes the generic
+        names / ids keys for the endpoints that do accept them. The helper is still used for
+        -Filter, -Sort and -Limit; the endpoint-specific keys are set inline afterwards.
     .PARAMETER Name
-        One or more administrator account names whose API tokens to retrieve. Accepts pipeline input.
+        One or more administrator account names whose API tokens to retrieve. Sent as the
+        `admin_names` query parameter. Also accepts the alias -AdminNames. Accepts pipeline input.
     .PARAMETER Id
-        One or more administrator account IDs whose API tokens to retrieve.
+        One or more administrator account IDs whose API tokens to retrieve. Sent as the
+        `admin_ids` query parameter. Also accepts the alias -AdminIds.
     .PARAMETER Filter
         A server-side filter expression to narrow results (e.g., "name='pureuser'").
     .PARAMETER Sort
         Sort field and direction (e.g., "name" or "name-").
     .PARAMETER Limit
         Maximum number of entries to return.
+    .PARAMETER ExposeApiToken
+        Return the calling administrator's API token value in full instead of masked.
+
+        Token values are masked by default. This switch un-masks ONLY the token belonging to
+        the administrator the current session is authenticated as; every other administrator's
+        token stays masked whether it is set or not. Verified against REST 2.26.
     .PARAMETER Array
         The FlashBlade connection object. If not specified, the default connection is used.
     .EXAMPLE
         Get-PfbApiToken
 
-        Retrieves all administrator API tokens from the connected FlashBlade.
+        Retrieves all administrator API tokens from the connected FlashBlade, with token
+        values masked.
     .EXAMPLE
         Get-PfbApiToken -Name "pureuser"
 
         Retrieves the API token for the administrator account named "pureuser".
+    .EXAMPLE
+        Get-PfbApiToken -Name "pureuser" -ExposeApiToken
+
+        Retrieves "pureuser"'s API token with its value un-masked. This returns a real
+        credential only when the session is authenticated as that same administrator.
     .EXAMPLE
         Get-PfbApiToken -Filter "name='ops-admin'" -Limit 5
 
@@ -34,11 +57,17 @@ function Get-PfbApiToken {
     [CmdletBinding(DefaultParameterSetName = 'List')]
     param(
         [Parameter(ParameterSetName = 'ByName', ValueFromPipeline, ValueFromPipelineByPropertyName)]
+        [Alias('AdminNames')]
         [string[]]$Name,
-        [Parameter(ParameterSetName = 'ById')] [string[]]$Id,
+
+        [Parameter(ParameterSetName = 'ById')]
+        [Alias('AdminIds')]
+        [string[]]$Id,
+
         [Parameter()] [string]$Filter,
         [Parameter()] [string]$Sort,
         [Parameter()] [int]$Limit,
+        [Parameter()] [switch]$ExposeApiToken,
         [Parameter()] [PSCustomObject]$Array
     )
 
@@ -53,7 +82,15 @@ function Get-PfbApiToken {
     }
     end {
         $queryParams = @{}
-        Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
+
+        # -Names/-Ids are deliberately NOT passed: the helper would emit names=/ids=, which
+        # this endpoint does not accept and silently ignores. See .DESCRIPTION.
+        Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters
+
+        if ($allNames) { $queryParams['admin_names'] = $allNames -join ',' }
+        if ($allIds)   { $queryParams['admin_ids']   = $allIds   -join ',' }
+        if ($ExposeApiToken) { $queryParams['expose_api_token'] = 'true' }
+
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'admins/api-tokens' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Admin/New-PfbApiToken.ps1
+++ b/Public/Admin/New-PfbApiToken.ps1
@@ -13,9 +13,10 @@ function New-PfbApiToken {
         A selector is mandatory. An unfiltered POST would arrive with no target, and what the
         array does then is not established -- most likely it falls back to the authenticated
         administrator, rotating the caller's own token and invalidating any stored copy of it.
-        Rather than depend on that, -Name and -Id are Mandatory within their parameter sets, so
-        the parameter binder rejects a call supplying neither (no parameter set resolves) or
-        supplying an empty string, before the process block runs. The process block also
+        Rather than depend on that, the parameter binder rejects both bad calls before the
+        process block runs. A call supplying neither selector cannot resolve a parameter set
+        at all, because there are two sets and no DefaultParameterSetName. A call supplying an
+        empty string is rejected because -Name and -Id are Mandatory. The process block also
         refuses to issue a request whose query carries neither key, but that check is a
         defensive backstop that no input reaches today, not a second live layer. To create
         a token for the current session's own account, name that account explicitly. To rotate
@@ -91,11 +92,13 @@ function New-PfbApiToken {
         if ($Id)   { $queryParams['admin_ids']   = $Id }
         if ($PSBoundParameters.ContainsKey('Timeout')) { $queryParams['timeout'] = $Timeout }
 
-        # Unreachable today: Mandatory on both sets means a selectorless call fails with
-        # AmbiguousParameterSet and an empty-string selector fails with EmptyStringNotAllowed,
-        # both at binding time. Kept deliberately as a backstop -- adding a
-        # DefaultParameterSetName or relaxing a Mandatory flag would silently re-open #99.
-        # Do not "simplify" it away.
+        # Unreachable today, for two different reasons. A selectorless call cannot resolve a
+        # parameter set -- two sets, no DefaultParameterSetName, no set-unique bound parameter
+        # -- so it fails with AmbiguousParameterSet whether or not Mandatory is present. An
+        # empty-string selector fails with EmptyStringNotAllowed, and that one IS Mandatory's
+        # doing. Both fire at binding time, before process. Kept deliberately as a backstop --
+        # adding a DefaultParameterSetName or relaxing a Mandatory flag would silently re-open
+        # #99. Do not "simplify" it away.
         if (-not $queryParams.ContainsKey('admin_names') -and -not $queryParams.ContainsKey('admin_ids')) {
             throw 'New-PfbApiToken requires -Name or -Id. An unfiltered POST ' +
                   '/admins/api-tokens has no explicit target and would act on the ' +

--- a/Public/Admin/New-PfbApiToken.ps1
+++ b/Public/Admin/New-PfbApiToken.ps1
@@ -8,10 +8,18 @@ function New-PfbApiToken {
         ShouldProcess for confirmation prompts.
 
         Note that `POST /admins/api-tokens` takes no request body at all -- every field this
-        endpoint accepts is a query parameter.
+        endpoint accepts is a query parameter, and this cmdlet sends none.
+
+        A selector is mandatory. An unfiltered POST would arrive with no target, and what the
+        array does then is not established -- most likely it falls back to the authenticated
+        administrator, rotating the caller's own token and invalidating any stored copy of it.
+        Rather than depend on that, -Name and -Id are Mandatory within their parameter sets and
+        the process block refuses to issue a request whose query carries neither key. To create
+        a token for the current session's own account, name that account explicitly. To rotate
+        several administrators' tokens, pipe their names in.
     .PARAMETER Name
         The name of the administrator account for which to create an API token. Sent as the
-        `admin_names` query parameter. Also accepts the alias -AdminNames.
+        `admin_names` query parameter. Also accepts the alias -AdminNames. Accepts pipeline input.
     .PARAMETER Id
         The ID of the administrator account for which to create an API token. Sent as the
         `admin_ids` query parameter. Also accepts the alias -AdminIds.
@@ -19,8 +27,8 @@ function New-PfbApiToken {
         The duration of API token validity, in milliseconds.
     .PARAMETER Attributes
         Retained for backward compatibility only. `POST /admins/api-tokens` accepts no request
-        body, so nothing supplied here is sent to the array. Use -Timeout to set the token's
-        validity period.
+        body, so nothing supplied here is sent to the array and a warning is emitted. Use
+        -Timeout to set the token's validity period.
     .PARAMETER Array
         The FlashBlade connection object. If not specified, the default connection is used.
     .EXAMPLE
@@ -35,14 +43,18 @@ function New-PfbApiToken {
         New-PfbApiToken -Id "10314f42-020d-7080-8013-000ddt400012"
 
         Creates a new API token for the administrator identified by ID.
+    .EXAMPLE
+        'ops-admin', 'svc-admin' | New-PfbApiToken -Confirm:$false
+
+        Rotates the API tokens of several administrators, issuing one POST per name.
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
     param(
-        [Parameter(ParameterSetName = 'ByName', ValueFromPipelineByPropertyName)]
+        [Parameter(ParameterSetName = 'ByName', Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [Alias('AdminNames')]
         [string]$Name,
 
-        [Parameter(ParameterSetName = 'ById')]
+        [Parameter(ParameterSetName = 'ById', Mandatory)]
         [Alias('AdminIds')]
         [string]$Id,
 
@@ -56,6 +68,8 @@ function New-PfbApiToken {
     }
 
     process {
+        if ($Name) { Assert-PfbAdminNameNotCoerced -Value $Name }
+
         # POST /admins/api-tokens accepts admin_names/admin_ids, NOT names/ids. The cmdlet
         # previously sent names/ids, which the array silently ignored, so -Name and -Id had
         # no effect at all.
@@ -64,11 +78,23 @@ function New-PfbApiToken {
         if ($Id)   { $queryParams['admin_ids']   = $Id }
         if ($PSBoundParameters.ContainsKey('Timeout')) { $queryParams['timeout'] = $Timeout }
 
+        if (-not $queryParams.ContainsKey('admin_names') -and -not $queryParams.ContainsKey('admin_ids')) {
+            throw 'New-PfbApiToken requires -Name or -Id. An unfiltered POST ' +
+                  '/admins/api-tokens has no explicit target and would act on the ' +
+                  'authenticated administrator.'
+        }
+
+        if ($PSBoundParameters.ContainsKey('Attributes')) {
+            Write-Warning ('-Attributes is accepted for backward compatibility only. ' +
+                           'POST /admins/api-tokens declares no request body, so nothing ' +
+                           "supplied here is sent to the array. Use -Timeout to set the " +
+                           "token's validity period.")
+        }
+
         $target = if ($Name) { $Name } else { $Id }
-        $body = if ($Attributes) { $Attributes } else { @{} }
 
         if ($PSCmdlet.ShouldProcess($target, 'Create API token')) {
-            Invoke-PfbApiRequest -Array $Array -Method POST -Endpoint 'admins/api-tokens' -Body $body -QueryParams $queryParams
+            Invoke-PfbApiRequest -Array $Array -Method POST -Endpoint 'admins/api-tokens' -QueryParams $queryParams
         }
     }
 }

--- a/Public/Admin/New-PfbApiToken.ps1
+++ b/Public/Admin/New-PfbApiToken.ps1
@@ -65,6 +65,16 @@ function New-PfbApiToken {
 
     begin {
         Assert-PfbConnection -Array ([ref]$Array)
+
+        # -Attributes is not a pipeline parameter -- it binds once for the whole invocation,
+        # so the warning belongs in begin. Emitting it from process would repeat it once per
+        # piped name, in exactly the bulk-rotation flow ValueFromPipeline exists to enable.
+        if ($PSBoundParameters.ContainsKey('Attributes')) {
+            Write-Warning ('-Attributes is accepted for backward compatibility only. ' +
+                           'POST /admins/api-tokens declares no request body, so nothing ' +
+                           "supplied here is sent to the array. Use -Timeout to set the " +
+                           "token's validity period.")
+        }
     }
 
     process {
@@ -82,13 +92,6 @@ function New-PfbApiToken {
             throw 'New-PfbApiToken requires -Name or -Id. An unfiltered POST ' +
                   '/admins/api-tokens has no explicit target and would act on the ' +
                   'authenticated administrator.'
-        }
-
-        if ($PSBoundParameters.ContainsKey('Attributes')) {
-            Write-Warning ('-Attributes is accepted for backward compatibility only. ' +
-                           'POST /admins/api-tokens declares no request body, so nothing ' +
-                           "supplied here is sent to the array. Use -Timeout to set the " +
-                           "token's validity period.")
         }
 
         $target = if ($Name) { $Name } else { $Id }

--- a/Public/Admin/New-PfbApiToken.ps1
+++ b/Public/Admin/New-PfbApiToken.ps1
@@ -13,8 +13,11 @@ function New-PfbApiToken {
         A selector is mandatory. An unfiltered POST would arrive with no target, and what the
         array does then is not established -- most likely it falls back to the authenticated
         administrator, rotating the caller's own token and invalidating any stored copy of it.
-        Rather than depend on that, -Name and -Id are Mandatory within their parameter sets and
-        the process block refuses to issue a request whose query carries neither key. To create
+        Rather than depend on that, -Name and -Id are Mandatory within their parameter sets, so
+        the parameter binder rejects a call supplying neither (no parameter set resolves) or
+        supplying an empty string, before the process block runs. The process block also
+        refuses to issue a request whose query carries neither key, but that check is a
+        defensive backstop that no input reaches today, not a second live layer. To create
         a token for the current session's own account, name that account explicitly. To rotate
         several administrators' tokens, pipe their names in.
     .PARAMETER Name
@@ -88,6 +91,11 @@ function New-PfbApiToken {
         if ($Id)   { $queryParams['admin_ids']   = $Id }
         if ($PSBoundParameters.ContainsKey('Timeout')) { $queryParams['timeout'] = $Timeout }
 
+        # Unreachable today: Mandatory on both sets means a selectorless call fails with
+        # AmbiguousParameterSet and an empty-string selector fails with EmptyStringNotAllowed,
+        # both at binding time. Kept deliberately as a backstop -- adding a
+        # DefaultParameterSetName or relaxing a Mandatory flag would silently re-open #99.
+        # Do not "simplify" it away.
         if (-not $queryParams.ContainsKey('admin_names') -and -not $queryParams.ContainsKey('admin_ids')) {
             throw 'New-PfbApiToken requires -Name or -Id. An unfiltered POST ' +
                   '/admins/api-tokens has no explicit target and would act on the ' +

--- a/Public/Admin/Remove-PfbApiToken.ps1
+++ b/Public/Admin/Remove-PfbApiToken.ps1
@@ -4,12 +4,25 @@ function Remove-PfbApiToken {
         Removes an API token from a FlashBlade administrator account.
     .DESCRIPTION
         The Remove-PfbApiToken cmdlet deletes the API token for a specified administrator account
-        on the connected Pure Storage FlashBlade. The administrator can be identified by name or
+        on the connected Everpure FlashBlade. The administrator can be identified by name or
         ID. This is a destructive operation and requires confirmation by default.
+
+        DELETE /admins/api-tokens selects its target with admin_names / admin_ids. It accepts
+        no generic names / ids key in any spec version, and FlashBlade silently drops an
+        undeclared query parameter -- so a DELETE sent with names= arrives with no target at
+        all, and the endpoint then falls back to the AUTHENTICATED administrator. Before
+        issue #99 this cmdlet sent names/ids, so -Name pointed at another admin destroyed the
+        CALLING session's own token and left the named admin's token untouched.
+
+        A selector is therefore mandatory, and enforced twice over: -Name and -Id are
+        Mandatory within their parameter sets, and the process block refuses to issue a
+        request whose query carries neither key.
     .PARAMETER Name
-        The name of the administrator account whose API token to remove. Accepts pipeline input.
+        The name of the administrator account whose API token to remove. Sent as the
+        `admin_names` query parameter. Also accepts the alias -AdminNames. Accepts pipeline input.
     .PARAMETER Id
-        The ID of the administrator account whose API token to remove.
+        The ID of the administrator account whose API token to remove. Sent as the
+        `admin_ids` query parameter. Also accepts the alias -AdminIds.
     .PARAMETER Array
         The FlashBlade connection object. If not specified, the default connection is used.
     .EXAMPLE
@@ -24,13 +37,21 @@ function Remove-PfbApiToken {
         "ops-admin" | Remove-PfbApiToken
 
         Removes the API token for the administrator named "ops-admin" via pipeline input.
+    .EXAMPLE
+        Get-PfbApiToken | ForEach-Object { $_.admin.name } | Remove-PfbApiToken
+
+        Removes every administrator's API token. Note the ForEach-Object: an API-token object
+        exposes the administrator name at .admin.name, not as a top-level property, so piping
+        Get-PfbApiToken output directly is rejected rather than silently misbound.
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
     param(
         [Parameter(ParameterSetName = 'ByName', Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)]
+        [Alias('AdminNames')]
         [string]$Name,
 
         [Parameter(ParameterSetName = 'ById', Mandatory)]
+        [Alias('AdminIds')]
         [string]$Id,
 
         [Parameter()] [PSCustomObject]$Array
@@ -41,10 +62,19 @@ function Remove-PfbApiToken {
     }
 
     process {
+        if ($Name) { Assert-PfbAdminNameNotCoerced -Value $Name }
+
         $target = if ($Name) { $Name } else { $Id }
+
+        # admin_names/admin_ids, NOT names/ids -- see the .DESCRIPTION note above.
         $queryParams = @{}
-        if ($Name) { $queryParams['names'] = $Name }
-        if ($Id)   { $queryParams['ids']   = $Id }
+        if ($Name) { $queryParams['admin_names'] = $Name }
+        if ($Id)   { $queryParams['admin_ids']   = $Id }
+
+        if (-not $queryParams.ContainsKey('admin_names') -and -not $queryParams.ContainsKey('admin_ids')) {
+            throw 'Remove-PfbApiToken requires -Name or -Id. An unfiltered DELETE ' +
+                  "/admins/api-tokens destroys the CALLING session's own API token."
+        }
 
         if ($PSCmdlet.ShouldProcess($target, 'Remove API token')) {
             Invoke-PfbApiRequest -Array $Array -Method DELETE -Endpoint 'admins/api-tokens' -QueryParams $queryParams

--- a/Public/Admin/Remove-PfbApiToken.ps1
+++ b/Public/Admin/Remove-PfbApiToken.ps1
@@ -14,9 +14,12 @@ function Remove-PfbApiToken {
         issue #99 this cmdlet sent names/ids, so -Name pointed at another admin destroyed the
         CALLING session's own token and left the named admin's token untouched.
 
-        A selector is therefore mandatory, and enforced twice over: -Name and -Id are
-        Mandatory within their parameter sets, and the process block refuses to issue a
-        request whose query carries neither key.
+        A selector is therefore mandatory. It is enforced by the parameter binder: -Name and
+        -Id are Mandatory within their parameter sets, so a call supplying neither fails to
+        resolve a parameter set and a call supplying an empty string is rejected as an empty
+        argument -- in both cases before the process block runs. The process block also
+        refuses to issue a request whose query carries neither key, but that check is a
+        defensive backstop that no input reaches today, not a second live layer.
     .PARAMETER Name
         The name of the administrator account whose API token to remove. Sent as the
         `admin_names` query parameter. Also accepts the alias -AdminNames. Accepts pipeline input.
@@ -71,6 +74,11 @@ function Remove-PfbApiToken {
         if ($Name) { $queryParams['admin_names'] = $Name }
         if ($Id)   { $queryParams['admin_ids']   = $Id }
 
+        # Unreachable today: Mandatory on both sets means a selectorless call fails with
+        # AmbiguousParameterSet and an empty-string selector fails with EmptyStringNotAllowed,
+        # both at binding time. Kept deliberately as a backstop -- adding a
+        # DefaultParameterSetName or relaxing a Mandatory flag would silently re-open #99.
+        # Do not "simplify" it away.
         if (-not $queryParams.ContainsKey('admin_names') -and -not $queryParams.ContainsKey('admin_ids')) {
             throw 'Remove-PfbApiToken requires -Name or -Id. An unfiltered DELETE ' +
                   "/admins/api-tokens destroys the CALLING session's own API token."

--- a/Public/Admin/Remove-PfbApiToken.ps1
+++ b/Public/Admin/Remove-PfbApiToken.ps1
@@ -14,10 +14,11 @@ function Remove-PfbApiToken {
         issue #99 this cmdlet sent names/ids, so -Name pointed at another admin destroyed the
         CALLING session's own token and left the named admin's token untouched.
 
-        A selector is therefore mandatory. It is enforced by the parameter binder: -Name and
-        -Id are Mandatory within their parameter sets, so a call supplying neither fails to
-        resolve a parameter set and a call supplying an empty string is rejected as an empty
-        argument -- in both cases before the process block runs. The process block also
+        A selector is therefore mandatory, and the parameter binder enforces it before the
+        process block runs. A call supplying neither selector cannot resolve a parameter set,
+        because there are two sets and no DefaultParameterSetName. A call supplying an empty
+        string is rejected as an empty argument, because -Name and -Id are Mandatory within
+        their sets. The process block also
         refuses to issue a request whose query carries neither key, but that check is a
         defensive backstop that no input reaches today, not a second live layer.
     .PARAMETER Name
@@ -74,11 +75,13 @@ function Remove-PfbApiToken {
         if ($Name) { $queryParams['admin_names'] = $Name }
         if ($Id)   { $queryParams['admin_ids']   = $Id }
 
-        # Unreachable today: Mandatory on both sets means a selectorless call fails with
-        # AmbiguousParameterSet and an empty-string selector fails with EmptyStringNotAllowed,
-        # both at binding time. Kept deliberately as a backstop -- adding a
-        # DefaultParameterSetName or relaxing a Mandatory flag would silently re-open #99.
-        # Do not "simplify" it away.
+        # Unreachable today, for two different reasons. A selectorless call cannot resolve a
+        # parameter set -- two sets, no DefaultParameterSetName, no set-unique bound parameter
+        # -- so it fails with AmbiguousParameterSet whether or not Mandatory is present. An
+        # empty-string selector fails with EmptyStringNotAllowed, and that one IS Mandatory's
+        # doing. Both fire at binding time, before process. Kept deliberately as a backstop --
+        # adding a DefaultParameterSetName or relaxing a Mandatory flag would silently re-open
+        # #99. Do not "simplify" it away.
         if (-not $queryParams.ContainsKey('admin_names') -and -not $queryParams.ContainsKey('admin_ids')) {
             throw 'Remove-PfbApiToken requires -Name or -Id. An unfiltered DELETE ' +
                   "/admins/api-tokens destroys the CALLING session's own API token."

--- a/Reports/PfbApiDriftReport.json
+++ b/Reports/PfbApiDriftReport.json
@@ -476,8 +476,6 @@
         "Remove-PfbApiToken"
       ],
       "missingQueryParameters": [
-        "admin_ids",
-        "admin_names",
         "context_names"
       ],
       "missingBodyProperties": [],
@@ -2189,11 +2187,8 @@
         "Get-PfbApiToken"
       ],
       "missingQueryParameters": [
-        "admin_ids",
-        "admin_names",
         "allow_errors",
-        "context_names",
-        "expose_api_token"
+        "context_names"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -10548,114 +10543,16 @@
         "context_names",
         "ids",
         "local_file_system_ids",
+        "remote_default_exports",
         "remote_ids"
       ],
       "missingBodyProperties": [
-        {
-          "name": "direction",
-          "type": null,
-          "format": null,
-          "specRequired": false,
-          "synopsis": null,
-          "suggestedPowerShellType": "[object]",
-          "enumValues": [
-            "inbound",
-            "outbound"
-          ],
-          "enumStatus": "matched",
-          "target": {
-            "file": "Public/Replication/New-PfbFileSystemReplicaLink.ps1",
-            "paramBlockLine": 55,
-            "payloadVariable": "body",
-            "assignmentStyle": "unknown",
-            "hasAttributes": false
-          }
-        },
-        {
-          "name": "link_type",
-          "type": "string",
-          "format": null,
-          "specRequired": false,
-          "synopsis": "Type of the replica link.",
-          "suggestedPowerShellType": "[string]",
-          "enumValues": [],
-          "enumStatus": "no-spec-enum-found",
-          "target": {
-            "file": "Public/Replication/New-PfbFileSystemReplicaLink.ps1",
-            "paramBlockLine": 55,
-            "payloadVariable": "body",
-            "assignmentStyle": "unknown",
-            "hasAttributes": false
-          }
-        },
-        {
-          "name": "local_file_system",
-          "type": null,
-          "format": null,
-          "specRequired": false,
-          "synopsis": "Reference to a local file system.",
-          "suggestedPowerShellType": "[object]",
-          "enumValues": [],
-          "enumStatus": "no-spec-enum-found",
-          "target": {
-            "file": "Public/Replication/New-PfbFileSystemReplicaLink.ps1",
-            "paramBlockLine": 55,
-            "payloadVariable": "body",
-            "assignmentStyle": "unknown",
-            "hasAttributes": false
-          }
-        },
-        {
-          "name": "policies",
-          "type": "array",
-          "format": null,
-          "specRequired": false,
-          "synopsis": null,
-          "suggestedPowerShellType": "[object[]]",
-          "enumValues": [],
-          "enumStatus": "no-spec-enum-found",
-          "target": {
-            "file": "Public/Replication/New-PfbFileSystemReplicaLink.ps1",
-            "paramBlockLine": 55,
-            "payloadVariable": "body",
-            "assignmentStyle": "unknown",
-            "hasAttributes": false
-          }
-        },
-        {
-          "name": "remote",
-          "type": null,
-          "format": null,
-          "specRequired": false,
-          "synopsis": "Reference to a remote array or realm.",
-          "suggestedPowerShellType": "[object]",
-          "enumValues": [],
-          "enumStatus": "no-spec-enum-found",
-          "target": {
-            "file": "Public/Replication/New-PfbFileSystemReplicaLink.ps1",
-            "paramBlockLine": 55,
-            "payloadVariable": "body",
-            "assignmentStyle": "unknown",
-            "hasAttributes": false
-          }
-        },
-        {
-          "name": "remote_file_system",
-          "type": null,
-          "format": null,
-          "specRequired": false,
-          "synopsis": "Reference to a remote file system.",
-          "suggestedPowerShellType": "[object]",
-          "enumValues": [],
-          "enumStatus": "no-spec-enum-found",
-          "target": {
-            "file": "Public/Replication/New-PfbFileSystemReplicaLink.ps1",
-            "paramBlockLine": 55,
-            "payloadVariable": "body",
-            "assignmentStyle": "unknown",
-            "hasAttributes": false
-          }
-        }
+        "direction",
+        "link_type",
+        "local_file_system",
+        "policies",
+        "remote",
+        "remote_file_system"
       ],
       "readOnlyFields": [
         "context",
@@ -10666,10 +10563,17 @@
         "status_details"
       ],
       "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
+        "level": "partial",
+        "unresolvedParameters": [
+          {
+            "parameter": "RemoteDefaultExports",
+            "surface": "TypedUnresolved",
+            "file": "Public/Replication/New-PfbFileSystemReplicaLink.ps1",
+            "line": 57
+          }
+        ],
         "escapeHatchOnly": [],
-        "caveat": ""
+        "caveat": "one or more parameters could not be traced to a wire name and have no -Attributes escape hatch; lists reflect typed-parameter coverage only, not full wire reachability"
       },
       "annotations": []
     },
@@ -14170,8 +14074,8 @@
   "systemicGaps": [
     {
       "name": "context_names",
-      "endpointCount": 270,
-      "queryEndpointCount": 270,
+      "endpointCount": 269,
+      "queryEndpointCount": 269,
       "bodyEndpointCount": 0,
       "endpoints": [
         "DELETE /admins/api-tokens",
@@ -14404,7 +14308,6 @@
         "POST /directory-services/local/directory-services",
         "POST /directory-services/local/groups",
         "POST /file-system-exports",
-        "POST /file-system-replica-links",
         "POST /file-system-replica-links/policies",
         "POST /file-systems/audit-policies",
         "POST /file-systems/locks/nlm-reclamations",
@@ -14592,8 +14495,8 @@
     },
     {
       "name": "ids",
-      "endpointCount": 43,
-      "queryEndpointCount": 43,
+      "endpointCount": 42,
+      "queryEndpointCount": 42,
       "bodyEndpointCount": 0,
       "endpoints": [
         "DELETE /network-access-policies/rules",
@@ -14637,8 +14540,7 @@
         "PATCH /password-policies",
         "PATCH /smb-client-policies/rules",
         "PATCH /smb-share-policies/rules",
-        "PATCH /syslog-servers/settings",
-        "POST /file-system-replica-links"
+        "PATCH /syslog-servers/settings"
       ],
       "annotations": []
     },
@@ -14848,8 +14750,8 @@
     },
     {
       "name": "remote_ids",
-      "endpointCount": 15,
-      "queryEndpointCount": 15,
+      "endpointCount": 14,
+      "queryEndpointCount": 14,
       "bodyEndpointCount": 0,
       "endpoints": [
         "DELETE /array-connections",
@@ -14865,8 +14767,7 @@
         "GET /file-system-replica-links/policies",
         "GET /file-system-replica-links/transfer",
         "GET /policies-all/members",
-        "GET /policies/file-system-replica-links",
-        "POST /file-system-replica-links"
+        "GET /policies/file-system-replica-links"
       ],
       "annotations": []
     },
@@ -14927,23 +14828,6 @@
       "annotations": []
     },
     {
-      "name": "local_file_system_ids",
-      "endpointCount": 8,
-      "queryEndpointCount": 8,
-      "bodyEndpointCount": 0,
-      "endpoints": [
-        "DELETE /file-system-replica-links",
-        "DELETE /file-system-replica-links/policies",
-        "DELETE /policies/file-system-replica-links",
-        "GET /file-system-replica-links",
-        "GET /file-system-replica-links/policies",
-        "GET /policies-all/members",
-        "GET /policies/file-system-replica-links",
-        "POST /file-system-replica-links"
-      ],
-      "annotations": []
-    },
-    {
       "name": "actions",
       "endpointCount": 7,
       "queryEndpointCount": 0,
@@ -14972,6 +14856,22 @@
         "GET /snmp-agents",
         "GET /snmp-managers/test",
         "GET /sso/saml2/idps/test"
+      ],
+      "annotations": []
+    },
+    {
+      "name": "local_file_system_ids",
+      "endpointCount": 7,
+      "queryEndpointCount": 7,
+      "bodyEndpointCount": 0,
+      "endpoints": [
+        "DELETE /file-system-replica-links",
+        "DELETE /file-system-replica-links/policies",
+        "DELETE /policies/file-system-replica-links",
+        "GET /file-system-replica-links",
+        "GET /file-system-replica-links/policies",
+        "GET /policies-all/members",
+        "GET /policies/file-system-replica-links"
       ],
       "annotations": []
     },
@@ -15569,28 +15469,6 @@
       "annotations": []
     },
     {
-      "name": "admin_ids",
-      "endpointCount": 2,
-      "queryEndpointCount": 2,
-      "bodyEndpointCount": 0,
-      "endpoints": [
-        "DELETE /admins/api-tokens",
-        "GET /admins/api-tokens"
-      ],
-      "annotations": []
-    },
-    {
-      "name": "admin_names",
-      "endpointCount": 2,
-      "queryEndpointCount": 2,
-      "bodyEndpointCount": 0,
-      "endpoints": [
-        "DELETE /admins/api-tokens",
-        "GET /admins/api-tokens"
-      ],
-      "annotations": []
-    },
-    {
       "name": "component_name",
       "endpointCount": 2,
       "queryEndpointCount": 2,
@@ -15642,17 +15520,6 @@
       "endpoints": [
         "POST /presets/workload",
         "PUT /presets/workload"
-      ],
-      "annotations": []
-    },
-    {
-      "name": "expose_api_token",
-      "endpointCount": 2,
-      "queryEndpointCount": 2,
-      "bodyEndpointCount": 0,
-      "endpoints": [
-        "GET /admins",
-        "GET /admins/api-tokens"
       ],
       "annotations": []
     },
@@ -16410,16 +16277,6 @@
       "annotations": []
     },
     {
-      "name": "direction",
-      "endpointCount": 1,
-      "queryEndpointCount": 0,
-      "bodyEndpointCount": 1,
-      "endpoints": [
-        "POST /file-system-replica-links"
-      ],
-      "annotations": []
-    },
-    {
       "name": "discover_mtu",
       "endpointCount": 1,
       "queryEndpointCount": 1,
@@ -16516,6 +16373,16 @@
       "bodyEndpointCount": 1,
       "endpoints": [
         "POST /object-store-account-exports"
+      ],
+      "annotations": []
+    },
+    {
+      "name": "expose_api_token",
+      "endpointCount": 1,
+      "queryEndpointCount": 1,
+      "bodyEndpointCount": 0,
+      "endpoints": [
+        "GET /admins"
       ],
       "annotations": []
     },
@@ -16760,32 +16627,12 @@
       "annotations": []
     },
     {
-      "name": "link_type",
-      "endpointCount": 1,
-      "queryEndpointCount": 0,
-      "bodyEndpointCount": 1,
-      "endpoints": [
-        "POST /file-system-replica-links"
-      ],
-      "annotations": []
-    },
-    {
       "name": "local_bucket_ids",
       "endpointCount": 1,
       "queryEndpointCount": 1,
       "bodyEndpointCount": 0,
       "endpoints": [
         "GET /bucket-replica-links"
-      ],
-      "annotations": []
-    },
-    {
-      "name": "local_file_system",
-      "endpointCount": 1,
-      "queryEndpointCount": 0,
-      "bodyEndpointCount": 1,
-      "endpoints": [
-        "POST /file-system-replica-links"
       ],
       "annotations": []
     },
@@ -17050,16 +16897,6 @@
       "annotations": []
     },
     {
-      "name": "policies",
-      "endpointCount": 1,
-      "queryEndpointCount": 0,
-      "bodyEndpointCount": 1,
-      "endpoints": [
-        "POST /file-system-replica-links"
-      ],
-      "annotations": []
-    },
-    {
       "name": "port",
       "endpointCount": 1,
       "queryEndpointCount": 1,
@@ -17230,16 +17067,6 @@
       "annotations": []
     },
     {
-      "name": "remote",
-      "endpointCount": 1,
-      "queryEndpointCount": 0,
-      "bodyEndpointCount": 1,
-      "endpoints": [
-        "POST /file-system-replica-links"
-      ],
-      "annotations": []
-    },
-    {
       "name": "remote_assist_active",
       "endpointCount": 1,
       "queryEndpointCount": 0,
@@ -17256,16 +17083,6 @@
       "bodyEndpointCount": 1,
       "endpoints": [
         "PATCH /support"
-      ],
-      "annotations": []
-    },
-    {
-      "name": "remote_file_system",
-      "endpointCount": 1,
-      "queryEndpointCount": 0,
-      "bodyEndpointCount": 1,
-      "endpoints": [
-        "POST /file-system-replica-links"
       ],
       "annotations": []
     },
@@ -17513,7 +17330,7 @@
   "conventionStrength": [
     {
       "name": "names",
-      "cmdletCount": 308,
+      "cmdletCount": 306,
       "cmdlets": [
         "Get-PfbActiveDirectory",
         "Get-PfbAdmin",
@@ -17521,7 +17338,6 @@
         "Get-PfbAlert",
         "Get-PfbAlertWatcher",
         "Get-PfbApiClient",
-        "Get-PfbApiToken",
         "Get-PfbArrayConnectionKey",
         "Get-PfbAsyncLog",
         "Get-PfbAsyncLogDownload",
@@ -17683,7 +17499,6 @@
         "Remove-PfbAdminCache",
         "Remove-PfbAlertWatcher",
         "Remove-PfbApiClient",
-        "Remove-PfbApiToken",
         "Remove-PfbAuditFileSystemPolicy",
         "Remove-PfbAuditObjectStorePolicy",
         "Remove-PfbBucket",
@@ -17827,14 +17642,13 @@
     },
     {
       "name": "ids",
-      "cmdletCount": 223,
+      "cmdletCount": 221,
       "cmdlets": [
         "Get-PfbAdmin",
         "Get-PfbAdminCache",
         "Get-PfbAlert",
         "Get-PfbAlertWatcher",
         "Get-PfbApiClient",
-        "Get-PfbApiToken",
         "Get-PfbArrayConnection",
         "Get-PfbAsyncLog",
         "Get-PfbAsyncLogDownload",
@@ -17927,7 +17741,6 @@
         "Remove-PfbAdminCache",
         "Remove-PfbAlertWatcher",
         "Remove-PfbApiClient",
-        "Remove-PfbApiToken",
         "Remove-PfbArrayConnection",
         "Remove-PfbAuditFileSystemPolicy",
         "Remove-PfbAuditObjectStorePolicy",
@@ -19520,15 +19333,6 @@
       ]
     },
     {
-      "name": "remote",
-      "cmdletCount": 3,
-      "cmdlets": [
-        "New-PfbArrayConnection",
-        "Update-PfbArrayConnection",
-        "Update-PfbObjectStoreRemoteCredential"
-      ]
-    },
-    {
       "name": "remote_file_system_names",
       "cmdletCount": 3,
       "cmdlets": [
@@ -19720,20 +19524,6 @@
       ]
     },
     {
-      "name": "admin_ids",
-      "cmdletCount": 1,
-      "cmdlets": [
-        "New-PfbApiToken"
-      ]
-    },
-    {
-      "name": "admin_names",
-      "cmdletCount": 1,
-      "cmdlets": [
-        "New-PfbApiToken"
-      ]
-    },
-    {
       "name": "aggregation_strategy",
       "cmdletCount": 1,
       "cmdlets": [
@@ -19864,6 +19654,13 @@
       "cmdletCount": 1,
       "cmdlets": [
         "Update-PfbObjectStoreAccountExport"
+      ]
+    },
+    {
+      "name": "expose_api_token",
+      "cmdletCount": 1,
+      "cmdlets": [
+        "Get-PfbApiToken"
       ]
     },
     {
@@ -20336,11 +20133,6 @@
       "cmdlets": []
     },
     {
-      "name": "direction",
-      "cmdletCount": 0,
-      "cmdlets": []
-    },
-    {
       "name": "directory_configurations",
       "cmdletCount": 0,
       "cmdlets": []
@@ -20392,11 +20184,6 @@
     },
     {
       "name": "export_configurations",
-      "cmdletCount": 0,
-      "cmdlets": []
-    },
-    {
-      "name": "expose_api_token",
       "cmdletCount": 0,
       "cmdlets": []
     },
@@ -20471,22 +20258,12 @@
       "cmdlets": []
     },
     {
-      "name": "link_type",
-      "cmdletCount": 0,
-      "cmdlets": []
-    },
-    {
       "name": "local_bucket_ids",
       "cmdletCount": 0,
       "cmdlets": []
     },
     {
       "name": "local_directory_service_ids",
-      "cmdletCount": 0,
-      "cmdlets": []
-    },
-    {
-      "name": "local_file_system",
       "cmdletCount": 0,
       "cmdlets": []
     },
@@ -20611,11 +20388,6 @@
       "cmdlets": []
     },
     {
-      "name": "policies",
-      "cmdletCount": 0,
-      "cmdlets": []
-    },
-    {
       "name": "port",
       "cmdletCount": 0,
       "cmdlets": []
@@ -20667,11 +20439,6 @@
     },
     {
       "name": "remote_assist_duration",
-      "cmdletCount": 0,
-      "cmdlets": []
-    },
-    {
-      "name": "remote_file_system",
       "cmdletCount": 0,
       "cmdlets": []
     },

--- a/Reports/PfbApiDriftReport.json
+++ b/Reports/PfbApiDriftReport.json
@@ -10543,16 +10543,114 @@
         "context_names",
         "ids",
         "local_file_system_ids",
-        "remote_default_exports",
         "remote_ids"
       ],
       "missingBodyProperties": [
-        "direction",
-        "link_type",
-        "local_file_system",
-        "policies",
-        "remote",
-        "remote_file_system"
+        {
+          "name": "direction",
+          "type": null,
+          "format": null,
+          "specRequired": false,
+          "synopsis": null,
+          "suggestedPowerShellType": "[object]",
+          "enumValues": [
+            "inbound",
+            "outbound"
+          ],
+          "enumStatus": "matched",
+          "target": {
+            "file": "Public/Replication/New-PfbFileSystemReplicaLink.ps1",
+            "paramBlockLine": 61,
+            "payloadVariable": "body",
+            "assignmentStyle": "unknown",
+            "hasAttributes": false
+          }
+        },
+        {
+          "name": "link_type",
+          "type": "string",
+          "format": null,
+          "specRequired": false,
+          "synopsis": "Type of the replica link.",
+          "suggestedPowerShellType": "[string]",
+          "enumValues": [],
+          "enumStatus": "no-spec-enum-found",
+          "target": {
+            "file": "Public/Replication/New-PfbFileSystemReplicaLink.ps1",
+            "paramBlockLine": 61,
+            "payloadVariable": "body",
+            "assignmentStyle": "unknown",
+            "hasAttributes": false
+          }
+        },
+        {
+          "name": "local_file_system",
+          "type": null,
+          "format": null,
+          "specRequired": false,
+          "synopsis": "Reference to a local file system.",
+          "suggestedPowerShellType": "[object]",
+          "enumValues": [],
+          "enumStatus": "no-spec-enum-found",
+          "target": {
+            "file": "Public/Replication/New-PfbFileSystemReplicaLink.ps1",
+            "paramBlockLine": 61,
+            "payloadVariable": "body",
+            "assignmentStyle": "unknown",
+            "hasAttributes": false
+          }
+        },
+        {
+          "name": "policies",
+          "type": "array",
+          "format": null,
+          "specRequired": false,
+          "synopsis": null,
+          "suggestedPowerShellType": "[object[]]",
+          "enumValues": [],
+          "enumStatus": "no-spec-enum-found",
+          "target": {
+            "file": "Public/Replication/New-PfbFileSystemReplicaLink.ps1",
+            "paramBlockLine": 61,
+            "payloadVariable": "body",
+            "assignmentStyle": "unknown",
+            "hasAttributes": false
+          }
+        },
+        {
+          "name": "remote",
+          "type": null,
+          "format": null,
+          "specRequired": false,
+          "synopsis": "Reference to a remote array or realm.",
+          "suggestedPowerShellType": "[object]",
+          "enumValues": [],
+          "enumStatus": "no-spec-enum-found",
+          "target": {
+            "file": "Public/Replication/New-PfbFileSystemReplicaLink.ps1",
+            "paramBlockLine": 61,
+            "payloadVariable": "body",
+            "assignmentStyle": "unknown",
+            "hasAttributes": false
+          }
+        },
+        {
+          "name": "remote_file_system",
+          "type": null,
+          "format": null,
+          "specRequired": false,
+          "synopsis": "Reference to a remote file system.",
+          "suggestedPowerShellType": "[object]",
+          "enumValues": [],
+          "enumStatus": "no-spec-enum-found",
+          "target": {
+            "file": "Public/Replication/New-PfbFileSystemReplicaLink.ps1",
+            "paramBlockLine": 61,
+            "payloadVariable": "body",
+            "assignmentStyle": "unknown",
+            "hasAttributes": false
+          }
+        }
       ],
       "readOnlyFields": [
         "context",
@@ -10563,17 +10661,10 @@
         "status_details"
       ],
       "confidence": {
-        "level": "partial",
-        "unresolvedParameters": [
-          {
-            "parameter": "RemoteDefaultExports",
-            "surface": "TypedUnresolved",
-            "file": "Public/Replication/New-PfbFileSystemReplicaLink.ps1",
-            "line": 57
-          }
-        ],
+        "level": "high",
+        "unresolvedParameters": [],
         "escapeHatchOnly": [],
-        "caveat": "one or more parameters could not be traced to a wire name and have no -Attributes escape hatch; lists reflect typed-parameter coverage only, not full wire reachability"
+        "caveat": ""
       },
       "annotations": []
     },
@@ -14074,8 +14165,8 @@
   "systemicGaps": [
     {
       "name": "context_names",
-      "endpointCount": 269,
-      "queryEndpointCount": 269,
+      "endpointCount": 270,
+      "queryEndpointCount": 270,
       "bodyEndpointCount": 0,
       "endpoints": [
         "DELETE /admins/api-tokens",
@@ -14308,6 +14399,7 @@
         "POST /directory-services/local/directory-services",
         "POST /directory-services/local/groups",
         "POST /file-system-exports",
+        "POST /file-system-replica-links",
         "POST /file-system-replica-links/policies",
         "POST /file-systems/audit-policies",
         "POST /file-systems/locks/nlm-reclamations",
@@ -14495,8 +14587,8 @@
     },
     {
       "name": "ids",
-      "endpointCount": 42,
-      "queryEndpointCount": 42,
+      "endpointCount": 43,
+      "queryEndpointCount": 43,
       "bodyEndpointCount": 0,
       "endpoints": [
         "DELETE /network-access-policies/rules",
@@ -14540,7 +14632,8 @@
         "PATCH /password-policies",
         "PATCH /smb-client-policies/rules",
         "PATCH /smb-share-policies/rules",
-        "PATCH /syslog-servers/settings"
+        "PATCH /syslog-servers/settings",
+        "POST /file-system-replica-links"
       ],
       "annotations": []
     },
@@ -14750,8 +14843,8 @@
     },
     {
       "name": "remote_ids",
-      "endpointCount": 14,
-      "queryEndpointCount": 14,
+      "endpointCount": 15,
+      "queryEndpointCount": 15,
       "bodyEndpointCount": 0,
       "endpoints": [
         "DELETE /array-connections",
@@ -14767,7 +14860,8 @@
         "GET /file-system-replica-links/policies",
         "GET /file-system-replica-links/transfer",
         "GET /policies-all/members",
-        "GET /policies/file-system-replica-links"
+        "GET /policies/file-system-replica-links",
+        "POST /file-system-replica-links"
       ],
       "annotations": []
     },
@@ -14828,6 +14922,23 @@
       "annotations": []
     },
     {
+      "name": "local_file_system_ids",
+      "endpointCount": 8,
+      "queryEndpointCount": 8,
+      "bodyEndpointCount": 0,
+      "endpoints": [
+        "DELETE /file-system-replica-links",
+        "DELETE /file-system-replica-links/policies",
+        "DELETE /policies/file-system-replica-links",
+        "GET /file-system-replica-links",
+        "GET /file-system-replica-links/policies",
+        "GET /policies-all/members",
+        "GET /policies/file-system-replica-links",
+        "POST /file-system-replica-links"
+      ],
+      "annotations": []
+    },
+    {
       "name": "actions",
       "endpointCount": 7,
       "queryEndpointCount": 0,
@@ -14856,22 +14967,6 @@
         "GET /snmp-agents",
         "GET /snmp-managers/test",
         "GET /sso/saml2/idps/test"
-      ],
-      "annotations": []
-    },
-    {
-      "name": "local_file_system_ids",
-      "endpointCount": 7,
-      "queryEndpointCount": 7,
-      "bodyEndpointCount": 0,
-      "endpoints": [
-        "DELETE /file-system-replica-links",
-        "DELETE /file-system-replica-links/policies",
-        "DELETE /policies/file-system-replica-links",
-        "GET /file-system-replica-links",
-        "GET /file-system-replica-links/policies",
-        "GET /policies-all/members",
-        "GET /policies/file-system-replica-links"
       ],
       "annotations": []
     },
@@ -16277,6 +16372,16 @@
       "annotations": []
     },
     {
+      "name": "direction",
+      "endpointCount": 1,
+      "queryEndpointCount": 0,
+      "bodyEndpointCount": 1,
+      "endpoints": [
+        "POST /file-system-replica-links"
+      ],
+      "annotations": []
+    },
+    {
       "name": "discover_mtu",
       "endpointCount": 1,
       "queryEndpointCount": 1,
@@ -16627,12 +16732,32 @@
       "annotations": []
     },
     {
+      "name": "link_type",
+      "endpointCount": 1,
+      "queryEndpointCount": 0,
+      "bodyEndpointCount": 1,
+      "endpoints": [
+        "POST /file-system-replica-links"
+      ],
+      "annotations": []
+    },
+    {
       "name": "local_bucket_ids",
       "endpointCount": 1,
       "queryEndpointCount": 1,
       "bodyEndpointCount": 0,
       "endpoints": [
         "GET /bucket-replica-links"
+      ],
+      "annotations": []
+    },
+    {
+      "name": "local_file_system",
+      "endpointCount": 1,
+      "queryEndpointCount": 0,
+      "bodyEndpointCount": 1,
+      "endpoints": [
+        "POST /file-system-replica-links"
       ],
       "annotations": []
     },
@@ -16897,6 +17022,16 @@
       "annotations": []
     },
     {
+      "name": "policies",
+      "endpointCount": 1,
+      "queryEndpointCount": 0,
+      "bodyEndpointCount": 1,
+      "endpoints": [
+        "POST /file-system-replica-links"
+      ],
+      "annotations": []
+    },
+    {
       "name": "port",
       "endpointCount": 1,
       "queryEndpointCount": 1,
@@ -17067,6 +17202,16 @@
       "annotations": []
     },
     {
+      "name": "remote",
+      "endpointCount": 1,
+      "queryEndpointCount": 0,
+      "bodyEndpointCount": 1,
+      "endpoints": [
+        "POST /file-system-replica-links"
+      ],
+      "annotations": []
+    },
+    {
       "name": "remote_assist_active",
       "endpointCount": 1,
       "queryEndpointCount": 0,
@@ -17083,6 +17228,16 @@
       "bodyEndpointCount": 1,
       "endpoints": [
         "PATCH /support"
+      ],
+      "annotations": []
+    },
+    {
+      "name": "remote_file_system",
+      "endpointCount": 1,
+      "queryEndpointCount": 0,
+      "bodyEndpointCount": 1,
+      "endpoints": [
+        "POST /file-system-replica-links"
       ],
       "annotations": []
     },
@@ -19333,6 +19488,15 @@
       ]
     },
     {
+      "name": "remote",
+      "cmdletCount": 3,
+      "cmdlets": [
+        "New-PfbArrayConnection",
+        "Update-PfbArrayConnection",
+        "Update-PfbObjectStoreRemoteCredential"
+      ]
+    },
+    {
       "name": "remote_file_system_names",
       "cmdletCount": 3,
       "cmdlets": [
@@ -20133,6 +20297,11 @@
       "cmdlets": []
     },
     {
+      "name": "direction",
+      "cmdletCount": 0,
+      "cmdlets": []
+    },
+    {
       "name": "directory_configurations",
       "cmdletCount": 0,
       "cmdlets": []
@@ -20258,12 +20427,22 @@
       "cmdlets": []
     },
     {
+      "name": "link_type",
+      "cmdletCount": 0,
+      "cmdlets": []
+    },
+    {
       "name": "local_bucket_ids",
       "cmdletCount": 0,
       "cmdlets": []
     },
     {
       "name": "local_directory_service_ids",
+      "cmdletCount": 0,
+      "cmdlets": []
+    },
+    {
+      "name": "local_file_system",
       "cmdletCount": 0,
       "cmdlets": []
     },
@@ -20388,6 +20567,11 @@
       "cmdlets": []
     },
     {
+      "name": "policies",
+      "cmdletCount": 0,
+      "cmdlets": []
+    },
+    {
       "name": "port",
       "cmdletCount": 0,
       "cmdlets": []
@@ -20439,6 +20623,11 @@
     },
     {
       "name": "remote_assist_duration",
+      "cmdletCount": 0,
+      "cmdlets": []
+    },
+    {
+      "name": "remote_file_system",
       "cmdletCount": 0,
       "cmdlets": []
     },

--- a/Reports/PfbApiDriftReport.md
+++ b/Reports/PfbApiDriftReport.md
@@ -23,11 +23,11 @@ This report accepts **false positives in order to eliminate false negatives**. A
 - Uncovered endpoints: 96
 - Endpoints with parameter gaps: 438
 - Missing body properties (addable): 422
-- Missing query parameters (addable): 948
+- Missing query parameters (addable): 947
 - Read-only body fields (not addable -- see the Read-only fields section below): 382
 - Phantom fields silently excluded (accumulated in the capability map, absent from the newest analysed spec): 40
-- Partial-confidence endpoints (see `How to read this report` above, and each row's marker in the Parameter gaps table): 60
-- Systemic gaps (distinct field names collapsed across high-confidence endpoints, detailed below): 244
+- Partial-confidence endpoints (see `How to read this report` above, and each row's marker in the Parameter gaps table): 59
+- Systemic gaps (distinct field names collapsed across high-confidence endpoints, detailed below): 250
 - ValidateSet drift: 0
 - New ValidateSet candidates: 1
 - Context cardinality signal disagreements (fb2.28): 9
@@ -39,13 +39,13 @@ This report accepts **false positives in order to eliminate false negatives**. A
 
 One finding per distinct wire field name, collapsed across every endpoint where a high-confidence gap exists (decision 7) -- turns hundreds of per-endpoint rows into a handful of real, actionable decisions. "Cmdlets already using this name" is decision 8's convention-strength ranking: a high count means closing the remaining gaps for this name is a mechanical batch fix; zero means no established convention exists to extend at all -- closing it is an architectural decision, not a mechanical one.
 
-Showing the top 25 of 244 findings by endpoint count -- the full list is in the JSON manifest's `systemicGaps`, nothing is dropped there.
+Showing the top 25 of 250 findings by endpoint count -- the full list is in the JSON manifest's `systemicGaps`, nothing is dropped there.
 
 | Field name | Endpoints | Query | Body | Cmdlets already using this name | Annotation |
 |---|---|---|---|---|---|
-| `context_names` | 269 | 269 | 0 | 0 | not yet implemented |
+| `context_names` | 270 | 270 | 0 | 0 | not yet implemented |
 | `allow_errors` | 118 | 118 | 0 | 0 | not yet implemented |
-| `ids` | 42 | 42 | 0 | 221 |  |
+| `ids` | 43 | 43 | 0 | 221 |  |
 | `names` | 31 | 31 | 0 | 306 |  |
 | `sort` | 28 | 28 | 0 | 180 |  |
 | `bucket_ids` | 17 | 17 | 0 | 2 |  |
@@ -53,13 +53,13 @@ Showing the top 25 of 244 findings by endpoint count -- the full list is in the 
 | `total_only` | 17 | 17 | 0 | 39 |  |
 | `bucket_names` | 16 | 16 | 0 | 3 |  |
 | `member_ids` | 15 | 15 | 0 | 85 |  |
-| `remote_ids` | 14 | 14 | 0 | 3 |  |
+| `remote_ids` | 15 | 15 | 0 | 3 |  |
 | `policy_names` | 11 | 11 | 0 | 118 |  |
 | `file_system_ids` | 9 | 9 | 0 | 9 |  |
 | `remote_names` | 9 | 9 | 0 | 9 |  |
+| `local_file_system_ids` | 8 | 8 | 0 | 2 |  |
 | `actions` | 7 | 0 | 7 | 2 |  |
 | `limit` | 7 | 7 | 0 | 199 |  |
-| `local_file_system_ids` | 7 | 7 | 0 | 2 |  |
 | `name` | 7 | 0 | 7 | 20 |  |
 | `versions` | 7 | 7 | 0 | 5 |  |
 | `enabled` | 6 | 0 | 6 | 10 |  |
@@ -437,7 +437,7 @@ Endpoints an existing cmdlet already calls, where the capability map knows of a 
 | `POST /directory-services/roles` | New-PfbDirectoryServiceRole |  | group, group_base, management_access_policies, role | `high` |  |
 | `POST /dns` | New-PfbDns | context_names, names | ca_certificate, ca_certificate_group, domain, nameservers, services, sources | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
 | `POST /file-system-exports` | New-PfbFileSystemExport | context_names, member_ids, policy_ids |  | `high` |  |
-| `POST /file-system-replica-links` | New-PfbFileSystemReplicaLink | context_names, ids, local_file_system_ids, remote_default_exports, remote_ids | direction, link_type, local_file_system, policies, remote, remote_file_system | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
+| `POST /file-system-replica-links` | New-PfbFileSystemReplicaLink | context_names, ids, local_file_system_ids, remote_ids | direction, link_type, local_file_system, policies, remote, remote_file_system | `high` |  |
 | `POST /file-system-replica-links/policies` | New-PfbFileSystemReplicaLinkPolicy | context_names |  | `high` |  |
 | `POST /file-system-snapshots` | New-PfbFileSystemSnapshot | context_names, source_ids, source_names |  | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
 | `POST /file-systems` | New-PfbFileSystem | context_names, default_exports, discard_non_snapshotted_data, include_snapshot, overwrite, policy_ids, policy_names | fast_remove_directory_enabled, hard_limit_enabled, http, multi_protocol, nfs, node_group, smb, snapshot_directory_enabled, workload, writable | `partial` -- /!\ 15 unresolved params (see Partial-confidence detail below) |  |
@@ -572,7 +572,6 @@ Per the decision-6 procedure above: open each parameter at its `file:line` and f
 | `POST /data-eviction-policies` | `-Disabled` | TypedUnresolved | `Public/DataEviction/New-PfbDataEvictionPolicy.ps1:31` | one or more parameters could not be traced to a wire name and have no -Attributes escape hatch; lists reflect typed-parameter coverage only, not full wire reachability |
 | `POST /directory-services/local/groups/members` | `-Member` | TypedUnresolved | `Public/DirectoryService/New-PfbLocalGroupMember.ps1:35` | one or more parameters could not be traced to a wire name and have no -Attributes escape hatch; lists reflect typed-parameter coverage only, not full wire reachability |
 | `POST /dns` | `-Name` | AttributesOnly | `Public/Network/New-PfbDns.ps1:29` | body reachable only via -Attributes; lists reflect typed-parameter coverage, not wire reachability |
-| `POST /file-system-replica-links` | `-RemoteDefaultExports` | TypedUnresolved | `Public/Replication/New-PfbFileSystemReplicaLink.ps1:57` | one or more parameters could not be traced to a wire name and have no -Attributes escape hatch; lists reflect typed-parameter coverage only, not full wire reachability |
 | `POST /file-system-snapshots` | `-SourceName` | TypedUnresolved | `Public/FileSystemSnapshot/New-PfbFileSystemSnapshot.ps1:36` | one or more parameters could not be traced to a wire name and have no -Attributes escape hatch; lists reflect typed-parameter coverage only, not full wire reachability |
 | `POST /file-systems` | `-FastRemoveDirectoryEnabled` | AttributesOnly | `Public/FileSystem/New-PfbFileSystem.ps1:139` | body reachable only via -Attributes; lists reflect typed-parameter coverage, not wire reachability |
 | `POST /file-systems` | `-HardLimit` | AttributesOnly | `Public/FileSystem/New-PfbFileSystem.ps1:93` | body reachable only via -Attributes; lists reflect typed-parameter coverage, not wire reachability |

--- a/Reports/PfbApiDriftReport.md
+++ b/Reports/PfbApiDriftReport.md
@@ -23,11 +23,11 @@ This report accepts **false positives in order to eliminate false negatives**. A
 - Uncovered endpoints: 96
 - Endpoints with parameter gaps: 438
 - Missing body properties (addable): 422
-- Missing query parameters (addable): 952
+- Missing query parameters (addable): 948
 - Read-only body fields (not addable -- see the Read-only fields section below): 382
 - Phantom fields silently excluded (accumulated in the capability map, absent from the newest analysed spec): 40
-- Partial-confidence endpoints (see `How to read this report` above, and each row's marker in the Parameter gaps table): 59
-- Systemic gaps (distinct field names collapsed across high-confidence endpoints, detailed below): 252
+- Partial-confidence endpoints (see `How to read this report` above, and each row's marker in the Parameter gaps table): 60
+- Systemic gaps (distinct field names collapsed across high-confidence endpoints, detailed below): 244
 - ValidateSet drift: 0
 - New ValidateSet candidates: 1
 - Context cardinality signal disagreements (fb2.28): 9
@@ -39,27 +39,27 @@ This report accepts **false positives in order to eliminate false negatives**. A
 
 One finding per distinct wire field name, collapsed across every endpoint where a high-confidence gap exists (decision 7) -- turns hundreds of per-endpoint rows into a handful of real, actionable decisions. "Cmdlets already using this name" is decision 8's convention-strength ranking: a high count means closing the remaining gaps for this name is a mechanical batch fix; zero means no established convention exists to extend at all -- closing it is an architectural decision, not a mechanical one.
 
-Showing the top 25 of 252 findings by endpoint count -- the full list is in the JSON manifest's `systemicGaps`, nothing is dropped there.
+Showing the top 25 of 244 findings by endpoint count -- the full list is in the JSON manifest's `systemicGaps`, nothing is dropped there.
 
 | Field name | Endpoints | Query | Body | Cmdlets already using this name | Annotation |
 |---|---|---|---|---|---|
-| `context_names` | 270 | 270 | 0 | 0 | not yet implemented |
+| `context_names` | 269 | 269 | 0 | 0 | not yet implemented |
 | `allow_errors` | 118 | 118 | 0 | 0 | not yet implemented |
-| `ids` | 43 | 43 | 0 | 223 |  |
-| `names` | 31 | 31 | 0 | 308 |  |
+| `ids` | 42 | 42 | 0 | 221 |  |
+| `names` | 31 | 31 | 0 | 306 |  |
 | `sort` | 28 | 28 | 0 | 180 |  |
 | `bucket_ids` | 17 | 17 | 0 | 2 |  |
 | `policy_ids` | 17 | 17 | 0 | 98 |  |
 | `total_only` | 17 | 17 | 0 | 39 |  |
 | `bucket_names` | 16 | 16 | 0 | 3 |  |
 | `member_ids` | 15 | 15 | 0 | 85 |  |
-| `remote_ids` | 15 | 15 | 0 | 3 |  |
+| `remote_ids` | 14 | 14 | 0 | 3 |  |
 | `policy_names` | 11 | 11 | 0 | 118 |  |
 | `file_system_ids` | 9 | 9 | 0 | 9 |  |
 | `remote_names` | 9 | 9 | 0 | 9 |  |
-| `local_file_system_ids` | 8 | 8 | 0 | 2 |  |
 | `actions` | 7 | 0 | 7 | 2 |  |
 | `limit` | 7 | 7 | 0 | 199 |  |
+| `local_file_system_ids` | 7 | 7 | 0 | 2 |  |
 | `name` | 7 | 0 | 7 | 20 |  |
 | `versions` | 7 | 7 | 0 | 5 |  |
 | `enabled` | 6 | 0 | 6 | 10 |  |
@@ -76,7 +76,7 @@ Endpoints an existing cmdlet already calls, where the capability map knows of a 
 | Endpoint | Cmdlets | Missing query parameters | Missing body properties | Confidence | Notes |
 |---|---|---|---|---|---|
 | `DELETE /active-directory` | Remove-PfbActiveDirectory | local_only |  | `high` |  |
-| `DELETE /admins/api-tokens` | Remove-PfbApiToken | admin_ids, admin_names, context_names |  | `high` |  |
+| `DELETE /admins/api-tokens` | Remove-PfbApiToken | context_names |  | `high` |  |
 | `DELETE /admins/cache` | Remove-PfbAdminCache | context_names |  | `high` |  |
 | `DELETE /admins/management-access-policies` | Remove-PfbAdminManagementAccessPolicy | context_names |  | `high` | POST/PATCH/DELETE return 403 regardless of account; not an implementation bug |
 | `DELETE /admins/ssh-certificate-authority-policies` | Remove-PfbAdminSshCaPolicy | context_names |  | `high` |  |
@@ -161,7 +161,7 @@ Endpoints an existing cmdlet already calls, where the capability map knows of a 
 | `GET /active-directory` | Get-PfbActiveDirectory | ids, limit, sort |  | `high` |  |
 | `GET /active-directory/test` | Test-PfbActiveDirectory | allow_errors, context_names, filter, limit, sort |  | `high` |  |
 | `GET /admins` | Get-PfbAdmin | allow_errors, context_names, expose_api_token |  | `high` |  |
-| `GET /admins/api-tokens` | Get-PfbApiToken | admin_ids, admin_names, allow_errors, context_names, expose_api_token |  | `high` |  |
+| `GET /admins/api-tokens` | Get-PfbApiToken | allow_errors, context_names |  | `high` |  |
 | `GET /admins/cache` | Get-PfbAdminCache | allow_errors, context_names, refresh |  | `high` |  |
 | `GET /admins/management-access-policies` | Get-PfbAdminManagementAccessPolicy | allow_errors, context_names, sort |  | `high` | POST/PATCH/DELETE return 403 regardless of account; not an implementation bug |
 | `GET /admins/ssh-certificate-authority-policies` | Get-PfbAdminSshCaPolicy | allow_errors, context_names, sort |  | `high` |  |
@@ -437,7 +437,7 @@ Endpoints an existing cmdlet already calls, where the capability map knows of a 
 | `POST /directory-services/roles` | New-PfbDirectoryServiceRole |  | group, group_base, management_access_policies, role | `high` |  |
 | `POST /dns` | New-PfbDns | context_names, names | ca_certificate, ca_certificate_group, domain, nameservers, services, sources | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
 | `POST /file-system-exports` | New-PfbFileSystemExport | context_names, member_ids, policy_ids |  | `high` |  |
-| `POST /file-system-replica-links` | New-PfbFileSystemReplicaLink | context_names, ids, local_file_system_ids, remote_ids | direction, link_type, local_file_system, policies, remote, remote_file_system | `high` |  |
+| `POST /file-system-replica-links` | New-PfbFileSystemReplicaLink | context_names, ids, local_file_system_ids, remote_default_exports, remote_ids | direction, link_type, local_file_system, policies, remote, remote_file_system | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
 | `POST /file-system-replica-links/policies` | New-PfbFileSystemReplicaLinkPolicy | context_names |  | `high` |  |
 | `POST /file-system-snapshots` | New-PfbFileSystemSnapshot | context_names, source_ids, source_names |  | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
 | `POST /file-systems` | New-PfbFileSystem | context_names, default_exports, discard_non_snapshotted_data, include_snapshot, overwrite, policy_ids, policy_names | fast_remove_directory_enabled, hard_limit_enabled, http, multi_protocol, nfs, node_group, smb, snapshot_directory_enabled, workload, writable | `partial` -- /!\ 15 unresolved params (see Partial-confidence detail below) |  |
@@ -572,6 +572,7 @@ Per the decision-6 procedure above: open each parameter at its `file:line` and f
 | `POST /data-eviction-policies` | `-Disabled` | TypedUnresolved | `Public/DataEviction/New-PfbDataEvictionPolicy.ps1:31` | one or more parameters could not be traced to a wire name and have no -Attributes escape hatch; lists reflect typed-parameter coverage only, not full wire reachability |
 | `POST /directory-services/local/groups/members` | `-Member` | TypedUnresolved | `Public/DirectoryService/New-PfbLocalGroupMember.ps1:35` | one or more parameters could not be traced to a wire name and have no -Attributes escape hatch; lists reflect typed-parameter coverage only, not full wire reachability |
 | `POST /dns` | `-Name` | AttributesOnly | `Public/Network/New-PfbDns.ps1:29` | body reachable only via -Attributes; lists reflect typed-parameter coverage, not wire reachability |
+| `POST /file-system-replica-links` | `-RemoteDefaultExports` | TypedUnresolved | `Public/Replication/New-PfbFileSystemReplicaLink.ps1:57` | one or more parameters could not be traced to a wire name and have no -Attributes escape hatch; lists reflect typed-parameter coverage only, not full wire reachability |
 | `POST /file-system-snapshots` | `-SourceName` | TypedUnresolved | `Public/FileSystemSnapshot/New-PfbFileSystemSnapshot.ps1:36` | one or more parameters could not be traced to a wire name and have no -Attributes escape hatch; lists reflect typed-parameter coverage only, not full wire reachability |
 | `POST /file-systems` | `-FastRemoveDirectoryEnabled` | AttributesOnly | `Public/FileSystem/New-PfbFileSystem.ps1:139` | body reachable only via -Attributes; lists reflect typed-parameter coverage, not wire reachability |
 | `POST /file-systems` | `-HardLimit` | AttributesOnly | `Public/FileSystem/New-PfbFileSystem.ps1:93` | body reachable only via -Attributes; lists reflect typed-parameter coverage, not wire reachability |

--- a/Reports/PfbFieldCmdletMap.json
+++ b/Reports/PfbFieldCmdletMap.json
@@ -494,6 +494,16 @@
     },
     {
       "cmdlet": "Get-PfbApiToken",
+      "parameter": "ExposeApiToken",
+      "wireName": "expose_api_token",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "Get-PfbApiToken",
       "parameter": "Filter",
       "wireName": "filter",
       "status": "no-spec-enum-found",
@@ -505,7 +515,7 @@
     {
       "cmdlet": "Get-PfbApiToken",
       "parameter": "Id",
-      "wireName": "ids",
+      "wireName": "admin_ids",
       "status": "no-spec-enum-found",
       "matchedKey": null,
       "specValues": null,
@@ -525,7 +535,7 @@
     {
       "cmdlet": "Get-PfbApiToken",
       "parameter": "Name",
-      "wireName": "names",
+      "wireName": "admin_names",
       "status": "no-spec-enum-found",
       "matchedKey": null,
       "specValues": null,
@@ -12159,16 +12169,6 @@
     },
     {
       "cmdlet": "New-PfbFileSystemReplicaLink",
-      "parameter": "RemoteDefaultExports",
-      "wireName": "remote_default_exports",
-      "status": "no-spec-enum-found",
-      "matchedKey": null,
-      "specValues": null,
-      "stableSinceOldestVersion": null,
-      "recommendation": null
-    },
-    {
-      "cmdlet": "New-PfbFileSystemReplicaLink",
       "parameter": "RemoteFileSystemName",
       "wireName": "remote_file_system_names",
       "status": "no-spec-enum-found",
@@ -14200,7 +14200,7 @@
     {
       "cmdlet": "Remove-PfbApiToken",
       "parameter": "Id",
-      "wireName": "ids",
+      "wireName": "admin_ids",
       "status": "no-spec-enum-found",
       "matchedKey": null,
       "specValues": null,
@@ -14210,7 +14210,7 @@
     {
       "cmdlet": "Remove-PfbApiToken",
       "parameter": "Name",
-      "wireName": "names",
+      "wireName": "admin_names",
       "status": "no-spec-enum-found",
       "matchedKey": null,
       "specValues": null,
@@ -20516,6 +20516,10 @@
     {
       "cmdlet": "New-PfbDataEvictionPolicy",
       "parameter": "Disabled"
+    },
+    {
+      "cmdlet": "New-PfbFileSystemReplicaLink",
+      "parameter": "RemoteDefaultExports"
     },
     {
       "cmdlet": "New-PfbFileSystemSnapshot",

--- a/Reports/PfbFieldCmdletMap.json
+++ b/Reports/PfbFieldCmdletMap.json
@@ -12169,6 +12169,16 @@
     },
     {
       "cmdlet": "New-PfbFileSystemReplicaLink",
+      "parameter": "RemoteDefaultExports",
+      "wireName": "remote_default_exports",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "New-PfbFileSystemReplicaLink",
       "parameter": "RemoteFileSystemName",
       "wireName": "remote_file_system_names",
       "status": "no-spec-enum-found",
@@ -20516,10 +20526,6 @@
     {
       "cmdlet": "New-PfbDataEvictionPolicy",
       "parameter": "Disabled"
-    },
-    {
-      "cmdlet": "New-PfbFileSystemReplicaLink",
-      "parameter": "RemoteDefaultExports"
     },
     {
       "cmdlet": "New-PfbFileSystemSnapshot",

--- a/Reports/PfbFieldCmdletMapping.md
+++ b/Reports/PfbFieldCmdletMapping.md
@@ -116,7 +116,7 @@ Reporting only -- no `Public/` cmdlet is edited by this script. Every `matched` 
 - `Update-PfbSmbSharePolicy -Enabled`
 - `Update-PfbUserGroupQuotaPolicy -Enabled`
 
-## Typed but unresolved wire name (needs manual inspection): 39
+## Typed but unresolved wire name (needs manual inspection): 40
 
 - `Connect-PfbArray -ApiToken`
 - `Connect-PfbArray -ApiVersion`
@@ -139,6 +139,7 @@ Reporting only -- no `Public/` cmdlet is edited by this script. Every `matched` 
 - `Get-PfbUserGroupQuotaPolicy -Id`
 - `Get-PfbUserGroupQuotaPolicy -Name`
 - `New-PfbDataEvictionPolicy -Disabled`
+- `New-PfbFileSystemReplicaLink -RemoteDefaultExports`
 - `New-PfbFileSystemSnapshot -SourceName`
 - `New-PfbLocalGroupMember -Member`
 - `New-PfbWorkloadPlacementRecommendation -Inputs`

--- a/Reports/PfbFieldCmdletMapping.md
+++ b/Reports/PfbFieldCmdletMapping.md
@@ -9,7 +9,7 @@ Reporting only -- no `Public/` cmdlet is edited by this script. Every `matched` 
 - matched: 1
 - collision: 1
 - not-found-in-resource: 29
-- no-spec-enum-found: 1981
+- no-spec-enum-found: 1982
 
 | Cmdlet | Parameter | Wire name | Status | Spec values | Recommendation |
 |---|---|---|---|---|---|
@@ -116,7 +116,7 @@ Reporting only -- no `Public/` cmdlet is edited by this script. Every `matched` 
 - `Update-PfbSmbSharePolicy -Enabled`
 - `Update-PfbUserGroupQuotaPolicy -Enabled`
 
-## Typed but unresolved wire name (needs manual inspection): 40
+## Typed but unresolved wire name (needs manual inspection): 39
 
 - `Connect-PfbArray -ApiToken`
 - `Connect-PfbArray -ApiVersion`
@@ -139,7 +139,6 @@ Reporting only -- no `Public/` cmdlet is edited by this script. Every `matched` 
 - `Get-PfbUserGroupQuotaPolicy -Id`
 - `Get-PfbUserGroupQuotaPolicy -Name`
 - `New-PfbDataEvictionPolicy -Disabled`
-- `New-PfbFileSystemReplicaLink -RemoteDefaultExports`
 - `New-PfbFileSystemSnapshot -SourceName`
 - `New-PfbLocalGroupMember -Member`
 - `New-PfbWorkloadPlacementRecommendation -Inputs`

--- a/Tests/Assert-PfbAdminNameNotCoerced.Tests.ps1
+++ b/Tests/Assert-PfbAdminNameNotCoerced.Tests.ps1
@@ -1,0 +1,51 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    $moduleRoot = Split-Path -Parent $PSScriptRoot
+    $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
+    Import-Module $manifest -Force
+}
+
+Describe 'Assert-PfbAdminNameNotCoerced (#99)' {
+
+    It 'accepts a plain administrator name' {
+        InModuleScope PureStorageFlashBladePowerShell {
+            { Assert-PfbAdminNameNotCoerced -Value 'ops-admin' } | Should -Not -Throw
+        }
+    }
+
+    It 'emits nothing to the success stream on success' {
+        InModuleScope PureStorageFlashBladePowerShell {
+            $out = Assert-PfbAdminNameNotCoerced -Value 'ops-admin'
+            $out | Should -BeNullOrEmpty
+        }
+    }
+
+    It 'throws on a stringified object' {
+        InModuleScope PureStorageFlashBladePowerShell {
+            { Assert-PfbAdminNameNotCoerced -Value '@{admin=; api_token=}' } |
+                Should -Throw -ExpectedMessage '*stringified object*'
+        }
+    }
+
+    It 'names .admin.name as the extraction path in the message' {
+        InModuleScope PureStorageFlashBladePowerShell {
+            { Assert-PfbAdminNameNotCoerced -Value '@{admin=}' } |
+                Should -Throw -ExpectedMessage '*admin.name*'
+        }
+    }
+
+    It 'checks every element of an array, not just the first' {
+        InModuleScope PureStorageFlashBladePowerShell {
+            { Assert-PfbAdminNameNotCoerced -Value @('ops-admin', '@{admin=}') } |
+                Should -Throw -ExpectedMessage '*stringified object*'
+        }
+    }
+
+    It 'ignores a non-string value' {
+        InModuleScope PureStorageFlashBladePowerShell {
+            { Assert-PfbAdminNameNotCoerced -Value ([PSCustomObject]@{ admin = 'x' }) } |
+                Should -Not -Throw
+        }
+    }
+}

--- a/Tests/Get-PfbApiToken.Tests.ps1
+++ b/Tests/Get-PfbApiToken.Tests.ps1
@@ -104,6 +104,33 @@ Describe 'Get-PfbApiToken (#99)' {
         }
     }
 
+    Context 'coercion guard' {
+
+        It 'throws on a piped Get-PfbApiToken-shaped object' {
+            {
+                [PSCustomObject]@{ admin = [PSCustomObject]@{ name = 'ops-admin' }; api_token = @{} } |
+                    Get-PfbApiToken -Array $fakeArray -ErrorAction Stop
+            } | Should -Throw -ExpectedMessage '*stringified object*'
+        }
+
+        It 'issues no request when the guard fires' {
+            try {
+                [PSCustomObject]@{ admin = [PSCustomObject]@{ name = 'ops-admin' }; api_token = @{} } |
+                    Get-PfbApiToken -Array $fakeArray -ErrorAction Stop
+            } catch { }
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 0 -Exactly
+        }
+
+        It 'still binds -Name by property name from a Get-PfbAdmin-shaped object' {
+            [PSCustomObject]@{ name = 'ops-admin' } | Get-PfbApiToken -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                $QueryParams['admin_names'] -eq 'ops-admin'
+            }
+        }
+    }
+
     Context 'common query parameters still flow through the helper' {
 
         It 'sends filter, sort and limit' {

--- a/Tests/Get-PfbApiToken.Tests.ps1
+++ b/Tests/Get-PfbApiToken.Tests.ps1
@@ -1,0 +1,127 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    $moduleRoot = Split-Path -Parent $PSScriptRoot
+    $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
+    Import-Module $manifest -Force
+
+    $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
+}
+
+Describe 'Get-PfbApiToken (#99)' {
+
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+    }
+
+    Context 'admin selector uses the real wire names (regression: was names/ids)' {
+
+        It 'sends -Name as admin_names, NOT names' {
+            Get-PfbApiToken -Name 'ops-admin' -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                $Method -eq 'GET' -and $Endpoint -eq 'admins/api-tokens' -and
+                $QueryParams['admin_names'] -eq 'ops-admin' -and
+                -not $QueryParams.ContainsKey('names')
+            }
+        }
+
+        It 'sends -Id as admin_ids, NOT ids' {
+            Get-PfbApiToken -Id 'admin-1' -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                $QueryParams['admin_ids'] -eq 'admin-1' -and
+                -not $QueryParams.ContainsKey('ids')
+            }
+        }
+
+        It 'joins multiple names into one comma-separated admin_names value' {
+            Get-PfbApiToken -Name 'ops-admin', 'svc-admin' -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                $QueryParams['admin_names'] -eq 'ops-admin,svc-admin'
+            }
+        }
+
+        It 'accumulates piped names into a single request' {
+            'ops-admin', 'svc-admin' | Get-PfbApiToken -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                $QueryParams['admin_names'] -eq 'ops-admin,svc-admin'
+            }
+        }
+
+        It 'accepts -AdminNames and -AdminIds as aliases' {
+            Get-PfbApiToken -AdminNames 'ops-admin' -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                $QueryParams['admin_names'] -eq 'ops-admin'
+            }
+
+            $params = (Get-Command Get-PfbApiToken).Parameters
+            $params.Keys | Should -Not -Contain 'AdminNames'
+            $params['Name'].Aliases | Should -Contain 'AdminNames'
+            $params['Id'].Aliases   | Should -Contain 'AdminIds'
+        }
+
+        It 'sends no selector key at all on an unfiltered list call' {
+            Get-PfbApiToken -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                -not $QueryParams.ContainsKey('admin_names') -and
+                -not $QueryParams.ContainsKey('admin_ids') -and
+                -not $QueryParams.ContainsKey('names') -and
+                -not $QueryParams.ContainsKey('ids')
+            }
+        }
+    }
+
+    Context '-ExposeApiToken' {
+
+        It 'sends expose_api_token=true when the switch is present' {
+            Get-PfbApiToken -Name 'ops-admin' -ExposeApiToken -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                $QueryParams['expose_api_token'] -eq 'true'
+            }
+        }
+
+        It 'omits expose_api_token entirely when the switch is absent' {
+            Get-PfbApiToken -Name 'ops-admin' -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                -not $QueryParams.ContainsKey('expose_api_token')
+            }
+        }
+
+        It 'omits expose_api_token when explicitly disabled with -ExposeApiToken:$false' {
+            Get-PfbApiToken -Name 'ops-admin' -ExposeApiToken:$false -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                -not $QueryParams.ContainsKey('expose_api_token')
+            }
+        }
+    }
+
+    Context 'common query parameters still flow through the helper' {
+
+        It 'sends filter, sort and limit' {
+            Get-PfbApiToken -Filter "name='ops-admin'" -Sort 'name' -Limit 5 -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                $QueryParams['filter'] -eq "name='ops-admin'" -and
+                $QueryParams['sort']   -eq 'name' -and
+                $QueryParams['limit']  -eq 5
+            }
+        }
+
+        It 'requests auto-pagination' {
+            Get-PfbApiToken -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                $AutoPaginate -eq $true
+            }
+        }
+    }
+}

--- a/Tests/New-PfbApiToken.Tests.ps1
+++ b/Tests/New-PfbApiToken.Tests.ps1
@@ -146,9 +146,16 @@ Describe 'New-PfbApiToken - query parameters (#31)' {
         # AmbiguousParameterSet -- two parameter sets with no DefaultParameterSetName and no
         # set-unique bound parameter fail to resolve before `process` is entered, with or
         # without the Mandatory flags. They are kept as regression rails, but they do not
-        # prove the Mandatory flags work. The empty-string tests at the end of this block are
-        # the ones that discriminate: pre-fix, -Name '' bound legally to the ByName set,
-        # `if ($Name)` was false, and an unfiltered POST went out.
+        # prove the Mandatory flags work.
+        #
+        # Neither do the empty-string tests at the end of this block. They are regressions
+        # against the pre-fix behaviour -- where -Name '' bound legally to the ByName set,
+        # `if ($Name)` was false, and an unfiltered POST went out -- but what stops them
+        # today is Mandatory's own EmptyStringNotAllowed check at binding time, not the
+        # in-process throw this Context is named after. That throw is unreachable from every
+        # input (see the .DESCRIPTION note in New-PfbApiToken.ps1); it is kept as a backstop
+        # and is not covered by any test here. The parameter-metadata test below is what
+        # actually pins the Mandatory flags and the parameter sets in place.
         It 'throws on a bare call' {
             { New-PfbApiToken -Array $fakeArray -Confirm:$false -ErrorAction Stop } | Should -Throw
         }

--- a/Tests/New-PfbApiToken.Tests.ps1
+++ b/Tests/New-PfbApiToken.Tests.ps1
@@ -93,4 +93,116 @@ Describe 'New-PfbApiToken - query parameters (#31)' {
             }
         }
     }
+
+    Context 'no request body reaches the wire (#99)' {
+
+        It 'passes no -Body on a plain call' {
+            New-PfbApiToken -Name 'ops-admin' -Confirm:$false -Array $fakeArray
+
+            # $PSBoundParameters is NOT populated inside a Pester ParameterFilter -- it is
+            # always empty, so a ContainsKey('Body') assertion would pass vacuously even
+            # against code that does pass -Body. Assert on the bound $Body value instead.
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                $null -eq $Body
+            }
+        }
+
+        It 'passes no -Body even when -Attributes is supplied' {
+            New-PfbApiToken -Name 'ops-admin' -Attributes @{ ignored = 'x' } -Confirm:$false -Array $fakeArray -WarningAction SilentlyContinue
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                $null -eq $Body
+            }
+        }
+
+        It 'warns that -Attributes is a no-op' {
+            $warnings = @()
+            New-PfbApiToken -Name 'ops-admin' -Attributes @{ ignored = 'x' } -Confirm:$false -Array $fakeArray -WarningVariable warnings -WarningAction SilentlyContinue
+
+            $warnings | Should -Not -BeNullOrEmpty
+            "$warnings" | Should -BeLike '*-Attributes*'
+        }
+
+        It 'does not warn when -Attributes is absent' {
+            $warnings = @()
+            New-PfbApiToken -Name 'ops-admin' -Confirm:$false -Array $fakeArray -WarningVariable warnings -WarningAction SilentlyContinue
+
+            $warnings | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'a request with no selector never reaches the wire (#99)' {
+
+        It 'throws on a bare call' {
+            { New-PfbApiToken -Array $fakeArray -Confirm:$false -ErrorAction Stop } | Should -Throw
+        }
+
+        It 'issues no request on a bare call' {
+            try { New-PfbApiToken -Array $fakeArray -Confirm:$false -ErrorAction Stop } catch { }
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 0 -Exactly
+        }
+
+        It 'issues no request when only -Timeout is supplied' {
+            try { New-PfbApiToken -Timeout 86400000 -Array $fakeArray -Confirm:$false -ErrorAction Stop } catch { }
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 0 -Exactly
+        }
+
+        It 'declares -Name and -Id as mandatory in their parameter sets' {
+            $cmd = Get-Command New-PfbApiToken
+            foreach ($p in 'Name', 'Id') {
+                $attr = $cmd.Parameters[$p].Attributes |
+                    Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] }
+                @($attr).Mandatory | Should -Contain $true
+            }
+        }
+    }
+
+    Context 'pipeline binding (#99)' {
+
+        It 'binds -Name by value from a plain string' {
+            'ops-admin' | New-PfbApiToken -Confirm:$false -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                $QueryParams['admin_names'] -eq 'ops-admin'
+            }
+        }
+
+        It 'issues one POST per piped name, in order' {
+            'ops-admin', 'svc-admin' | New-PfbApiToken -Confirm:$false -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 2 -Exactly
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                $QueryParams['admin_names'] -eq 'ops-admin'
+            }
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                $QueryParams['admin_names'] -eq 'svc-admin'
+            }
+        }
+
+        It 'still binds -Name by property name from a Get-PfbAdmin-shaped object' {
+            [PSCustomObject]@{ name = 'ops-admin' } | New-PfbApiToken -Confirm:$false -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                $QueryParams['admin_names'] -eq 'ops-admin'
+            }
+        }
+
+        It 'throws on a piped Get-PfbApiToken-shaped object' {
+            {
+                [PSCustomObject]@{ admin = [PSCustomObject]@{ name = 'ops-admin' }; api_token = @{} } |
+                    New-PfbApiToken -Confirm:$false -Array $fakeArray -ErrorAction Stop
+            } | Should -Throw -ExpectedMessage '*stringified object*'
+        }
+
+        It 'issues no request when the coercion guard fires' {
+            try {
+                [PSCustomObject]@{ admin = [PSCustomObject]@{ name = 'ops-admin' }; api_token = @{} } |
+                    New-PfbApiToken -Confirm:$false -Array $fakeArray -ErrorAction Stop
+            } catch { }
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 0 -Exactly
+        }
+    }
 }

--- a/Tests/New-PfbApiToken.Tests.ps1
+++ b/Tests/New-PfbApiToken.Tests.ps1
@@ -123,6 +123,15 @@ Describe 'New-PfbApiToken - query parameters (#31)' {
             "$warnings" | Should -BeLike '*-Attributes*'
         }
 
+        It 'warns once for the whole invocation, not once per piped name' {
+            # -Attributes binds once for the whole invocation, so the warning lives in begin.
+            # Emitted from process it would repeat per item in the bulk-rotation flow.
+            $warnings = @()
+            'ops-admin', 'svc-admin' | New-PfbApiToken -Attributes @{ ignored = 'x' } -Confirm:$false -Array $fakeArray -WarningVariable warnings -WarningAction SilentlyContinue
+
+            @($warnings).Count | Should -Be 1
+        }
+
         It 'does not warn when -Attributes is absent' {
             $warnings = @()
             New-PfbApiToken -Name 'ops-admin' -Confirm:$false -Array $fakeArray -WarningVariable warnings -WarningAction SilentlyContinue
@@ -133,6 +142,13 @@ Describe 'New-PfbApiToken - query parameters (#31)' {
 
     Context 'a request with no selector never reaches the wire (#99)' {
 
+        # NOTE: the bare-call and -Timeout-only cases below are ALSO caught upstream by
+        # AmbiguousParameterSet -- two parameter sets with no DefaultParameterSetName and no
+        # set-unique bound parameter fail to resolve before `process` is entered, with or
+        # without the Mandatory flags. They are kept as regression rails, but they do not
+        # prove the Mandatory flags work. The empty-string tests at the end of this block are
+        # the ones that discriminate: pre-fix, -Name '' bound legally to the ByName set,
+        # `if ($Name)` was false, and an unfiltered POST went out.
         It 'throws on a bare call' {
             { New-PfbApiToken -Array $fakeArray -Confirm:$false -ErrorAction Stop } | Should -Throw
         }
@@ -145,6 +161,16 @@ Describe 'New-PfbApiToken - query parameters (#31)' {
 
         It 'issues no request when only -Timeout is supplied' {
             try { New-PfbApiToken -Timeout 86400000 -Array $fakeArray -Confirm:$false -ErrorAction Stop } catch { }
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 0 -Exactly
+        }
+
+        It 'throws when the selector is an empty string' {
+            { New-PfbApiToken -Name '' -Array $fakeArray -Confirm:$false -ErrorAction Stop } | Should -Throw
+        }
+
+        It 'issues no request when the selector is an empty string' {
+            try { New-PfbApiToken -Name '' -Array $fakeArray -Confirm:$false -ErrorAction Stop } catch { }
 
             Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 0 -Exactly
         }

--- a/Tests/PfbCmdletParamTools.Tests.ps1
+++ b/Tests/PfbCmdletParamTools.Tests.ps1
@@ -519,10 +519,10 @@ Describe 'Get-PfbWireNameForParameter: switch-to-literal pattern' {
         $ast = [System.Management.Automation.Language.Parser]::ParseInput(
             'function Test-Fixture { param([switch]$Foo) $body = @{}; $body["bar"] = "literal" }', [ref]$tokens, [ref]$errs)
         $funcAst = $ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.FunctionDefinitionAst] }, $true) | Select-Object -First 1
-        Get-PfbWireNameForParameter -FunctionAst $funcAst -ParameterName 'Foo' -IsSwitchParameter | Should -BeNullOrEmpty
+        Get-PfbWireNameForParameter -FunctionAst $funcAst -ParameterName 'Foo' -IsBooleanLikeParameter | Should -BeNullOrEmpty
     }
 
-    It 'does NOT apply the switch-literal match when -IsSwitchParameter is not passed' {
+    It 'does NOT apply the switch-literal match when -IsBooleanLikeParameter is not passed' {
         $tokens = $null; $errs = $null
         $ast = [System.Management.Automation.Language.Parser]::ParseInput(
             'function Test-Fixture { param([switch]$Foo) if ($Foo) { $body["bar"] = "literal" } }', [ref]$tokens, [ref]$errs)
@@ -1226,5 +1226,122 @@ function Get-PfbFixtureOrderAlpha {
             'Get-PfbFixtureOrderZulu|Apple'
             'Get-PfbFixtureOrderZulu|Zebra'
         )
+    }
+}
+
+Describe 'Conditional right-hand side awareness (issue #99)' {
+    # New-PfbFileSystemReplicaLink sends a [Nullable[bool]] as
+    # `$queryParams['remote_default_exports'] = if ($RemoteDefaultExports) { 'true' } else { 'false' }`
+    # -- the $false value must reach the wire, so the assignment is guarded on
+    # $PSBoundParameters.ContainsKey rather than on truthiness. The tracer refused that shape
+    # twice over: its only constant-value branch was gated on [switch], and an if-EXPRESSION
+    # right-hand side matched no branch at all.
+    BeforeAll {
+        $script:condDir = Join-Path $TestDrive 'Conditional/Public'
+        New-Item -ItemType Directory -Path $script:condDir -Force | Out-Null
+
+        Set-Content -Path (Join-Path $script:condDir 'New-PfbFixtureConditional.ps1') -Value @'
+function New-PfbFixtureConditional {
+    [CmdletBinding()]
+    param(
+        [Parameter()] [Nullable[bool]]$RemoteDefaultExports,
+        [Parameter()] [bool]$PlainBool,
+        [Parameter()] [switch]$SwitchFlag,
+        [Parameter()] [Nullable[bool]]$Negated,
+        [Parameter()] [string]$NotBoolean,
+        [Parameter()] [PSCustomObject]$Array
+    )
+
+    $queryParams = @{}
+    if ($PSBoundParameters.ContainsKey('RemoteDefaultExports')) {
+        $queryParams['remote_default_exports'] = if ($RemoteDefaultExports) { 'true' } else { 'false' }
+    }
+    if ($PSBoundParameters.ContainsKey('PlainBool')) {
+        $queryParams['plain_bool'] = if ($PlainBool) { 'true' } else { 'false' }
+    }
+    $queryParams['switch_flag'] = if ($SwitchFlag) { 'true' } else { 'false' }
+    $queryParams['negated'] = if (-not $Negated) { 'false' } else { 'true' }
+    $queryParams['not_boolean'] = if ($NotBoolean) { 'true' } else { 'false' }
+    Invoke-PfbApiRequest -Array $Array -Method POST -Endpoint 'conditional' -QueryParams $queryParams
+}
+'@
+
+        Set-Content -Path (Join-Path $script:condDir 'New-PfbFixtureConditionalLiteral.ps1') -Value @'
+function New-PfbFixtureConditionalLiteral {
+    [CmdletBinding()]
+    param(
+        [Parameter()] [Nullable[bool]]$Enabled,
+        [Parameter()] [PSCustomObject]$Array
+    )
+
+    $queryParams = @{
+        'enabled' = if ($Enabled) { 'true' } else { 'false' }
+    }
+    Invoke-PfbApiRequest -Array $Array -Method POST -Endpoint 'conditional-literal' -QueryParams $queryParams
+}
+'@
+
+        $script:condInventory = Get-PfbCmdletParameterInventory -PublicDirectory $script:condDir
+    }
+
+    It 'resolves a <Type> parameter assigned a two-branch constant if-expression' -ForEach @(
+        @{ Type = '[Nullable[bool]]'; Parameter = 'RemoteDefaultExports'; WireName = 'remote_default_exports' }
+        @{ Type = '[bool]';           Parameter = 'PlainBool';            WireName = 'plain_bool' }
+        @{ Type = '[switch]';         Parameter = 'SwitchFlag';           WireName = 'switch_flag' }
+        @{ Type = '-not, swapped';    Parameter = 'Negated';              WireName = 'negated' }
+    ) {
+        $rec = $script:condInventory | Where-Object { $_.Cmdlet -eq 'New-PfbFixtureConditional' -and $_.Parameter -eq $Parameter }
+        $rec.WireName | Should -Be $WireName
+        $rec.Surface | Should -Be 'Typed'
+    }
+
+    It 'refuses the same shape for a parameter that is not boolean-like' {
+        $rec = $script:condInventory | Where-Object { $_.Cmdlet -eq 'New-PfbFixtureConditional' -and $_.Parameter -eq 'NotBoolean' }
+        $rec.WireName | Should -BeNullOrEmpty
+        $rec.Surface | Should -Be 'TypedUnresolved'
+    }
+
+    It 'resolves the same shape inside a hashtable literal initializer' {
+        $rec = $script:condInventory | Where-Object { $_.Cmdlet -eq 'New-PfbFixtureConditionalLiteral' -and $_.Parameter -eq 'Enabled' }
+        $rec.WireName | Should -Be 'enabled'
+        $rec.Surface | Should -Be 'Typed'
+        $rec.Endpoint | Should -Be 'conditional-literal'
+        $rec.Method | Should -Be 'POST'
+    }
+
+    It 'resolves end-to-end through Get-PfbWireNameForParameter to the wire name AND the target variable' {
+        $tokens = $null; $errs = $null
+        $ast = [System.Management.Automation.Language.Parser]::ParseInput(@'
+function Test-Fixture {
+    param([Nullable[bool]]$RemoteDefaultExports)
+    $queryParams = @{}
+    if ($PSBoundParameters.ContainsKey('RemoteDefaultExports')) {
+        $queryParams['remote_default_exports'] = if ($RemoteDefaultExports) { 'true' } else { 'false' }
+    }
+}
+'@, [ref]$tokens, [ref]$errs)
+        $funcAst = $ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.FunctionDefinitionAst] }, $true) | Select-Object -First 1
+        $result = Get-PfbWireNameForParameter -FunctionAst $funcAst -ParameterName 'RemoteDefaultExports' -IsBooleanLikeParameter
+        $result.WireName | Should -Be 'remote_default_exports'
+        $result.TargetVariable | Should -Be 'queryParams'
+    }
+
+    # The guard on the "never guess" contract: every one of these is boolean-like, so only the
+    # SHAPE rules keep them refused.
+    It 'refuses <Case>' -ForEach @(
+        @{ Case = 'a condition naming a DIFFERENT variable'
+           Body = '$queryParams["k"] = if ($Other) { "true" } else { "false" }' }
+        @{ Case = 'a branch that is not a constant'
+           Body = '$queryParams["k"] = if ($Param) { $Other } else { "false" }' }
+        @{ Case = 'a missing else clause'
+           Body = '$queryParams["k"] = if ($Param) { "true" }' }
+        @{ Case = 'an elseif, so Clauses.Count is 2'
+           Body = '$queryParams["k"] = if ($Param) { "true" } elseif ($Other) { "maybe" } else { "false" }' }
+    ) {
+        $tokens = $null; $errs = $null
+        $source = 'function Test-Fixture { param([Nullable[bool]]$Param, [Nullable[bool]]$Other) ' + $Body + ' }'
+        $ast = [System.Management.Automation.Language.Parser]::ParseInput($source, [ref]$tokens, [ref]$errs)
+        $funcAst = $ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.FunctionDefinitionAst] }, $true) | Select-Object -First 1
+        Get-PfbWireNameForParameter -FunctionAst $funcAst -ParameterName 'Param' -IsBooleanLikeParameter | Should -BeNullOrEmpty
     }
 }

--- a/Tests/Remove-PfbApiToken.Tests.ps1
+++ b/Tests/Remove-PfbApiToken.Tests.ps1
@@ -1,0 +1,144 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    $moduleRoot = Split-Path -Parent $PSScriptRoot
+    $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
+    Import-Module $manifest -Force
+
+    $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
+}
+
+Describe 'Remove-PfbApiToken (#99)' {
+
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+    }
+
+    Context 'admin selector uses the real wire names (regression: was names/ids)' {
+
+        It 'sends -Name as admin_names, NOT names' {
+            Remove-PfbApiToken -Name 'ops-admin' -Confirm:$false -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                $Method -eq 'DELETE' -and $Endpoint -eq 'admins/api-tokens' -and
+                $QueryParams['admin_names'] -eq 'ops-admin' -and
+                -not $QueryParams.ContainsKey('names')
+            }
+        }
+
+        It 'sends -Id as admin_ids, NOT ids' {
+            Remove-PfbApiToken -Id 'admin-1' -Confirm:$false -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                $QueryParams['admin_ids'] -eq 'admin-1' -and
+                -not $QueryParams.ContainsKey('ids')
+            }
+        }
+
+        It 'accepts -AdminNames as an alias of -Name' {
+            Remove-PfbApiToken -AdminNames 'ops-admin' -Confirm:$false -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                $QueryParams['admin_names'] -eq 'ops-admin'
+            }
+        }
+
+        It 'accepts -AdminIds as an alias of -Id' {
+            Remove-PfbApiToken -AdminIds 'admin-1' -Confirm:$false -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                $QueryParams['admin_ids'] -eq 'admin-1'
+            }
+        }
+
+        It 'exposes no separate -AdminNames/-AdminIds parameters (they are aliases only)' {
+            $params = (Get-Command Remove-PfbApiToken).Parameters
+            $params.Keys | Should -Not -Contain 'AdminNames'
+            $params.Keys | Should -Not -Contain 'AdminIds'
+            $params['Name'].Aliases | Should -Contain 'AdminNames'
+            $params['Id'].Aliases   | Should -Contain 'AdminIds'
+        }
+    }
+
+    Context 'a request with no selector never reaches the wire' {
+
+        It 'throws on a bare call' {
+            { Remove-PfbApiToken -Array $fakeArray -Confirm:$false -ErrorAction Stop } | Should -Throw
+        }
+
+        It 'issues no request on a bare call' {
+            try { Remove-PfbApiToken -Array $fakeArray -Confirm:$false -ErrorAction Stop } catch { }
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 0 -Exactly
+        }
+
+        It 'declares -Name and -Id as mandatory in their parameter sets' {
+            $cmd = Get-Command Remove-PfbApiToken
+            foreach ($p in 'Name', 'Id') {
+                $attr = $cmd.Parameters[$p].Attributes |
+                    Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] }
+                @($attr).Mandatory | Should -Contain $true
+            }
+        }
+    }
+
+    Context 'pipeline binding' {
+
+        It 'binds -Name by value from a plain string' {
+            'ops-admin' | Remove-PfbApiToken -Confirm:$false -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                $QueryParams['admin_names'] -eq 'ops-admin'
+            }
+        }
+
+        It 'issues one DELETE per piped name' {
+            'ops-admin', 'svc-admin' | Remove-PfbApiToken -Confirm:$false -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 2 -Exactly
+        }
+
+        It 'binds -Name by property name from a Get-PfbAdmin-shaped object' {
+            [PSCustomObject]@{ name = 'ops-admin' } | Remove-PfbApiToken -Confirm:$false -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                $QueryParams['admin_names'] -eq 'ops-admin'
+            }
+        }
+    }
+
+    Context 'coercion guard' {
+
+        It 'throws on a piped Get-PfbApiToken-shaped object' {
+            {
+                [PSCustomObject]@{ admin = [PSCustomObject]@{ name = 'ops-admin' }; api_token = @{} } |
+                    Remove-PfbApiToken -Confirm:$false -Array $fakeArray -ErrorAction Stop
+            } | Should -Throw -ExpectedMessage '*stringified object*'
+        }
+
+        It 'issues no request when the guard fires' {
+            try {
+                [PSCustomObject]@{ admin = [PSCustomObject]@{ name = 'ops-admin' }; api_token = @{} } |
+                    Remove-PfbApiToken -Confirm:$false -Array $fakeArray -ErrorAction Stop
+            } catch { }
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 0 -Exactly
+        }
+    }
+
+    Context 'ShouldProcess' {
+
+        It 'issues no request under -WhatIf' {
+            Remove-PfbApiToken -Name 'ops-admin' -WhatIf -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 0 -Exactly
+        }
+
+        It 'issues the request under -Confirm:$false' {
+            Remove-PfbApiToken -Name 'ops-admin' -Confirm:$false -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly
+        }
+    }
+}

--- a/tools/lib/PfbCmdletParamTools.ps1
+++ b/tools/lib/PfbCmdletParamTools.ps1
@@ -76,8 +76,10 @@ function Test-PfbAssignmentGuardedBySwitch {
     .SYNOPSIS
         True if $Assignment is lexically inside an `if ($ParameterName) { ... }` clause
         whose condition is exactly a bare reference to $ParameterName -- the guard shape
-        Test-PfbAssignmentGuardedBySwitch's caller requires before trusting a literal
-        string assignment as switch-derived.
+        this function's caller requires before trusting a literal string assignment as
+        derived from that parameter. The caller's own gate is boolean-like (switch, bool,
+        or Nullable[bool]); this function tests only the guard shape and neither knows nor
+        cares which of those types the parameter has.
     #>
     [CmdletBinding()]
     param(

--- a/tools/lib/PfbCmdletParamTools.ps1
+++ b/tools/lib/PfbCmdletParamTools.ps1
@@ -155,8 +155,25 @@ function Test-PfbWireValueIsParameter {
             $Param                  -- direct
             @($Param)               -- array-wrapped
             $Param -join ','        -- joined into a plural query key
-            'literal'               -- ONLY for a [switch] whose mere presence is keyed to a
-                                       hardcoded string, and only inside an `if ($Param)` guard
+            'literal'               -- ONLY for a BOOLEAN-LIKE parameter whose mere presence is
+                                       keyed to a hardcoded string, and only inside an
+                                       `if ($Param)` guard
+            if ($Param) { 'a' } else { 'b' }
+                                    -- ONLY for a BOOLEAN-LIKE parameter, and only in exactly
+                                       that shape: one clause plus an else (no elseif), a
+                                       condition that is textually the bare `$Param` or
+                                       `-not $Param` and nothing more, and a single constant
+                                       statement in each branch. This is how a [Nullable[bool]]
+                                       reaches a string-valued query key (real:
+                                       New-PfbFileSystemReplicaLink's remote_default_exports,
+                                       whose $false must reach the wire, so the assignment is
+                                       guarded on $PSBoundParameters.ContainsKey rather than on
+                                       truthiness). Boolean-like means [switch], [bool] or
+                                       [Nullable[bool]] -- see -IsBooleanLikeParameter, computed
+                                       by Get-PfbCmdletParameterInventory from the declared
+                                       StaticType. A wider condition or a non-constant branch
+                                       means the wire value is derived from something other
+                                       than this parameter alone, and stays refused.
         Refused (correctly, per this file's "never guess" contract): anything else, e.g.
         `"$Param"`. The array-projection shape `@($Param | ForEach-Object { @{ name = $_ } })`
         is also refused HERE by design -- it is matched by the sibling
@@ -172,7 +189,7 @@ function Test-PfbWireValueIsParameter {
         [Parameter(Mandatory)]
         [string]$ParameterName,
 
-        [switch]$IsSwitchParameter
+        [switch]$IsBooleanLikeParameter
     )
 
     $text = $ValueAst.Extent.Text.Trim()
@@ -187,8 +204,33 @@ function Test-PfbWireValueIsParameter {
         if ($joinLeft -and $joinLeft.VariablePath.UserPath -eq $ParameterName) { return $true }
     }
 
-    if ($IsSwitchParameter -and $expr -is [System.Management.Automation.Language.StringConstantExpressionAst]) {
+    if ($IsBooleanLikeParameter -and $expr -is [System.Management.Automation.Language.StringConstantExpressionAst]) {
         if (Test-PfbAssignmentGuardedBySwitch -Assignment $ValueAst -ParameterName $ParameterName) { return $true }
+    }
+
+    # `if ($Param) { 'true' } else { 'false' }` as the VALUE half. An if-expression right-hand
+    # side arrives as an IfStatementAst directly (Resolve-PfbSingleExpression peels only the
+    # Pipeline/CommandExpression wrappers a bare expression gets, and correctly leaves this
+    # alone). Every condition below is load-bearing: without them the branch would credit the
+    # parameter with a key whose value some OTHER expression decides.
+    if ($IsBooleanLikeParameter -and $expr -is [System.Management.Automation.Language.IfStatementAst]) {
+        $clauses = @($expr.Clauses)
+        if ($clauses.Count -eq 1 -and $null -ne $expr.ElseClause) {
+            $condition = $clauses[0].Item1.Extent.Text.Trim()
+            if ($condition -eq $simple -or $condition -eq ('-not ' + $simple)) {
+                $allConstant = $true
+                foreach ($block in @($clauses[0].Item2, $expr.ElseClause)) {
+                    if (@($block.Statements).Count -ne 1) { $allConstant = $false; break }
+                    # StringConstantExpressionAst derives from ConstantExpressionAst, so the one
+                    # test covers both the quoted and the bare-number forms.
+                    $branch = Resolve-PfbSingleExpression -Ast $block.Statements[0]
+                    if ($branch -isnot [System.Management.Automation.Language.ConstantExpressionAst]) {
+                        $allConstant = $false; break
+                    }
+                }
+                if ($allConstant) { return $true }
+            }
+        }
     }
 
     return $false
@@ -434,7 +476,7 @@ function Get-PfbWireNameForParameter {
         [Parameter(Mandatory)]
         [string]$ParameterName,
 
-        [switch]$IsSwitchParameter
+        [switch]$IsBooleanLikeParameter
     )
 
     $assignments = $FunctionAst.FindAll({
@@ -452,7 +494,7 @@ function Get-PfbWireNameForParameter {
         $keyExpr = $indexExpr.Index -as [System.Management.Automation.Language.StringConstantExpressionAst]
         if (-not $keyExpr) { continue }
 
-        if (Test-PfbWireValueIsParameter -ValueAst $assign.Right -ParameterName $ParameterName -IsSwitchParameter:$IsSwitchParameter) {
+        if (Test-PfbWireValueIsParameter -ValueAst $assign.Right -ParameterName $ParameterName -IsBooleanLikeParameter:$IsBooleanLikeParameter) {
             return [PSCustomObject]@{
                 WireName       = $keyExpr.Value
                 TargetVariable = $targetVar.VariablePath.UserPath
@@ -466,14 +508,14 @@ function Get-PfbWireNameForParameter {
     # New-PfbObjectStoreAccount, the whole Policy/*Rule family, ...). Runs after the index
     # form, not instead of it: a cmdlet routinely does both (literal initializer for its
     # -Name, then `$body['x'] = $X` lines), and both key sets must resolve.
-    $literalMatch = Get-PfbHashtableLiteralWireNameForParameter -FunctionAst $FunctionAst -ParameterName $ParameterName -IsSwitchParameter:$IsSwitchParameter
+    $literalMatch = Get-PfbHashtableLiteralWireNameForParameter -FunctionAst $FunctionAst -ParameterName $ParameterName -IsBooleanLikeParameter:$IsBooleanLikeParameter
     if ($literalMatch) { return $literalMatch }
 
     # Third idiom: a nested single-key REFERENCE OBJECT -- `$body['account'] = @{ name =
     # $Account }` -- whose wire field is the OUTER key. Runs strictly after both direct
     # forms above so it can only ever add a resolution, never rename one: a parameter that
     # already resolved via a direct assignment returned before reaching here.
-    $nestedMatch = Get-PfbNestedReferenceWireNameForParameter -FunctionAst $FunctionAst -ParameterName $ParameterName -IsSwitchParameter:$IsSwitchParameter
+    $nestedMatch = Get-PfbNestedReferenceWireNameForParameter -FunctionAst $FunctionAst -ParameterName $ParameterName -IsBooleanLikeParameter:$IsBooleanLikeParameter
     if ($nestedMatch) { return $nestedMatch }
 
     # No literal assignment of any shape in this function body -- but the parameter may
@@ -512,7 +554,7 @@ function Get-PfbHashtableLiteralWireNameForParameter {
         [Parameter(Mandatory)]
         [string]$ParameterName,
 
-        [switch]$IsSwitchParameter
+        [switch]$IsBooleanLikeParameter
     )
 
     $assignments = @($FunctionAst.FindAll({
@@ -535,7 +577,7 @@ function Get-PfbHashtableLiteralWireNameForParameter {
             $keyExpr = $pair.Item1 -as [System.Management.Automation.Language.StringConstantExpressionAst]
             if (-not $keyExpr) { continue }
 
-            if (Test-PfbWireValueIsParameter -ValueAst $pair.Item2 -ParameterName $ParameterName -IsSwitchParameter:$IsSwitchParameter) {
+            if (Test-PfbWireValueIsParameter -ValueAst $pair.Item2 -ParameterName $ParameterName -IsBooleanLikeParameter:$IsBooleanLikeParameter) {
                 return [PSCustomObject]@{
                     WireName       = $keyExpr.Value
                     TargetVariable = $targetVar.VariablePath.UserPath
@@ -596,7 +638,7 @@ function Get-PfbNestedReferenceWireNameForParameter {
         [Parameter(Mandatory)]
         [string]$ParameterName,
 
-        [switch]$IsSwitchParameter
+        [switch]$IsBooleanLikeParameter
     )
 
     # Local predicate: is $Candidate a single-string-key hashtable literal whose one value
@@ -612,7 +654,7 @@ function Get-PfbNestedReferenceWireNameForParameter {
         if ($hash.KeyValuePairs.Count -ne 1) { return $false }
         $innerPair = $hash.KeyValuePairs[0]
         if (-not ($innerPair.Item1 -as [System.Management.Automation.Language.StringConstantExpressionAst])) { return $false }
-        return (Test-PfbWireValueIsParameter -ValueAst $innerPair.Item2 -ParameterName $ParameterName -IsSwitchParameter:$IsSwitchParameter)
+        return (Test-PfbWireValueIsParameter -ValueAst $innerPair.Item2 -ParameterName $ParameterName -IsBooleanLikeParameter:$IsBooleanLikeParameter)
     }
 
     $assignments = @($FunctionAst.FindAll({
@@ -1012,8 +1054,16 @@ function Get-PfbCmdletParameterInventory {
                     }
                 }
 
-                $isSwitch = $p.StaticType -eq [System.Management.Automation.SwitchParameter]
-                $wireInfo = Get-PfbWireNameForParameter -FunctionAst $funcAst -ParameterName $paramName -IsSwitchParameter:$isSwitch
+                # Boolean-like, not switch-only: a [bool] or [Nullable[bool]] reaches a wire key
+                # through the same presence-keyed literal and if-expression shapes a [switch]
+                # does. [Nullable[bool]]'s StaticType is System.Nullable`1[[System.Boolean,...]],
+                # so compare against the constructed type rather than string-matching its name.
+                $isBooleanLike = $p.StaticType -in @(
+                    [System.Management.Automation.SwitchParameter]
+                    [bool]
+                    [System.Nullable[bool]]
+                )
+                $wireInfo = Get-PfbWireNameForParameter -FunctionAst $funcAst -ParameterName $paramName -IsBooleanLikeParameter:$isBooleanLike
                 if (-not $wireInfo) {
                     $accumulatorName = Find-PfbAccumulatorVariable -FunctionAst $funcAst -ParameterName $paramName
                     if ($accumulatorName) {


### PR DESCRIPTION
Fixes #99.

## The bug

`/admins/api-tokens` selects its target with `admin_names` / `admin_ids`. It accepts no
generic `names` / `ids` key in any spec version, and FlashBlade silently drops a query
parameter an endpoint does not declare. All three API-token cmdlets sent `names` / `ids`.

For `Remove-PfbApiToken` that is destructive, exactly as reported: the DELETE arrived with
no target at all, so the endpoint fell back to the **authenticated** administrator.
`Remove-PfbApiToken -Name someone-else` destroyed the calling session's own token and left
the named administrator's token untouched. `Get-` returned every administrator's row
regardless of `-Name`. `New-` created a token for whoever was authenticated rather than for
the named account.

### One correction to the issue as filed

The issue describes the `Get-PfbApiToken` defect as a credential leak. It is not. Token
values come back masked by default, and `expose_api_token=true` un-masks only the *caller's
own* token — verified live: the caller's row returned a full-length token while a second
administrator's row stayed masked at 4 characters. The `Get-` defect is an over-broad result
set, not exposure of anyone else's credential. The `Remove-PfbApiToken` finding stands
exactly as filed.

## What changed

**`Remove-PfbApiToken`** — sends `admin_names` / `admin_ids`. Selector is now mandatory.

**`Get-PfbApiToken`** — sends `admin_names` / `admin_ids`, and gains `-ExposeApiToken`,
which maps to the `expose_api_token` query parameter the endpoint has declared since REST
2.0 and no cmdlet previously reached.

**`New-PfbApiToken`** — sends `admin_names` / `admin_ids`; selector is now mandatory;
`-Name` gains `ValueFromPipeline` so bulk rotation works; and the cmdlet no longer sends a
request body. `POST /admins/api-tokens` declares no `requestBody` in any spec version, and
the docstring already claimed nothing passed via `-Attributes` reached the array — but the
code passed `-Body` unconditionally. Since `[bool]@{}` is `$true` in PowerShell (only `@()`
is falsy), an empty `{}` was serialised on every call and a supplied `-Attributes` went out
verbatim. `-Attributes` remains a declared parameter so no existing script fails to bind; it
now warns that it is a no-op.

**`Private/Assert-PfbAdminNameNotCoerced.ps1`** (new) — a shared guard, wired into all three
cmdlets. A `Get-PfbApiToken` row has no top-level `name` property (the administrator name is
nested at `.admin.name`), so piping one cmdlet's output into another would `ToString()` the
whole object onto a live query key. It now throws and tells the caller to pipe
`$_.admin.name`.

**`tools/lib/PfbCmdletParamTools.ps1`** — see "Why a tools change is in here" below.

## Behaviour changes existing scripts may notice

1. `New-PfbApiToken` and `Remove-PfbApiToken` now require `-Name` or `-Id`. A bare call
   previously acted on the authenticated administrator; it now fails at parameter binding.
2. `New-PfbApiToken -Attributes @{...}` no longer sends those values. It never should have —
   the endpoint has no request body — but a script relying on the old behaviour was relying
   on something the array was free to reject.
3. `Get-PfbApiToken | Get-PfbApiToken` now throws instead of silently returning every row.
4. `Remove-PfbApiToken -Name` is `[string]`, while `Get-PfbApiToken -Name` is `[string[]]`.
   This asymmetry predates the PR and is left alone deliberately: making a destructive cmdlet
   accept an array is a scope expansion, and passing an array today fails cleanly at binding
   rather than doing something surprising.

On the mandatory selectors, note what actually enforces what, since it is easy to
misattribute: a call supplying neither selector fails with `AmbiguousParameterSet` because
there are two parameter sets and no `DefaultParameterSetName` — that fires with or without
`Mandatory`. `Mandatory` is what rejects an empty-string selector, via
`EmptyStringNotAllowed`. Both fire at binding time, so the in-`process` `throw` in each
cmdlet is unreachable today. It is kept as a backstop and commented as such, because adding
a `DefaultParameterSetName` or relaxing a `Mandatory` flag later would silently re-open this
issue.

## Why a tools change is in here

Regenerating `Reports/` surfaced a defect in the static wire-name tracer, unrelated to
`/admins/api-tokens`. `Test-PfbWireValueIsParameter` refused an `if`-expression on the value
half of a wire-key assignment, and gated its only constant-value branch on the parameter
being a `[switch]`. `New-PfbFileSystemReplicaLink` sends `remote_default_exports` as
`if ($RemoteDefaultExports) { 'true' } else { 'false' }` from a `[Nullable[bool]]`, so it
failed both tests and the tracer reported an implemented parameter as an unimplemented gap,
downgrading `POST /file-system-replica-links` to `partial` confidence.

The gate widens from switch-only to boolean-like (`switch`, `bool`, `Nullable[bool]`), and
an `IfStatementAst` right-hand side is accepted only when it has exactly one clause plus an
`else`, the condition is a bare `$Param` or `-not $Param`, and every branch is a single
constant. Every other shape stays refused, per that file's never-guess contract — probed
against `$Param -eq $true`, `!$Param`, nested `if`, a trailing statement in a branch, and an
empty body, all of which land on the refusing side. Module-wide this resolved exactly one new
parameter.

**No cmdlet was changed to satisfy the tracer.** `New-PfbFileSystemReplicaLink` is untouched;
guarding on `$PSBoundParameters.ContainsKey(...)` is the correct idiom for a nullable bool
whose `$false` must reach the wire.

## About the `Reports/` diff

Larger than this change warrants, and most of it is not from this PR. `main`'s committed
reports are stale: the `update-api-capability-map` workflow has been unable to open its PR
since 2026-07-24 (`GitHub Actions is not permitted to create or approve pull requests` — a
repo Actions setting), so regenerating picks up already-merged work alongside ours.

I verified this rather than assuming it. Regenerating the two reports from **unmodified**
`main` source produces output byte-identical to the existing
`automated/update-api-capability-map` branch. Measured against that reproducible baseline,
this PR's entire report delta is four things:

| Change | Cause |
|---|---|
| `DELETE /admins/api-tokens` gaps lose `admin_ids`, `admin_names` | this fix |
| `GET /admins/api-tokens` gaps lose `admin_ids`, `admin_names`, `expose_api_token` | this fix |
| `POST /file-system-replica-links` `partial` → `high`, `remote_default_exports` leaves gaps | tracer fix |
| `RemoteDefaultExports` leaves the typed-but-unresolved list, 40 → 39 | tracer fix |

The aggregates follow from those: missing query parameters 953 → 947, partial-confidence
endpoints 60 → 59, and systemic gaps 246 → 250 because six gaps that endpoint already carried
stop being suppressed from the high-confidence roll-up once it is promoted. `names` and `ids`
cmdlet counts drop by two each as `Get-` and `Remove-PfbApiToken` stop using the generic keys.

Merging `automated/update-api-capability-map` first would shrink this PR's report diff to only
the four rows above.

## Testing

Unit: 54 tests across the three cmdlets plus the shared guard, passing under **both**
Windows PowerShell 5.1 and pwsh 7. The tracer change adds coverage in
`Tests/PfbCmdletParamTools.Tests.ps1`, also green on both editions.

Live: verified against a FlashBlade running Purity//FB 4.8.2 / REST 2.26.

- `Get-PfbApiToken` unfiltered returned 2 rows; `-Name <admin>` returned exactly 1 — the fix.
- Token values masked by default on all rows; `-ExposeApiToken` un-masked only the caller's
  own row.
- `New-PfbApiToken` succeeded with **no request body**, confirming the `-Body` removal.
- `Remove-PfbApiToken` against a disposable service account removed that account's token,
  and the calling session's own token still worked afterwards — an authenticated call
  succeeded rather than returning `401 Authentication failed`. That is the regression this
  issue exists for.

The destructive step was run only against a disposable service account, never against the
account whose token the session was authenticated with.

## Not included

No version bump and no `CHANGELOG.md` edit — those are the maintainer's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
