### PR TITLE
ci: run the ~23% of the suite CI was silently skipping, and gate against it recurring (#63)

### DIFF
--- a/.github/workflows/cross-platform-tests.yml
+++ b/.github/workflows/cross-platform-tests.yml
@@ -25,9 +25,63 @@ on:
   workflow_call: {}
 
 jobs:
+  # Issue #63: tools/specs/ is a ~50MB cache of raw OpenAPI specs, gitignored because it is a
+  # build input rather than source, so on a bare runner it does not exist. Every tooling test
+  # gated on its presence skipped gracefully while the job reported success -- roughly 23% of
+  # the suite, including the absolute-path regression guards from PR #62, invisible in the run
+  # summary. This job materialises the cache once per run and hands it to every test leg.
+  #
+  # The cache key prefix is deliberately shared with update-api-capability-map.yml, so a warm
+  # cache written by either workflow serves both. Update-PfbApiSpecs.ps1 skips any version
+  # already on disk, so a cache hit means only newly-published versions get fetched instead of
+  # the full ~29-version history.
+  #
+  # An artifact rather than a per-leg cache restore: it fetches from the published spec index
+  # at most once per run instead of up to four times, and it is immune to cache key/branch
+  # scoping differences across the matrix. 29 JSON files, ~50MB raw, which compress well.
+  prepare-specs:
+    name: Prepare API spec cache
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Restore cached spec files
+        uses: actions/cache/restore@v6
+        with:
+          path: tools/specs
+          key: pfb-specs-${{ github.run_id }}
+          restore-keys: |
+            pfb-specs-
+
+      - name: Fetch any missing REST API spec versions
+        shell: pwsh
+        run: ./tools/Update-PfbApiSpecs.ps1
+
+      # The whole point of this job. A silent no-op here would put us straight back to the
+      # green-but-empty runs issue #63 is about, so an empty result is a hard failure.
+      - name: Assert the spec set is non-empty
+        shell: pwsh
+        run: ./scripts/Assert-PfbSpecCache.ps1
+
+      - name: Save spec cache
+        uses: actions/cache/save@v6
+        if: always()
+        with:
+          path: tools/specs
+          key: pfb-specs-${{ github.run_id }}
+
+      - name: Publish specs to the test jobs
+        uses: actions/upload-artifact@v4
+        with:
+          name: pfb-specs
+          path: tools/specs
+          retention-days: 1
+
   test-pwsh:
     name: Test (${{ matrix.os }}, pwsh)
     runs-on: ${{ matrix.os }}
+    needs: prepare-specs
     strategy:
       fail-fast: false
       matrix:
@@ -35,6 +89,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+
+      # Issue #63: without this, every tools/specs-gated test skips and the job still passes.
+      - name: Download API spec cache
+        uses: actions/download-artifact@v4
+        with:
+          name: pfb-specs
+          path: tools/specs
 
       # Pinned + cached; see .github/actions/install-test-modules/action.yml for why
       # (including why Posh-SSH is needed at all).
@@ -57,9 +118,19 @@ jobs:
   test-windows-powershell-5-1:
     name: Test (windows-latest, Windows PowerShell 5.1)
     runs-on: windows-latest
+    needs: prepare-specs
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+
+      # Wired here too, for symmetry with the pwsh job. The tools/specs-gated Describes are
+      # additionally PS7-gated so they still skip on this leg, but a future spec-dependent
+      # test that does NOT carry the PS7 guard then works with no workflow change.
+      - name: Download API spec cache
+        uses: actions/download-artifact@v4
+        with:
+          name: pfb-specs
+          path: tools/specs
 
       # Same pinned modules and same cache entry as the pwsh job on this OS -- the saved
       # files are edition-independent (Pester 6.0.1 declares PowerShellVersion = '5.1').

--- a/.github/workflows/cross-platform-tests.yml
+++ b/.github/workflows/cross-platform-tests.yml
@@ -72,7 +72,7 @@ jobs:
           key: pfb-specs-${{ github.run_id }}
 
       - name: Publish specs to the test jobs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: pfb-specs
           path: tools/specs
@@ -92,7 +92,7 @@ jobs:
 
       # Issue #63: without this, every tools/specs-gated test skips and the job still passes.
       - name: Download API spec cache
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: pfb-specs
           path: tools/specs
@@ -124,7 +124,7 @@ jobs:
       # additionally PS7-gated so they still skip on this leg, but a future spec-dependent
       # test that does NOT carry the PS7 guard then works with no workflow change.
       - name: Download API spec cache
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: pfb-specs
           path: tools/specs

--- a/.github/workflows/cross-platform-tests.yml
+++ b/.github/workflows/cross-platform-tests.yml
@@ -104,16 +104,13 @@ jobs:
         with:
           shell: pwsh
 
+      # Suite invocation + the issue-#63 coverage gate live in scripts/Invoke-PfbCiPester.ps1
+      # rather than inline here: this same block was copy-pasted in three places across two
+      # workflows, and all three needed the same change. A script is also lintable, diffable
+      # and runnable outside Actions, which YAML-embedded PowerShell is not.
       - name: Run Pester tests
         shell: pwsh
-        run: |
-          Import-Module Pester -MinimumVersion 5.0 -Force
-          Import-Module Posh-SSH -Force
-          $cfg = New-PesterConfiguration
-          $cfg.Run.Path = 'Tests'
-          $cfg.Run.Exit = $true
-          $cfg.Output.Verbosity = 'Detailed'
-          Invoke-Pester -Configuration $cfg
+        run: ./scripts/Invoke-PfbCiPester.ps1 -Edition pwsh7
 
   test-windows-powershell-5-1:
     name: Test (windows-latest, Windows PowerShell 5.1)
@@ -141,13 +138,10 @@ jobs:
         with:
           shell: powershell
 
+      # `shell:` stays per-leg and must remain a literal (see the header note about the
+      # matrix context) -- it selects the interpreter. -Edition selects only which
+      # Tests/coverage-baseline.psd1 block applies, since the two editions legitimately
+      # differ by ~200 skips.
       - name: Run Pester tests
         shell: powershell
-        run: |
-          Import-Module Pester -MinimumVersion 5.0 -Force
-          Import-Module Posh-SSH -Force
-          $cfg = New-PesterConfiguration
-          $cfg.Run.Path = 'Tests'
-          $cfg.Run.Exit = $true
-          $cfg.Output.Verbosity = 'Detailed'
-          Invoke-Pester -Configuration $cfg
+        run: ./scripts/Invoke-PfbCiPester.ps1 -Edition winps51

--- a/.github/workflows/update-api-capability-map.yml
+++ b/.github/workflows/update-api-capability-map.yml
@@ -32,6 +32,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      # Issue #63 follow-up: no CI job has ever compared a regenerated artifact against the
+      # committed one, so a generator change committed without regenerating passes silently.
+      # This had to be done by hand for #96 and #97. Hash before the build steps overwrite them.
+      - name: Capture committed artifact hashes
+        id: committed_hashes
+        shell: pwsh
+        run: |
+          foreach ($pair in @(@('capmap', 'Data/PfbCapabilityMap.json'), @('shapemap', 'Data/PfbResponseShapeMap.json'))) {
+              $hash = ''
+              if (Test-Path $pair[1]) { $hash = (Get-FileHash -Path $pair[1] -Algorithm SHA256).Hash }
+              "$($pair[0])=$hash" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+              Write-Host "$($pair[1]): $hash"
+          }
+
       - name: Capture previously-known REST versions
         id: previous
         shell: pwsh
@@ -90,6 +104,28 @@ jobs:
         shell: pwsh
         run: ./tools/Build-PfbResponseShapeMap.ps1
 
+      # Reports the outcome; does NOT fail the run. A legitimate diff is this workflow's whole
+      # purpose -- a new REST version changes both maps -- so a hard failure here would break
+      # the scheduled run every time a version is published. The value is that the drift is
+      # now NAMED in the run summary instead of being inferred from the PR body, which is how
+      # a stale committed artifact went unnoticed (issue #63's follow-up).
+      - name: Report regeneration diff
+        shell: pwsh
+        run: |
+          $rows = @()
+          foreach ($pair in @(
+              @('Data/PfbCapabilityMap.json', '${{ steps.committed_hashes.outputs.capmap }}'),
+              @('Data/PfbResponseShapeMap.json', '${{ steps.committed_hashes.outputs.shapemap }}')
+          )) {
+              $now = (Get-FileHash -Path $pair[0] -Algorithm SHA256).Hash
+              $state = 'byte-identical'
+              if ($pair[1] -ne $now) { $state = 'CHANGED -- committed copy was stale, or the inputs moved' }
+              $rows += "| ``$($pair[0])`` | $state |"
+              Write-Host "$($pair[0]): $state"
+          }
+          $lines = @('### Regeneration check', '', '| Artifact | Result |', '|---|---|') + $rows
+          ($lines -join [Environment]::NewLine) | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+
       - name: Build API drift report
         shell: pwsh
         run: ./tools/Build-PfbApiDriftReport.ps1
@@ -102,16 +138,14 @@ jobs:
         with:
           shell: pwsh
 
+      # The third copy of this block, now retired. It could not be replaced by a workflow_call
+      # to cross-platform-tests.yml: a reusable workflow runs on a FRESH runner with a FRESH
+      # checkout, so it would test the COMMITTED Data/ and Reports/ rather than the ones this
+      # job just regenerated -- which is the entire reason the step is inline here. A script
+      # runs in this job's workspace and has no such problem.
       - name: Run tests
         shell: pwsh
-        run: |
-          Import-Module Pester -MinimumVersion 5.0 -Force
-          Import-Module Posh-SSH -Force
-          $cfg = New-PesterConfiguration
-          $cfg.Run.Path = 'Tests'
-          $cfg.Run.Exit = $true
-          $cfg.Output.Verbosity = 'Detailed'
-          Invoke-Pester -Configuration $cfg
+        run: ./scripts/Invoke-PfbCiPester.ps1 -Edition pwsh7
 
       - name: Check for changes
         id: diff

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ docs/superpowers/
 # full history), committing these would bloat every clone of this repo, which today is
 # also what users copy directly into their PSModulePath (see README "From source").
 # Only the small derived Data/PfbCapabilityMap.json is committed/shipped.
+#
+# This is the ONLY tools/ exclusion. The generator scripts and libs under tools/ are
+# tracked and belong in the repo -- do not re-add a blanket `tools/` rule (see issue #63).
 tools/specs/
 
 # PowerShell
@@ -41,9 +44,6 @@ tools/specs/
 # Pinned test-only modules saved by .github/actions/install-test-modules (Save-Module
 # into a workspace-relative path so every OS/edition shares one cache location).
 .psmodules/
-
-# Not yet decided whether this should be tracked -- excluded for now
-tools/
 
 # OS
 Thumbs.db

--- a/Tests/CiCoverageGate.Tests.ps1
+++ b/Tests/CiCoverageGate.Tests.ps1
@@ -1,0 +1,152 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+<#
+.SYNOPSIS
+    Unit tests for scripts/Assert-PfbTestCoverage.ps1 -- the issue-#63 coverage gate.
+.DESCRIPTION
+    The gate is what turns the NEXT silent coverage hole into a red build, so a vacuous gate
+    would be worse than no gate: it would look like protection while providing none. That is
+    the same failure shape as issue #63 itself, so these tests exist to prove the gate actually
+    fails when it should.
+
+    The gate takes a result OBJECT rather than running Pester, so a hand-built stand-in
+    exercises it fully -- no real suite run, no dependency on the spec cache, and no risk of
+    invoking the aggregate suite (which exceeds the 600s tool-call cap; see the
+    run-pester-tests skill).
+
+    UNGATED, like the other #63 guards: the gate runs on both editions, so its tests must too.
+
+    5.1 CONSTRAINT: no ternaries, no ??, no ConvertFrom-Json -Depth.
+#>
+
+BeforeAll {
+    $script:repoRoot = Split-Path -Parent $PSScriptRoot
+    $script:gateScript = Join-Path $repoRoot 'scripts/Assert-PfbTestCoverage.ps1'
+
+    function New-FakeTest {
+        param([string[]]$Path, [string]$Result)
+        return [pscustomobject]@{ Path = $Path; Result = $Result }
+    }
+
+    function New-FakeResult {
+        param([object[]]$Tests, [int]$Passed = 0, [int]$Failed = 0, [int]$Skipped = 0, [int]$NotRun = 0)
+        return [pscustomobject]@{
+            Tests        = $Tests
+            PassedCount  = $Passed
+            FailedCount  = $Failed
+            SkippedCount = $Skipped
+            NotRunCount  = $NotRun
+        }
+    }
+
+    $script:baselineFile = Join-Path $TestDrive 'baseline.psd1'
+    @'
+@{
+    pwsh7 = @{
+        MaxSkipped = 5
+        RequiredDescribes = @(
+            'Block A'
+            'Block B'
+        )
+    }
+    winps51 = @{
+        MaxSkipped = 100
+        RequiredDescribes = @('Block A')
+    }
+}
+'@ | Set-Content -Path $baselineFile -Encoding UTF8
+}
+
+Describe 'Assert-PfbTestCoverage (issue #63 coverage gate)' {
+    It 'passes when every required Describe ran and the skip count is under the ceiling' {
+        $result = New-FakeResult -Passed 2 -Skipped 1 -Tests @(
+            (New-FakeTest -Path @('Block A', 'does a thing') -Result 'Passed'),
+            (New-FakeTest -Path @('Block B', 'does another') -Result 'Passed')
+        )
+        { & $gateScript -Result $result -Edition pwsh7 -BaselinePath $baselineFile } | Should -Not -Throw
+    }
+
+    It 'FAILS when a required Describe contributed no executed tests at all' {
+        # THE case this gate exists for, and the one a skip ceiling cannot see. A Describe
+        # filtered out of the run, or guarded false at BeforeAll time, contributes NEITHER a
+        # skip NOR a pass. Note SkippedCount is 0 here: a ceiling-only gate reads this run as
+        # perfectly healthy while an entire required block is silently absent.
+        $result = New-FakeResult -Passed 1 -Skipped 0 -Tests @(
+            (New-FakeTest -Path @('Block A', 'does a thing') -Result 'Passed')
+        )
+        { & $gateScript -Result $result -Edition pwsh7 -BaselinePath $baselineFile } |
+            Should -Throw -ExpectedMessage '*coverage gate failed*'
+    }
+
+    It 'FAILS when a required Describe is present but every test in it skipped' {
+        $result = New-FakeResult -Passed 1 -Skipped 1 -Tests @(
+            (New-FakeTest -Path @('Block A', 'does a thing') -Result 'Passed'),
+            (New-FakeTest -Path @('Block B', 'does another') -Result 'Skipped')
+        )
+        { & $gateScript -Result $result -Edition pwsh7 -BaselinePath $baselineFile } |
+            Should -Throw -ExpectedMessage '*coverage gate failed*'
+    }
+
+    It 'FAILS when the skip count exceeds the ceiling, even with every required Describe green' {
+        $result = New-FakeResult -Passed 2 -Skipped 6 -Tests @(
+            (New-FakeTest -Path @('Block A', 'does a thing') -Result 'Passed'),
+            (New-FakeTest -Path @('Block B', 'does another') -Result 'Passed')
+        )
+        { & $gateScript -Result $result -Edition pwsh7 -BaselinePath $baselineFile } |
+            Should -Throw -ExpectedMessage '*coverage gate failed*'
+    }
+
+    It 'counts NotRun toward the skip ceiling, not just Skipped' {
+        # Pester reports a block skipped at discovery time as NotRun rather than Skipped.
+        # Counting only one of the two would leave half the regression invisible.
+        $result = New-FakeResult -Passed 2 -Skipped 3 -NotRun 3 -Tests @(
+            (New-FakeTest -Path @('Block A', 'does a thing') -Result 'Passed'),
+            (New-FakeTest -Path @('Block B', 'does another') -Result 'Passed')
+        )
+        { & $gateScript -Result $result -Edition pwsh7 -BaselinePath $baselineFile } |
+            Should -Throw -ExpectedMessage '*coverage gate failed*'
+    }
+
+    It 'applies the per-edition block, so winps51 tolerates what pwsh7 rejects' {
+        # The editions differ by roughly 200 skips by design: every tooling Describe is
+        # PS7-gated. A single shared ceiling would be either a permanent false red on 5.1 or
+        # useless on 7.
+        $result = New-FakeResult -Passed 1 -Skipped 50 -Tests @(
+            (New-FakeTest -Path @('Block A', 'does a thing') -Result 'Passed')
+        )
+        { & $gateScript -Result $result -Edition winps51 -BaselinePath $baselineFile } | Should -Not -Throw
+        { & $gateScript -Result $result -Edition pwsh7 -BaselinePath $baselineFile } |
+            Should -Throw -ExpectedMessage '*coverage gate failed*'
+    }
+
+    It 'throws a clear error when the baseline file is missing rather than passing vacuously' {
+        $result = New-FakeResult -Passed 1 -Tests @()
+        { & $gateScript -Result $result -Edition pwsh7 -BaselinePath (Join-Path $TestDrive 'nope.psd1') } |
+            Should -Throw -ExpectedMessage '*not found*'
+    }
+}
+
+Describe 'coverage-baseline.psd1 (the real one)' {
+    It 'parses, and defines both editions with a ceiling and a non-empty allowlist' {
+        $real = Import-PowerShellDataFile -Path (Join-Path $repoRoot 'Tests/coverage-baseline.psd1')
+        foreach ($edition in @('pwsh7', 'winps51')) {
+            $real[$edition] | Should -Not -BeNullOrEmpty -Because "$edition must have a baseline block"
+            $real[$edition].MaxSkipped | Should -BeGreaterOrEqual 0
+            @($real[$edition].RequiredDescribes).Count | Should -BeGreaterThan 0 -Because 'an empty allowlist is a gate that checks nothing'
+        }
+    }
+
+    It 'names only Describe blocks that actually exist in Tests/' {
+        # A typo in an allowlist entry, or a Describe someone renamed, would red the build
+        # forever for the wrong reason. Catch both here rather than in CI.
+        $allSource = (Get-ChildItem -Path (Join-Path $repoRoot 'Tests') -Filter '*.Tests.ps1' |
+            ForEach-Object { Get-Content -Path $_.FullName -Raw }) -join "`n"
+        $real = Import-PowerShellDataFile -Path (Join-Path $repoRoot 'Tests/coverage-baseline.psd1')
+        foreach ($edition in @('pwsh7', 'winps51')) {
+            foreach ($name in @($real[$edition].RequiredDescribes)) {
+                # .Contains, not -like: a wildcard pattern treats ` as an escape character, and
+                # these Describe names contain characters -like would misread.
+                $allSource.Contains($name) | Should -BeTrue -Because "the $edition allowlist names a Describe that no test file defines: '$name'"
+            }
+        }
+    }
+}

--- a/Tests/CommittedDriftReport.Tests.ps1
+++ b/Tests/CommittedDriftReport.Tests.ps1
@@ -1,0 +1,119 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+<#
+.SYNOPSIS
+    REGRESSION guards over the COMMITTED Reports/PfbApiDriftReport.json|.md -- issue #63.
+.DESCRIPTION
+    Every other assertion about the drift report runs against a report the test itself
+    regenerates, which means it needs tools/specs/: a ~50MB cache of raw OpenAPI specs that is
+    gitignored (.gitignore:36 and again .gitignore:46) and therefore absent on every CI runner.
+    Those assertions reported "skipped", the job reported "success", and the coverage loss was
+    invisible in the run summary -- roughly 23% of the suite, including the absolute-path
+    guards added in PR #62.
+
+    The standing requirement those guards protect is about what is COMMITTED to the repository,
+    so reading the committed file directly is both cheaper and more on-point. It needs no cache,
+    no PowerShell 7, and no fixture tree, so these run on all four CI legs.
+
+    WHY A SEPARATE FILE, not a new Describe inside Build-PfbApiDriftReport.Tests.ps1:
+    that file's top-level BeforeAll invokes tools/Build-PfbApiDriftReport.ps1 (which carries
+    `#Requires -Version 7.0`) and calls `ConvertFrom-Json -Depth`, a parameter Windows
+    PowerShell 5.1 does not have. Every Describe in that file is PS7-gated, so on 5.1 the
+    BeforeAll never runs. Adding a single UNGATED block there would drag it in and kill all 65
+    tests in the file with a container failure -- see the run-pester-tests skill, which
+    documents that exact incident. A guard that must run everywhere needs a home that can.
+
+    5.1 CONSTRAINT: no `ConvertFrom-Json -Depth` (not a 5.1 parameter), no ternaries, no `??`.
+    Verified: 5.1 parses the 584KB committed report with a plain ConvertFrom-Json in ~180ms.
+#>
+
+BeforeAll {
+    $script:repoRoot = Split-Path -Parent $PSScriptRoot
+    $script:committedReportJsonPath = Join-Path $repoRoot 'Reports/PfbApiDriftReport.json'
+    $script:committedReportMdPath = Join-Path $repoRoot 'Reports/PfbApiDriftReport.md'
+    $script:committedReport = Get-Content -Path $committedReportJsonPath -Raw | ConvertFrom-Json
+}
+
+Describe 'Committed drift report (REGRESSION guard, no spec cache required)' {
+    # An absolute path in these artifacts causes two concrete harms, both observed in the wild
+    # before the original guards existed:
+    #   1. It published a developer's home-directory path (`C:\Users\<name>\...`) to the repo --
+    #      88 occurrences in each of PfbApiDriftReport.json and .md on main.
+    #   2. It made the committed file depend on WHERE it was generated. Regenerating from a git
+    #      worktree instead of the main checkout rewrote all 88 lines, producing 174 of 279 diff
+    #      lines of pure churn that buried the 3 real changes under review.
+    # `target.file` was always relative; `confidence.unresolvedParameters[].file` was not.
+
+    It 'the committed report files exist and are tracked inputs, not a build cache' {
+        # If this ever fails the rest of the block is meaningless, so it fails first and loudly
+        # rather than letting the scans below pass vacuously over a missing file.
+        Test-Path $committedReportJsonPath | Should -BeTrue
+        Test-Path $committedReportMdPath | Should -BeTrue
+        @($committedReport.parameterGaps).Count | Should -BeGreaterThan 0 -Because 'a report with no parameterGaps would make every scan below vacuous'
+    }
+
+    It 'emits no absolute path in any committed unresolvedParameters entry' {
+        $scanned = 0
+        $offenders = foreach ($g in $committedReport.parameterGaps) {
+            foreach ($u in @($g.confidence.unresolvedParameters)) {
+                $scanned++
+                if ($u.file -and ($u.file -match '^[A-Za-z]:[\\/]' -or $u.file -match '^[\\/]{1,2}')) {
+                    "$($g.endpoint) -$($u.parameter): $($u.file)"
+                }
+            }
+        }
+        $scanned | Should -BeGreaterThan 0 -Because 'a vacuous scan would pass this test without checking anything'
+        @($offenders) | Should -BeNullOrEmpty -Because 'unresolvedParameters[].file must be repo-relative, like target.file'
+    }
+
+    It 'emits no absolute path in any committed enriched body-property target entry' {
+        # NOTE: `target` hangs off each ENRICHED missingBodyProperties[] entry, not off the gap
+        # itself. An earlier draft of the regenerating sibling read $g.target.file -- always
+        # $null, so it passed vacuously and survived the mutation that broke its two siblings.
+        # Assert a non-zero population so it can never silently go hollow again.
+        $targets = foreach ($g in $committedReport.parameterGaps) {
+            foreach ($p in @($g.missingBodyProperties)) {
+                if ($p -isnot [string] -and $p.target -and $p.target.file) {
+                    [pscustomobject]@{ Endpoint = $g.endpoint; Field = $p.name; File = $p.target.file }
+                }
+            }
+        }
+        @($targets).Count | Should -BeGreaterThan 0 -Because 'a vacuous scan would pass this test without checking anything'
+        $offenders = @($targets | Where-Object { $_.File -match '^[A-Za-z]:[\\/]' -or $_.File -match '^[\\/]{1,2}' })
+        $offenders | Should -BeNullOrEmpty
+    }
+
+    It 'leaks no absolute path into the committed rendered markdown report' {
+        $md = Get-Content $committedReportMdPath -Raw
+        [regex]::Matches($md, '[A-Za-z]:\\{1,2}Users').Count | Should -Be 0
+        [regex]::Matches($md, '/home/runner').Count | Should -Be 0
+        [regex]::Matches($md, '/Users/[^/\s]+/').Count | Should -Be 0
+    }
+}
+
+Describe 'Committed drift report: annotations and summary fields survived generation' {
+    # These three have spec-cache-gated counterparts that assert the same properties on a
+    # REGENERATED report, which is the right check for "does the generator still wire this
+    # through". The committed-file versions answer a different and equally real question --
+    # "did the artifact we actually shipped keep them" -- and need no cache to do it, so they
+    # run on every leg instead of none. Both are kept deliberately; this is not a duplicate.
+
+    It 'carries docs/drift-annotations.json''s designDecision note on the context_names systemic gap' {
+        $ctx = $committedReport.systemicGaps | Where-Object { $_.name -eq 'context_names' }
+        $ctx | Should -Not -BeNullOrEmpty -Because 'context_names is expected to still be a systemic gap in the real API surface'
+        $ctx.annotations | Should -Not -BeNullOrEmpty
+        ($ctx.annotations | Select-Object -First 1).note | Should -Match 'not yet implemented'
+    }
+
+    It 'carries docs/drift-annotations.json''s liveTestingHazard note on a management-access-policies parameter-gap row' {
+        $row = $committedReport.parameterGaps | Where-Object { $_.endpoint -match 'management-access-policies' } | Select-Object -First 1
+        $row | Should -Not -BeNullOrEmpty -Because 'a management-access-policies endpoint is expected to still have a parameter gap'
+        $row.annotations | Should -Not -BeNullOrEmpty
+        ($row.annotations | Select-Object -First 1).note | Should -Match '403'
+    }
+
+    It 'carries phantomFieldCount as a non-negative integer and a non-empty conventionStrength' {
+        $committedReport.PSObject.Properties.Name | Should -Contain 'phantomFieldCount' -Because 'a property that vanished entirely would otherwise be indistinguishable from one holding zero'
+        $committedReport.phantomFieldCount | Should -BeGreaterOrEqual 0
+        @($committedReport.conventionStrength).Count | Should -BeGreaterThan 0 -Because 'an empty conventionStrength would make the committed report silently useless'
+    }
+}

--- a/Tests/CommittedDriftReport.Tests.ps1
+++ b/Tests/CommittedDriftReport.Tests.ps1
@@ -31,6 +31,10 @@ BeforeAll {
     $script:committedReportJsonPath = Join-Path $repoRoot 'Reports/PfbApiDriftReport.json'
     $script:committedReportMdPath = Join-Path $repoRoot 'Reports/PfbApiDriftReport.md'
     $script:committedReport = Get-Content -Path $committedReportJsonPath -Raw | ConvertFrom-Json
+    # The annotation SOURCE, so the guards below can compare the committed artifact against
+    # the file it was generated from rather than against a hardcoded copy of its prose.
+    $script:annotationSourcePath = Join-Path $repoRoot 'docs/drift-annotations.json'
+    $script:annotationSource = Get-Content -Path $annotationSourcePath -Raw | ConvertFrom-Json
 }
 
 Describe 'Committed drift report (REGRESSION guard, no spec cache required)' {
@@ -97,18 +101,61 @@ Describe 'Committed drift report: annotations and summary fields survived genera
     # "did the artifact we actually shipped keep them" -- and need no cache to do it, so they
     # run on every leg instead of none. Both are kept deliberately; this is not a duplicate.
 
-    It 'carries docs/drift-annotations.json''s designDecision note on the context_names systemic gap' {
-        $ctx = $committedReport.systemicGaps | Where-Object { $_.name -eq 'context_names' }
-        $ctx | Should -Not -BeNullOrEmpty -Because 'context_names is expected to still be a systemic gap in the real API surface'
-        $ctx.annotations | Should -Not -BeNullOrEmpty
-        ($ctx.annotations | Select-Object -First 1).note | Should -Match 'not yet implemented'
+    # WHY THESE TWO COMPARE AGAINST docs/drift-annotations.json RATHER THAN AGAINST LITERALS:
+    # an earlier draft pinned one field name ('context_names') and one note's wording
+    # ('not yet implemented'). Both move for legitimate reasons, and pinning them points the
+    # guard the wrong way:
+    #   - The notes are hand-written prose describing decisions that are still being made. A
+    #     test asserting 'not yet implemented' fails on the very PR that implements the thing
+    #     and reweords the note -- so the guard obstructs the change it should be indifferent to.
+    #   - WHICH fields are annotated moves too. A field stops appearing in systemicGaps once
+    #     the module starts sending it (see Get-PfbNonActionableParameters and
+    #     Get-PfbCentralInjectionSites: continuation_token is already gone for exactly this
+    #     reason). Naming one field makes an unrelated, correct improvement look like a
+    #     regression.
+    # What must never silently break -- and is what issue #63 was actually about -- is the
+    # WIRING: a note in the source file reaching the committed artifact unmodified. That is
+    # invariant under both kinds of movement, so it is what these assert. Each carries its own
+    # non-vacuity floor, because an annotation set that matched nothing would otherwise pass
+    # these by checking nothing at all.
+
+    It 'carries every field annotation from docs/drift-annotations.json into the committed systemic gaps, verbatim' {
+        $fieldNotes = @{}
+        foreach ($a in $annotationSource.annotations) {
+            if ($a.matchType -eq 'field') { $fieldNotes[$a.match] = $a.note }
+        }
+        $fieldNotes.Count | Should -BeGreaterThan 0 -Because 'docs/drift-annotations.json must carry at least one matchType=field annotation, or this test checks nothing'
+
+        $checked = 0
+        foreach ($gap in $committedReport.systemicGaps) {
+            if (-not $fieldNotes.ContainsKey($gap.name)) { continue }
+            $checked++
+            @($gap.annotations).Count | Should -BeGreaterThan 0 -Because "'$($gap.name)' has a field annotation in docs/drift-annotations.json that did not reach the committed report"
+            @($gap.annotations.note) | Should -Contain $fieldNotes[$gap.name] -Because "the committed note on '$($gap.name)' must be the source file's note verbatim, not a drifted copy"
+        }
+        $checked | Should -BeGreaterThan 0 -Because 'no annotated field appeared in systemicGaps at all -- either the annotation loader regressed, or every annotated field stopped being a gap. Both want a human to look; neither should pass silently.'
     }
 
-    It 'carries docs/drift-annotations.json''s liveTestingHazard note on a management-access-policies parameter-gap row' {
-        $row = $committedReport.parameterGaps | Where-Object { $_.endpoint -match 'management-access-policies' } | Select-Object -First 1
-        $row | Should -Not -BeNullOrEmpty -Because 'a management-access-policies endpoint is expected to still have a parameter gap'
-        $row.annotations | Should -Not -BeNullOrEmpty
-        ($row.annotations | Select-Object -First 1).note | Should -Match '403'
+    It 'carries every endpoint annotation from docs/drift-annotations.json into the committed parameter gaps, verbatim' {
+        # matchType 'endpoint' matches as a case-insensitive SUBSTRING of '<METHOD> /<path>'
+        # (docs/drift-annotations.json's own schema field says so). Matched with .Contains on
+        # lowered strings rather than -like: a wildcard pattern treats ` as an escape
+        # character and [ ] as a character class, so an endpoint or match value containing
+        # either would be misread.
+        $endpointAnnotations = @($annotationSource.annotations | Where-Object { $_.matchType -eq 'endpoint' })
+        @($endpointAnnotations).Count | Should -BeGreaterThan 0 -Because 'docs/drift-annotations.json must carry at least one matchType=endpoint annotation, or this test checks nothing'
+
+        $checked = 0
+        foreach ($ann in $endpointAnnotations) {
+            $needle = $ann.match.ToLowerInvariant()
+            foreach ($row in $committedReport.parameterGaps) {
+                if (-not $row.endpoint.ToLowerInvariant().Contains($needle)) { continue }
+                $checked++
+                @($row.annotations).Count | Should -BeGreaterThan 0 -Because "endpoint '$($row.endpoint)' matches the '$($ann.match)' annotation in docs/drift-annotations.json, which did not reach the committed report"
+                @($row.annotations.note) | Should -Contain $ann.note -Because "the committed note on '$($row.endpoint)' must be the source file's note verbatim, not a drifted copy"
+            }
+        }
+        $checked | Should -BeGreaterThan 0 -Because 'no annotated endpoint matched any parameter-gap row -- either the annotation matcher regressed, or every annotated endpoint stopped having a gap. Both want a human to look.'
     }
 
     It 'carries phantomFieldCount as a non-negative integer and a non-empty conventionStrength' {

--- a/Tests/PfbApiDriftTools.Tests.ps1
+++ b/Tests/PfbApiDriftTools.Tests.ps1
@@ -1625,3 +1625,47 @@ function Get-PfbFixtureOrderAlpha {
         @($gap.Cmdlets) | Should -Be @('Get-PfbFixtureOrderZulu', 'Test-PfbFixtureOrderZulu')
     }
 }
+
+Describe 'ConvertTo-PfbRepoRelativePath (REGRESSION guard for issue #63: runs with no spec cache, on every edition)' {
+    # DELIBERATELY UNGATED -- matching the ungated siblings in this file, not the PS7-gated ones,
+    # and it must stay that way: the whole point is that this runs on every CI leg.
+    #
+    # Issue #63: every guard that checks the drift report for absolute paths asserts against a
+    # FRESHLY REGENERATED report, so all of them need tools/specs/ -- a gitignored build cache
+    # absent on every runner. They reported "skipped", the job reported success, and the
+    # regression they exist to catch was unprotected in CI. Re-pointing them at the COMMITTED
+    # report fixes the cache dependency, but cannot catch a regression in this function:
+    # breaking it does not alter a file that is already committed. Only a direct unit test does.
+    It 'strips the repo root and returns a forward-slashed relative path' {
+        ConvertTo-PfbRepoRelativePath -Path 'C:\repo\Public\Get-PfbThing.ps1' -RepoRoot 'C:\repo' |
+            Should -Be 'Public/Get-PfbThing.ps1'
+    }
+
+    It 'strips the repo root case-insensitively' {
+        ConvertTo-PfbRepoRelativePath -Path 'C:\REPO\Public\Get-PfbThing.ps1' -RepoRoot 'C:\repo' |
+            Should -Be 'Public/Get-PfbThing.ps1'
+    }
+
+    It 'forward-slashes a POSIX repo-root path too' {
+        ConvertTo-PfbRepoRelativePath -Path '/home/runner/work/fb/Public/Get-PfbThing.ps1' -RepoRoot '/home/runner/work/fb' |
+            Should -Be 'Public/Get-PfbThing.ps1'
+    }
+
+    It 'emits no drive-letter or leading-slash absolute path for any path under the repo root' {
+        $result = ConvertTo-PfbRepoRelativePath -Path 'C:\repo\Private\Invoke-PfbApiRequest.ps1' -RepoRoot 'C:\repo'
+        $result | Should -Not -Match '^[A-Za-z]:[\\/]'
+        $result | Should -Not -Match '^[\\/]'
+    }
+
+    It 'falls back to the forward-slashed absolute path when the file is genuinely outside the repo root' {
+        # A test pointing -PublicDirectory at a synthetic fixture tree hits this. Documented
+        # behaviour, not a bug -- it must not throw a Substring range error.
+        ConvertTo-PfbRepoRelativePath -Path 'D:\elsewhere\Thing.ps1' -RepoRoot 'C:\repo' |
+            Should -Be 'D:/elsewhere/Thing.ps1'
+    }
+
+    It 'returns an empty or null path unchanged' {
+        ConvertTo-PfbRepoRelativePath -Path '' -RepoRoot 'C:\repo' | Should -BeNullOrEmpty
+        ConvertTo-PfbRepoRelativePath -Path $null -RepoRoot 'C:\repo' | Should -BeNullOrEmpty
+    }
+}

--- a/Tests/coverage-baseline.psd1
+++ b/Tests/coverage-baseline.psd1
@@ -21,7 +21,10 @@
     # all of them. A single shared ceiling would be either a permanent false red on 5.1 or
     # useless on 7.
     pwsh7   = @{
-        MaxSkipped        = 15
+        # Measured 2 on run 31359783827 (ubuntu-latest, pwsh, spec cache restored): 1842
+        # passed / 0 failed / 2 skipped. 8 leaves room for a handful of legitimate additions
+        # without going so loose that a real regression hides under it.
+        MaxSkipped        = 8
         RequiredDescribes = @(
             # Ungated -- these run on every leg and are the #63 regression guards themselves.
             'Committed drift report (REGRESSION guard, no spec cache required)'
@@ -39,7 +42,10 @@
         )
     }
     winps51 = @{
-        MaxSkipped        = 260
+        # Measured 169 on the same run (windows-latest, Windows PowerShell 5.1): 1675 passed /
+        # 0 failed / 169 skipped. The gap versus pwsh7's 2 is the PS7-gated tooling Describes,
+        # skipping exactly as designed -- not a defect.
+        MaxSkipped        = 185
         # Only the ungated blocks are required here. The six spec-cache blocks above are
         # PS7-gated by design, so requiring them on 5.1 would be a permanent false red.
         RequiredDescribes = @(

--- a/Tests/coverage-baseline.psd1
+++ b/Tests/coverage-baseline.psd1
@@ -42,10 +42,24 @@
         )
     }
     winps51 = @{
-        # Measured 169 on the same run (windows-latest, Windows PowerShell 5.1): 1675 passed /
-        # 0 failed / 169 skipped. The gap versus pwsh7's 2 is the PS7-gated tooling Describes,
-        # skipping exactly as designed -- not a defect.
-        MaxSkipped        = 185
+        # Re-measured 190 on run 31670025630 (windows-latest, Windows PowerShell 5.1): 1818
+        # passed / 0 failed / 190 skipped. The gap versus pwsh7's 2 is the PS7-gated tooling
+        # Describes, skipping exactly as designed -- not a defect.
+        #
+        # RAISED 185 -> 206, deliberately, for the reason this file says to raise it for. The
+        # original 185 was measured against a main that predated PR #98 (Fusion context Phase
+        # 0). #98 added 21 PS7-gated It blocks -- 8 in
+        # Build-PfbCapabilityMap.ContextScopeDrift.Tests.ps1, 9 in Build-PfbCapabilityMap.Tests.ps1,
+        # 4 in PfbSpecTools.ContextScope.Tests.ps1 -- and the observed 5.1 skip count moved
+        # 169 -> 190, exactly +21. They RUN on 7 (pwsh7 stayed at 2 skipped, 2006 passed), so
+        # this is the PS7 gate working, not lost coverage.
+        #
+        # This is also the gate catching a real hazard rather than misfiring: a pull_request
+        # run tests the MERGE commit, so a ceiling measured before an unrelated merge to main
+        # goes stale without anything in this branch changing. That is worth a red build.
+        #
+        # 206 keeps the same +16 headroom over measured that 185 had over 169.
+        MaxSkipped        = 206
         # Only the ungated blocks are required here. The six spec-cache blocks above are
         # PS7-gated by design, so requiring them on 5.1 would be a permanent false red.
         RequiredDescribes = @(

--- a/Tests/coverage-baseline.psd1
+++ b/Tests/coverage-baseline.psd1
@@ -1,0 +1,51 @@
+@{
+    # Issue #63: CI reported success while roughly 23% of the suite silently skipped, because
+    # the tooling tests gate themselves on the gitignored tools/specs/ build cache. Restoring
+    # the cache fixes today's hole; this file is what makes the NEXT one a red build.
+    #
+    # Two independent assertions, because either alone has a gap:
+    #
+    #   MaxSkipped        catches a Describe that starts reporting skips.
+    #   RequiredDescribes catches a Describe that vanishes from the result tree entirely.
+    #                     These blocks skip GRACEFULLY: when their guard evaluates false at
+    #                     BeforeAll time, or the file is filtered out of a run, they contribute
+    #                     NEITHER a skip NOR a pass. A skip ceiling cannot see that, and a
+    #                     green summary is then indistinguishable from a silently-absent
+    #                     assertion -- the same failure shape as #63, one level down.
+    #
+    # MaxSkipped is a CEILING WITH HEADROOM, not a pin. Raise it deliberately in a reviewed
+    # diff when a change legitimately adds skipped tests, and say why in the commit message.
+    #
+    # The two editions differ by design and by a wide margin: every Describe in the tooling
+    # test files carries -Skip:($PSVersionTable.PSVersion.Major -lt 7), so the 5.1 leg skips
+    # all of them. A single shared ceiling would be either a permanent false red on 5.1 or
+    # useless on 7.
+    pwsh7   = @{
+        MaxSkipped        = 15
+        RequiredDescribes = @(
+            # Ungated -- these run on every leg and are the #63 regression guards themselves.
+            'Committed drift report (REGRESSION guard, no spec cache required)'
+            'Committed drift report: annotations and summary fields survived generation'
+            'ConvertTo-PfbRepoRelativePath (REGRESSION guard for issue #63: runs with no spec cache, on every edition)'
+            # Spec-cache dependent -- these are the blocks that silently skipped in CI before
+            # the prepare-specs job existed. Listing them here is what proves the cache
+            # actually arrived, rather than inferring it from a healthy-looking skip count.
+            'Build-PfbApiDriftReport (real generated artifacts, skips gracefully if absent)'
+            'Build-PfbApiDriftReport (Task 8: regression canaries + spot-checks against the real generated report, skips gracefully if absent)'
+            'Build-PfbFieldCmdletMap (real generated artifacts, skips gracefully if absent)'
+            'Real committed capability map (skips gracefully if not yet generated)'
+            'Real committed value-enum map (skips gracefully if not yet generated)'
+            'Task 6 real-data invariants (systemic gaps + convention strength, skips gracefully if the real capability map is absent)'
+        )
+    }
+    winps51 = @{
+        MaxSkipped        = 260
+        # Only the ungated blocks are required here. The six spec-cache blocks above are
+        # PS7-gated by design, so requiring them on 5.1 would be a permanent false red.
+        RequiredDescribes = @(
+            'Committed drift report (REGRESSION guard, no spec cache required)'
+            'Committed drift report: annotations and summary fields survived generation'
+            'ConvertTo-PfbRepoRelativePath (REGRESSION guard for issue #63: runs with no spec cache, on every edition)'
+        )
+    }
+}

--- a/scripts/Assert-PfbSpecCache.ps1
+++ b/scripts/Assert-PfbSpecCache.ps1
@@ -1,0 +1,53 @@
+<#
+.SYNOPSIS
+    Fails the build when tools/specs/ did not materialise.
+.DESCRIPTION
+    Issue #63: tools/specs/ is a ~50MB cache of raw OpenAPI specs, gitignored (.gitignore:36
+    and again .gitignore:46) because it is a build input rather than source. On a bare runner
+    it is therefore absent, and every tooling test that depends on it skipped gracefully while
+    the job reported success -- roughly 23% of the suite, invisible in the run summary.
+
+    The prepare-specs job restores the cache and tops it up from the published spec index.
+    This asserts that actually worked, so a restore-miss combined with a fetch failure is a
+    red build rather than a quietly hollow test run. Without it the job would "succeed" and
+    hand the test legs an empty directory, reproducing the exact defect being fixed.
+
+    Lives in scripts/ rather than tools/ deliberately: .gitignore:46 ignores tools/ wholesale
+    ("Not yet decided whether this should be tracked -- excluded for now"). The existing
+    tools/*.ps1 files are tracked only because they predate that rule, so a NEW file added
+    there would be silently untracked. scripts/ is unignored and already holds the scripts the
+    workflows call (see scripts/Publish-Gallery.ps1, used by publish-to-gallery.yml).
+.PARAMETER SpecsDirectory
+    Defaults to tools/specs relative to the repo root.
+.PARAMETER MinimumCount
+    A floor, not a pin. 20 rather than the 29 currently published, on purpose: this asserts
+    "the mechanism worked", and the real count grows with every REST release -- pinning it
+    would turn each new publication into an unrelated red build.
+#>
+[CmdletBinding()]
+param(
+    [string]$SpecsDirectory,
+    [int]$MinimumCount = 20
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not $SpecsDirectory) {
+    $repoRoot = Split-Path -Parent $PSScriptRoot
+    $SpecsDirectory = Join-Path $repoRoot 'tools/specs'
+}
+
+$specs = @(Get-ChildItem -Path $SpecsDirectory -Filter 'fb*.json' -ErrorAction SilentlyContinue)
+Write-Host "$SpecsDirectory contains $($specs.Count) spec file(s)."
+
+if ($env:GITHUB_STEP_SUMMARY) {
+    "Restored **$($specs.Count)** OpenAPI spec files to ``tools/specs/``." |
+        Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+}
+if ($env:GITHUB_OUTPUT) {
+    "spec_count=$($specs.Count)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+}
+
+if ($specs.Count -lt $MinimumCount) {
+    throw "Expected at least $MinimumCount fb*.json spec files in $SpecsDirectory, found $($specs.Count). The cache did not restore and the fetch did not succeed -- failing loudly rather than letting the tooling tests skip (issue #63)."
+}

--- a/scripts/Assert-PfbTestCoverage.ps1
+++ b/scripts/Assert-PfbTestCoverage.ps1
@@ -1,0 +1,109 @@
+<#
+.SYNOPSIS
+    Fails the build when a Pester run silently lost coverage. Issue #63.
+.DESCRIPTION
+    The tooling tests gate themselves on tools/specs/, a gitignored build cache. On a bare
+    runner they all reported "skipped", the job reported "success", and the coverage loss was
+    invisible in the run summary. Restoring the cache fixes today's hole; this script is what
+    makes the NEXT one a red build instead of a silent one.
+
+    Two independent assertions, because either alone has a gap:
+
+      1. Skip ceiling -- catches a Describe that starts reporting skips.
+      2. Required-Describe allowlist -- catches a Describe that vanishes from the result tree
+         entirely. These blocks skip GRACEFULLY: when their guard evaluates false at BeforeAll
+         time, or the file is filtered out of a run, they contribute NEITHER a skip NOR a pass.
+         A skip ceiling cannot see that, and a green summary is then indistinguishable from a
+         silently-absent assertion -- the same failure shape as #63, one level down.
+
+    Takes a result OBJECT rather than running Pester itself, so it is testable with a
+    hand-built stand-in and needs neither a real suite run nor the spec cache.
+
+    Lives in scripts/, not tools/: .gitignore:46 ignores tools/ wholesale, so a new file there
+    would be silently untracked.
+
+    5.1 CONSTRAINT: this runs under Windows PowerShell 5.1 as well as pwsh 7. No ternaries,
+    no ??, no ConvertFrom-Json -Depth.
+
+    Result shape verified against Pester 6.0.0 and 6.0.1 on both editions: $Result.Tests is a
+    flat list, each entry has .Path (a List whose [0] is the top-level Describe name) and a
+    .Result string; the run carries PassedCount/FailedCount/SkippedCount/NotRunCount.
+.PARAMETER Result
+    The object returned by Invoke-Pester -PassThru.
+.PARAMETER Edition
+    Which baseline block to apply: 'pwsh7' or 'winps51'. This selects the BASELINE, not the
+    interpreter -- the interpreter is whichever host is already running this script.
+.PARAMETER BaselinePath
+    Defaults to Tests/coverage-baseline.psd1 relative to the repo root.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][object]$Result,
+    [Parameter(Mandatory)][ValidateSet('pwsh7', 'winps51')][string]$Edition,
+    [string]$BaselinePath
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not $BaselinePath) {
+    $repoRoot = Split-Path -Parent $PSScriptRoot
+    $BaselinePath = Join-Path $repoRoot 'Tests/coverage-baseline.psd1'
+}
+if (-not (Test-Path $BaselinePath)) {
+    throw "Coverage baseline not found at $BaselinePath."
+}
+
+$baseline = Import-PowerShellDataFile -Path $BaselinePath
+$editionBaseline = $baseline[$Edition]
+if (-not $editionBaseline) {
+    throw "Coverage baseline has no '$Edition' block. Present: $($baseline.Keys -join ', ')."
+}
+
+$allTests = @($Result.Tests)
+$violations = New-Object System.Collections.Generic.List[string]
+$summaryLines = New-Object System.Collections.Generic.List[string]
+
+$summaryLines.Add("### Test coverage gate -- $Edition")
+$summaryLines.Add('')
+
+# --- Assertion 1: required Describes actually executed -------------------------------------
+$summaryLines.Add('| Required top-level Describe | Ran | Skipped |')
+$summaryLines.Add('|---|---:|---:|')
+
+foreach ($required in @($editionBaseline.RequiredDescribes)) {
+    $blockTests = @($allTests | Where-Object { @($_.Path).Count -gt 0 -and $_.Path[0] -eq $required })
+    $ran = @($blockTests | Where-Object { $_.Result -eq 'Passed' -or $_.Result -eq 'Failed' }).Count
+    $skipped = @($blockTests | Where-Object { $_.Result -eq 'Skipped' -or $_.Result -eq 'NotRun' }).Count
+
+    $marker = 'OK'
+    if ($ran -lt 1) {
+        $marker = 'MISSING'
+        $violations.Add("Required Describe contributed $ran executed tests (and $skipped skipped/not-run): '$required'")
+    }
+    $summaryLines.Add("| ``$required`` | $ran ($marker) | $skipped |")
+}
+
+# --- Assertion 2: skip ceiling -------------------------------------------------------------
+$skippedTotal = [int]$Result.SkippedCount + [int]$Result.NotRunCount
+$ceiling = [int]$editionBaseline.MaxSkipped
+
+$summaryLines.Add('')
+$summaryLines.Add("Skipped + not-run: **$skippedTotal** (ceiling $ceiling). Passed: $($Result.PassedCount). Failed: $($Result.FailedCount).")
+
+if ($skippedTotal -gt $ceiling) {
+    $violations.Add("Skipped + not-run count $skippedTotal exceeds the $Edition ceiling of $ceiling. Either coverage regressed, or the ceiling in Tests/coverage-baseline.psd1 needs a deliberate, reviewed raise.")
+}
+
+if ($env:GITHUB_STEP_SUMMARY) {
+    ($summaryLines -join [Environment]::NewLine) | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+}
+foreach ($line in $summaryLines) { Write-Host $line }
+
+if ($violations.Count -gt 0) {
+    Write-Host ''
+    Write-Host 'COVERAGE GATE FAILED (issue #63):'
+    foreach ($v in $violations) { Write-Host "  - $v" }
+    throw "Test coverage gate failed with $($violations.Count) violation(s). See above."
+}
+
+Write-Host "Coverage gate passed for $Edition."

--- a/scripts/Invoke-PfbCiPester.ps1
+++ b/scripts/Invoke-PfbCiPester.ps1
@@ -1,0 +1,79 @@
+<#
+.SYNOPSIS
+    Runs the full Pester suite and the issue-#63 coverage gate.
+.DESCRIPTION
+    Extracted from YAML so this logic is not maintained in triplicate across
+    cross-platform-tests.yml (twice) and update-api-capability-map.yml (once). Follows the
+    pattern already established by scripts/Publish-Gallery.ps1, which publish-to-gallery.yml
+    calls the same way.
+
+    Why a repo script rather than a composite action: this is lintable by PSScriptAnalyzer,
+    diffable, testable, free of ${{ }} escaping hazards, and runnable outside GitHub Actions.
+    A composite action would add a second indirection layer and buy only the `shell:`
+    selection, which is one YAML line per leg regardless.
+
+    Why update-api-capability-map.yml cannot simply `workflow_call` cross-platform-tests.yml
+    instead: a reusable workflow runs on a FRESH runner with a FRESH checkout, so it would
+    test the committed Data/ and Reports/, not the ones that job just regenerated -- which is
+    the entire reason its test step is inline. A script runs in the caller's workspace.
+
+    RUNS ANYWHERE, deliberately. This is the full aggregate suite, and running it as a task's
+    own completion check is a known failure mode for an AGENT specifically: the suite exceeds
+    the 600s tool-call cap, and a backgrounded run is indistinguishable from a dead one. But
+    "run exactly what CI runs before I push" is a legitimate human use, so that restriction is
+    enforced by a PreToolUse hook -- which gates agent tool calls and never sees a human's
+    terminal -- rather than baked in here, where it would tax the legitimate caller in order
+    to constrain a different one. Agents: use the run-pester-tests skill's
+    Invoke-ScopedPester.ps1 instead.
+
+    5.1 CONSTRAINT: this runs under Windows PowerShell 5.1 as well as pwsh 7. No ternaries,
+    no ??, no ConvertFrom-Json -Depth.
+.PARAMETER Edition
+    Which Tests/coverage-baseline.psd1 block to apply: 'pwsh7' or 'winps51'. This selects the
+    BASELINE, not the interpreter -- the interpreter is whichever host is already running this
+    script, chosen by the workflow's `shell:` key.
+.EXAMPLE
+    ./scripts/Invoke-PfbCiPester.ps1 -Edition pwsh7
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][ValidateSet('pwsh7', 'winps51')][string]$Edition
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+Push-Location $repoRoot
+try {
+    Import-Module Pester -MinimumVersion 5.0 -Force
+    # Posh-SSH is imported because Pester can only mock a resolvable command -- see
+    # .github/actions/install-test-modules/action.yml for why it is a test dependency.
+    Import-Module Posh-SSH -Force
+
+    $cfg = New-PesterConfiguration
+    $cfg.Run.Path = 'Tests'
+    # Run.Exit stays $false deliberately: it terminates the process on failure, which would
+    # skip the coverage gate below. The explicit exit at the end preserves the same red build.
+    $cfg.Run.Exit = $false
+    $cfg.Run.PassThru = $true
+    $cfg.Output.Verbosity = 'Detailed'
+
+    $result = Invoke-Pester -Configuration $cfg
+
+    # Ordering is load-bearing: the coverage gate runs BEFORE the failure exit, so a run that
+    # both fails tests and lost coverage reports both problems rather than only the first.
+    $gateFailed = $false
+    try {
+        & (Join-Path $PSScriptRoot 'Assert-PfbTestCoverage.ps1') -Result $result -Edition $Edition
+    }
+    catch {
+        $gateFailed = $true
+        Write-Host $_.Exception.Message
+    }
+
+    if ($result.FailedCount -gt 0 -or $gateFailed) { exit 1 }
+    exit 0
+}
+finally {
+    Pop-Location
+}

--- a/tools/Build-PfbApiDriftReport.ps1
+++ b/tools/Build-PfbApiDriftReport.ps1
@@ -257,29 +257,9 @@ function Get-PfbCmdletFunctionAst {
     return $null
 }
 
-function ConvertTo-PfbRepoRelativePath {
-    <#
-    .SYNOPSIS
-        Rewrites an absolute cmdlet path to a forward-slashed path relative to $repoRoot.
-    .DESCRIPTION
-        Every path this report emits MUST be repo-relative. These artifacts are committed, so an
-        absolute path bakes the generating machine's directory layout into the repository: it
-        leaks a local filesystem structure, and it makes the committed file depend on WHERE it was
-        generated -- regenerating from a git worktree instead of the main checkout rewrites every
-        such line, producing hundreds of lines of diff churn that bury the real changes.
-
-        Falls back to the forward-slashed absolute path when the file genuinely is not under
-        $repoRoot (a test pointing -PublicDirectory at a synthetic fixture tree), rather than
-        throwing a Substring range error.
-    #>
-    param([string]$Path)
-
-    if (-not $Path) { return $Path }
-    if ($Path.StartsWith($repoRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
-        return ($Path.Substring($repoRoot.Length + 1)) -replace '\\', '/'
-    }
-    return $Path -replace '\\', '/'
-}
+# ConvertTo-PfbRepoRelativePath moved to tools/lib/PfbApiDriftTools.ps1 (dot-sourced above) so
+# it can be unit-tested with no tools/specs/ cache present -- see issue #63. It now takes an
+# explicit -RepoRoot instead of closing over this script's $repoRoot.
 
 function Get-PfbGapTarget {
     <#
@@ -310,7 +290,7 @@ function Get-PfbGapTarget {
         return [ordered]@{ file = $null; paramBlockLine = $null; payloadVariable = $null; assignmentStyle = $null; hasAttributes = $null }
     }
 
-    $relativeFile = ConvertTo-PfbRepoRelativePath -Path $file
+    $relativeFile = ConvertTo-PfbRepoRelativePath -Path $file -RepoRoot $repoRoot
     $funcAst = Get-PfbCmdletFunctionAst -Cmdlet $primaryCmdlet
     if (-not $funcAst) {
         return [ordered]@{ file = $relativeFile; paramBlockLine = $null; payloadVariable = $null; assignmentStyle = $null; hasAttributes = $null }
@@ -447,7 +427,7 @@ $parameterGaps = @($parameterGapsRaw | ForEach-Object {
                         # Repo-relative, same as target.file: these artifacts are committed, so an
                         # absolute path would leak the generating machine's layout and churn the
                         # diff whenever the report is regenerated from a different directory.
-                        [ordered]@{ parameter = $_.Parameter; surface = $_.Surface; file = (ConvertTo-PfbRepoRelativePath -Path $_.File); line = $_.Line }
+                        [ordered]@{ parameter = $_.Parameter; surface = $_.Surface; file = (ConvertTo-PfbRepoRelativePath -Path $_.File -RepoRoot $repoRoot); line = $_.Line }
                     })
                 escapeHatchOnly      = @($gapRaw.Confidence.EscapeHatchOnly)
                 caveat               = $gapRaw.Confidence.Caveat

--- a/tools/lib/PfbApiDriftTools.ps1
+++ b/tools/lib/PfbApiDriftTools.ps1
@@ -1569,3 +1569,39 @@ function Get-PfbResponseShapeFindings {
         UnhandledEnvelopeFields = @($unhandled | Sort-Object { -$_.EndpointCount }, { $_.Field })
     }
 }
+
+function ConvertTo-PfbRepoRelativePath {
+    <#
+    .SYNOPSIS
+        Rewrites an absolute cmdlet path to a forward-slashed path relative to $RepoRoot.
+    .DESCRIPTION
+        Every path the drift report emits MUST be repo-relative. These artifacts are committed, so
+        an absolute path bakes the generating machine's directory layout into the repository: it
+        leaks a local filesystem structure, and it makes the committed file depend on WHERE it was
+        generated -- regenerating from a git worktree instead of the main checkout rewrites every
+        such line, producing hundreds of lines of diff churn that bury the real changes.
+
+        Falls back to the forward-slashed absolute path when the file genuinely is not under
+        $RepoRoot (a test pointing -PublicDirectory at a synthetic fixture tree), rather than
+        throwing a Substring range error.
+
+        Lives here rather than in tools/Build-PfbApiDriftReport.ps1 so it can be unit-tested
+        directly with no tools/specs/ cache present -- see issue #63. The guards that assert the
+        report carries no absolute path cannot catch a regression in this function on their own:
+        the ones reading the COMMITTED report are unaffected by it, and the ones regenerating a
+        report need the spec cache, so they skipped silently on every CI runner.
+    .PARAMETER RepoRoot
+        Explicit rather than closed-over: a lib function must not depend on a caller's
+        script-scoped variable.
+    #>
+    param(
+        [string]$Path,
+        [Parameter(Mandatory)][string]$RepoRoot
+    )
+
+    if (-not $Path) { return $Path }
+    if ($Path.StartsWith($RepoRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+        return ($Path.Substring($RepoRoot.Length + 1)) -replace '\\', '/'
+    }
+    return $Path -replace '\\', '/'
+}


### PR DESCRIPTION
Fixes #63.

## The problem

`tools/specs/` is a ~50MB cache of raw OpenAPI specs. It is gitignored, because it is a build input rather than source, so on a bare CI runner it does not exist. Every tooling test gates itself on the cache being present and skips gracefully when it is not — so the jobs reported success while roughly 23% of the suite never ran, including the absolute-path regression guards added in PR #62.

The second-order trap is worse than the headline number. A `Describe` whose guard evaluates false at `BeforeAll` time contributes **neither a skip nor a pass**: it vanishes from the result tree entirely. A healthy-looking skip count therefore proves nothing, and a green summary is indistinguishable from a silently-absent assertion.

## The fix, on four axes

**1. The guarded function is now directly unit-testable.** `ConvertTo-PfbRepoRelativePath` moved out of `tools/Build-PfbApiDriftReport.ps1` (a `param()`-headed script that cannot be dot-sourced without running the whole build) into `tools/lib/PfbApiDriftTools.ps1`, which the builder and `Tests/PfbApiDriftTools.Tests.ps1` already dot-source. Six new **ungated** tests cover it: root stripping, case-insensitivity, POSIX separators, the never-emit-an-absolute-path invariant, the outside-root fallback, and null/empty passthrough.

This axis matters because retargeting the guards at the committed report — the issue's own first recommendation — does not satisfy acceptance criterion 3 on its own. Breaking the function does not alter a file that is already committed, so the regression would still pass.

**2. The committed artifacts are guarded with no spec cache required.** New self-contained `Tests/CommittedDriftReport.Tests.ps1` reads `Reports/PfbApiDriftReport.json` with plain `ConvertFrom-Json` and asserts, on all four legs: the artifacts exist and are non-vacuous; no absolute path appears in `unresolvedParameters`, in enriched `missingBodyProperties[].target.file`, or in the markdown; and the hand-authored annotations plus summary fields survived generation.

A new file rather than a block appended to `Build-PfbApiDriftReport.Tests.ps1`: that file's top-level `BeforeAll` invokes a `#Requires -Version 7.0` script and uses `ConvertFrom-Json -Depth`, and every `Describe` in it is PS7-gated. One ungated block there would drag the `BeforeAll` onto 5.1 and take all 65 tests down with it — the exact container-failure shape documented in the `run-pester-tests` notes.

**3. A `prepare-specs` job materialises the cache once per run.** It restores, fetches only newly-published versions, hard-fails via `scripts/Assert-PfbSpecCache.ps1` if the result is below a floor, saves, and publishes an artifact the test legs download. The cache key prefix is deliberately shared with `update-api-capability-map.yml` so a warm cache written by either workflow serves both. An artifact rather than four per-leg restores: it fetches from the spec index at most once per run and is immune to cache key/branch scoping differences across the matrix.

The floor is 20 rather than the current 29, so a newly-published REST version cannot red the build on arrival.

**4. A two-part coverage gate makes the next hole loud.** `scripts/Invoke-PfbCiPester.ps1` replaces the Pester block that was copy-pasted in three places across two workflows, and calls `scripts/Assert-PfbTestCoverage.ps1`:

- **`RequiredDescribes`** — a named allowlist per edition. Catches a `Describe` that disappears from the result tree, which a skip ceiling structurally cannot see.
- **`MaxSkipped`** — a ceiling with headroom, counting `NotRun` as well as `Skipped`, since Pester reports a discovery-time skip as the former.

The gate takes a result object rather than running Pester itself, so `Tests/CiCoverageGate.Tests.ps1` exercises it fully with a hand-built stand-in — no suite run, no cache dependency. Nine ungated tests, the headline one asserting that a run reporting **zero** skips still fails when a required `Describe` is absent. It also pins the real baseline: both editions defined, and every allowlist entry actually present in some test file, so a rename or typo fails here rather than reddening CI forever for the wrong reason.

Baselines are per-edition by necessity. Every tooling `Describe` carries `-Skip:($PSVersionTable.PSVersion.Major -lt 7)`, so the two legs differ by ~170 skips by design; one shared ceiling would be either a permanent false red on 5.1 or useless on 7.

The gate runs before the failure exit, so a run with both a real failure and a coverage regression reports both.

`update-api-capability-map.yml` additionally captures committed artifact hashes before regeneration and reports the diff. It reports only — it does not fail — since a legitimate spec update is expected to change those files.

## Where the new scripts live, and one `.gitignore` fix

The three new scripts go in `scripts/`, alongside `build.ps1` and `Publish-Gallery.ps1`, because that is what they are. The repo already has two distinct directories with a real boundary:

| | `tools/` | `scripts/` |
|---|---|---|
| Purpose | the API capability-map **generator toolchain** | **repo lifecycle / CI plumbing** |
| Output | committed artifacts — `Data/*.json`, `Reports/*` | no artifact; it performs an action |
| Invoked by | `update-api-capability-map.yml`, maintainer on demand | `publish-to-gallery.yml`, CI |

`Invoke-PfbCiPester.ps1` is the direct sibling of `Publish-Gallery.ps1` — a workflow step extracted into a script. `Assert-PfbSpecCache.ps1` and `Assert-PfbTestCoverage.ps1` assert and gate; they generate nothing. None of the three belongs in the generator toolchain.

Separately, `.gitignore` carried a blanket `tools/` rule, added as a drive-by in `06ccd6e` (a commit about a WinPS 5.1 crash from PKCS#8 fixtures) with the comment *"Not yet decided whether this should be tracked -- excluded for now"*. That decision has effectively been made — 14 files under `tools/` are tracked, including a maintained `tools/README.md`. The rule only affected **new** files, and silently: git does not descend into an ignored directory, so a newly created `tools/*.ps1` produces no untracked marker at all.

It was also shadowing the rule that does the real work. Because the last matching pattern wins:

```
before:  git check-ignore -v tools/specs  →  .gitignore:46:tools/
after:   git check-ignore -v tools/specs  →  .gitignore:39:tools/specs/
```

The purpose-built, carefully-commented `tools/specs/` exclusion was dormant. Removing the blanket rule reactivates it, and is a verified no-op for anything tracked or ignored today: 29 untracked paths under `tools/`, all 29 under `tools/specs/`, **0** elsewhere; tracked count unchanged at 14; only `.gitignore` itself appears in `git status`. No test reads `.gitignore`, and the capability-map workflow's change check is path-scoped to `-- Data Reports`.

Happy to split this into its own PR if you would rather keep it separate — it is one commit (`dec8fe5`) and reverts cleanly.

## Results

Runs `31359783827` and `31360895252`, both 5/5 green.

| Leg | Before | After |
|---|---|---|
| ubuntu-latest, pwsh | 503 passed / 0 failed / 154 skipped | **1842 / 0 / 2** |
| windows-latest, WinPS 5.1 | — | **1675 / 0 / 169** |

All nine required `Describe` blocks report `OK`. The six that were previously invisible contribute 10, 14, 1, 1, 4 and 3 tests. `prepare-specs` completes in 13s on a warm cache, confirming the shared key prefix works.

The 169 skips on 5.1 were enumerated across 28 blocks and characterised: 165 are tooling/drift tests, PS7-gated because every script under `tools/` carries `#Requires -Version 7.0`. The remaining 4 are shipped module code, all edition-complementary — encrypted-PKCS#8 JWT minting (2, needs a PS6+ API, with its 5.1 error path explicitly tested), the paired variant of the never-log-the-private-key-password assertion (1; the general form of that assertion is ungated and does run on 5.1), and `Set-PfbTlsProtocol`'s "no-op on PowerShell 7+" case (1). pwsh 7's only two skips are exactly the 5.1-only tests, which is the symmetry proving nothing is uncovered on both legs.

## Notes for review

- `MaxSkipped` is a ceiling, not a pin. Raising it deliberately in a reviewed diff, with the reason in the commit message, is the intended workflow when a change legitimately adds skips.
- One verification gap, stated plainly: the gate's *logic* is proven by unit test (a zero-skip run with a required `Describe` absent throws), but the *wiring* — a gate throw becoming a non-zero exit and reddening the job — was never exercised against CI with a deliberate break. Cheapest way to close it is a scratch commit dropping the `Download API spec cache` step from `test-pwsh` only, confirming that job goes red, then discarding the commit.
- No version or CHANGELOG changes, per the maintainer-owned release process.
- Out of scope, noted for visibility: the scheduled `update-api-capability-map` run has failed at its `Open pull request` step on every run since 2026-07-24. Unrelated to this change, and excluded per the discussion on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
