### PR TITLE
Add a regression gate for dead query keys

### DIFF
--- a/.github/workflows/update-api-capability-map.yml
+++ b/.github/workflows/update-api-capability-map.yml
@@ -212,6 +212,9 @@ jobs:
             - Rebuilt `Reports/PfbValueEnumMap.json`, `Reports/PfbFieldCmdletMap.json`, and
               `Reports/PfbApiDriftReport.json` (+ their Markdown companions) -- see
               `Reports/README.md` for what each answers.
+            - Rebuilt `Reports/PfbDeadKeyReport.json`, the inventory of query keys that
+              `Public/` cmdlets send but the endpoint does not declare for that HTTP verb --
+              see `Reports/README.md`.
 
             New REST versions detected: ${{ steps.summary.outputs.new_versions || 'none - see diff (e.g. a version-map-only update once an SSOT_API_KEY secret was configured, or new parameters/fields added to existing endpoints in a point release)' }}
 

--- a/.github/workflows/update-api-capability-map.yml
+++ b/.github/workflows/update-api-capability-map.yml
@@ -130,6 +130,10 @@ jobs:
         shell: pwsh
         run: ./tools/Build-PfbApiDriftReport.ps1
 
+      - name: Build dead-key report
+        shell: pwsh
+        run: ./tools/Build-PfbDeadKeyReport.ps1
+
       # Pinned + cached, with retry on the gallery path; see
       # .github/actions/install-test-modules/action.yml (including why Posh-SSH is
       # needed at all -- Pester can only mock a resolvable command).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,12 +23,14 @@ Gallery listing.
 Any commit that changes which REST query/body parameters or endpoints a
 `Public/` cmdlet covers must regenerate the derived `Reports/` artifacts in
 the same commit -- otherwise they go stale relative to your own change, and
-the drift-report invariant tests (`Tests/Build-PfbApiDriftReport.Tests.ps1`,
-Task 8) will catch it later for whoever next merges `main`, instead of now:
+the derived-report invariant tests (`Tests/Build-PfbApiDriftReport.Tests.ps1`,
+Task 8, and `Tests/Build-PfbDeadKeyReport.Tests.ps1`) will catch it later for
+whoever next merges `main`, instead of now:
 
 ```powershell
 ./tools/Build-PfbFieldCmdletMap.ps1   # must run first -- Build-PfbApiDriftReport.ps1 reads its output
 ./tools/Build-PfbApiDriftReport.ps1
+./tools/Build-PfbDeadKeyReport.ps1
 ```
 
 Merge/rebase onto an up-to-date `main` *before* regenerating. `Build-PfbApiDriftReport.ps1`

--- a/Reports/PfbDeadKeyReport.json
+++ b/Reports/PfbDeadKeyReport.json
@@ -1,0 +1,2155 @@
+{
+  "specVersion": "2.28",
+  "counts": {
+    "parametersInventoried": 2174,
+    "keysEvaluated": 1757,
+    "ok": 1631,
+    "deadKey": 126,
+    "skipReasons": {
+      "wire name unresolved": 125,
+      "body property": 278,
+      "endpoint/method ambiguous": 14,
+      "endpoint/verb absent from spec": 0
+    }
+  },
+  "deadKeys": [
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbArrayClientPerformance",
+      "parameter": "EndTime",
+      "wireKey": "end_time",
+      "method": "GET",
+      "endpoint": "arrays/clients/performance",
+      "declared": [
+        "filter",
+        "limit",
+        "names",
+        "protocol",
+        "sort",
+        "total_only"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbArrayClientPerformance",
+      "parameter": "Resolution",
+      "wireKey": "resolution",
+      "method": "GET",
+      "endpoint": "arrays/clients/performance",
+      "declared": [
+        "filter",
+        "limit",
+        "names",
+        "protocol",
+        "sort",
+        "total_only"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbArrayClientPerformance",
+      "parameter": "StartTime",
+      "wireKey": "start_time",
+      "method": "GET",
+      "endpoint": "arrays/clients/performance",
+      "declared": [
+        "filter",
+        "limit",
+        "names",
+        "protocol",
+        "sort",
+        "total_only"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbArrayClientS3Performance",
+      "parameter": "EndTime",
+      "wireKey": "end_time",
+      "method": "GET",
+      "endpoint": "arrays/clients/s3-specific-performance",
+      "declared": [
+        "filter",
+        "limit",
+        "names",
+        "sort",
+        "total_only"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbArrayClientS3Performance",
+      "parameter": "Resolution",
+      "wireKey": "resolution",
+      "method": "GET",
+      "endpoint": "arrays/clients/s3-specific-performance",
+      "declared": [
+        "filter",
+        "limit",
+        "names",
+        "sort",
+        "total_only"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbArrayClientS3Performance",
+      "parameter": "StartTime",
+      "wireKey": "start_time",
+      "method": "GET",
+      "endpoint": "arrays/clients/s3-specific-performance",
+      "declared": [
+        "filter",
+        "limit",
+        "names",
+        "sort",
+        "total_only"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbArrayErasure",
+      "parameter": "Filter",
+      "wireKey": "filter",
+      "method": "GET",
+      "endpoint": "arrays/erasures",
+      "declared": []
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbArrayErasure",
+      "parameter": "Limit",
+      "wireKey": "limit",
+      "method": "GET",
+      "endpoint": "arrays/erasures",
+      "declared": []
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbArrayErasure",
+      "parameter": "Sort",
+      "wireKey": "sort",
+      "method": "GET",
+      "endpoint": "arrays/erasures",
+      "declared": []
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbArrayHttpPerformance",
+      "parameter": "Filter",
+      "wireKey": "filter",
+      "method": "GET",
+      "endpoint": "arrays/http-specific-performance",
+      "declared": [
+        "allow_errors",
+        "context_names",
+        "end_time",
+        "resolution",
+        "start_time"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbArrayHttpPerformance",
+      "parameter": "Limit",
+      "wireKey": "limit",
+      "method": "GET",
+      "endpoint": "arrays/http-specific-performance",
+      "declared": [
+        "allow_errors",
+        "context_names",
+        "end_time",
+        "resolution",
+        "start_time"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbArrayHttpPerformance",
+      "parameter": "Sort",
+      "wireKey": "sort",
+      "method": "GET",
+      "endpoint": "arrays/http-specific-performance",
+      "declared": [
+        "allow_errors",
+        "context_names",
+        "end_time",
+        "resolution",
+        "start_time"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbArrayNfsPerformance",
+      "parameter": "Filter",
+      "wireKey": "filter",
+      "method": "GET",
+      "endpoint": "arrays/nfs-specific-performance",
+      "declared": [
+        "allow_errors",
+        "context_names",
+        "end_time",
+        "resolution",
+        "start_time"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbArrayNfsPerformance",
+      "parameter": "Limit",
+      "wireKey": "limit",
+      "method": "GET",
+      "endpoint": "arrays/nfs-specific-performance",
+      "declared": [
+        "allow_errors",
+        "context_names",
+        "end_time",
+        "resolution",
+        "start_time"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbArrayNfsPerformance",
+      "parameter": "Sort",
+      "wireKey": "sort",
+      "method": "GET",
+      "endpoint": "arrays/nfs-specific-performance",
+      "declared": [
+        "allow_errors",
+        "context_names",
+        "end_time",
+        "resolution",
+        "start_time"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbArrayPerformanceReplication",
+      "parameter": "Filter",
+      "wireKey": "filter",
+      "method": "GET",
+      "endpoint": "arrays/performance/replication",
+      "declared": [
+        "allow_errors",
+        "context_names",
+        "end_time",
+        "resolution",
+        "start_time",
+        "type"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbArrayPerformanceReplication",
+      "parameter": "Limit",
+      "wireKey": "limit",
+      "method": "GET",
+      "endpoint": "arrays/performance/replication",
+      "declared": [
+        "allow_errors",
+        "context_names",
+        "end_time",
+        "resolution",
+        "start_time",
+        "type"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbArrayPerformanceReplication",
+      "parameter": "Sort",
+      "wireKey": "sort",
+      "method": "GET",
+      "endpoint": "arrays/performance/replication",
+      "declared": [
+        "allow_errors",
+        "context_names",
+        "end_time",
+        "resolution",
+        "start_time",
+        "type"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbArrayS3Performance",
+      "parameter": "Filter",
+      "wireKey": "filter",
+      "method": "GET",
+      "endpoint": "arrays/s3-specific-performance",
+      "declared": [
+        "allow_errors",
+        "context_names",
+        "end_time",
+        "resolution",
+        "start_time"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbArrayS3Performance",
+      "parameter": "Limit",
+      "wireKey": "limit",
+      "method": "GET",
+      "endpoint": "arrays/s3-specific-performance",
+      "declared": [
+        "allow_errors",
+        "context_names",
+        "end_time",
+        "resolution",
+        "start_time"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbArrayS3Performance",
+      "parameter": "Sort",
+      "wireKey": "sort",
+      "method": "GET",
+      "endpoint": "arrays/s3-specific-performance",
+      "declared": [
+        "allow_errors",
+        "context_names",
+        "end_time",
+        "resolution",
+        "start_time"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbAsyncLogDownload",
+      "parameter": "Id",
+      "wireKey": "ids",
+      "method": "GET",
+      "endpoint": "logs-async/download",
+      "declared": [
+        "names"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbBucketAccessPolicy",
+      "parameter": "Id",
+      "wireKey": "ids",
+      "method": "GET",
+      "endpoint": "buckets/bucket-access-policies",
+      "declared": [
+        "allow_errors",
+        "bucket_ids",
+        "bucket_names",
+        "context_names",
+        "continuation_token",
+        "filter",
+        "limit",
+        "names",
+        "offset",
+        "sort"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbBucketAccessPolicy",
+      "parameter": "MemberId",
+      "wireKey": "member_ids",
+      "method": "GET",
+      "endpoint": "buckets/bucket-access-policies",
+      "declared": [
+        "allow_errors",
+        "bucket_ids",
+        "bucket_names",
+        "context_names",
+        "continuation_token",
+        "filter",
+        "limit",
+        "names",
+        "offset",
+        "sort"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbBucketAccessPolicy",
+      "parameter": "MemberName",
+      "wireKey": "member_names",
+      "method": "GET",
+      "endpoint": "buckets/bucket-access-policies",
+      "declared": [
+        "allow_errors",
+        "bucket_ids",
+        "bucket_names",
+        "context_names",
+        "continuation_token",
+        "filter",
+        "limit",
+        "names",
+        "offset",
+        "sort"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbBucketAccessPolicy",
+      "parameter": "PolicyId",
+      "wireKey": "policy_ids",
+      "method": "GET",
+      "endpoint": "buckets/bucket-access-policies",
+      "declared": [
+        "allow_errors",
+        "bucket_ids",
+        "bucket_names",
+        "context_names",
+        "continuation_token",
+        "filter",
+        "limit",
+        "names",
+        "offset",
+        "sort"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbBucketAccessPolicy",
+      "parameter": "PolicyName",
+      "wireKey": "policy_names",
+      "method": "GET",
+      "endpoint": "buckets/bucket-access-policies",
+      "declared": [
+        "allow_errors",
+        "bucket_ids",
+        "bucket_names",
+        "context_names",
+        "continuation_token",
+        "filter",
+        "limit",
+        "names",
+        "offset",
+        "sort"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbBucketAccessPolicyRule",
+      "parameter": "Id",
+      "wireKey": "ids",
+      "method": "GET",
+      "endpoint": "buckets/bucket-access-policies/rules",
+      "declared": [
+        "allow_errors",
+        "bucket_ids",
+        "bucket_names",
+        "context_names",
+        "continuation_token",
+        "filter",
+        "limit",
+        "names",
+        "offset",
+        "policy_names",
+        "sort"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbBucketAccessPolicyRule",
+      "parameter": "MemberName",
+      "wireKey": "member_names",
+      "method": "GET",
+      "endpoint": "buckets/bucket-access-policies/rules",
+      "declared": [
+        "allow_errors",
+        "bucket_ids",
+        "bucket_names",
+        "context_names",
+        "continuation_token",
+        "filter",
+        "limit",
+        "names",
+        "offset",
+        "policy_names",
+        "sort"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbBucketAuditFilter",
+      "parameter": "MemberId",
+      "wireKey": "member_ids",
+      "method": "GET",
+      "endpoint": "buckets/audit-filters",
+      "declared": [
+        "allow_errors",
+        "bucket_ids",
+        "bucket_names",
+        "context_names",
+        "continuation_token",
+        "filter",
+        "limit",
+        "names",
+        "offset",
+        "sort"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbBucketAuditFilter",
+      "parameter": "MemberName",
+      "wireKey": "member_names",
+      "method": "GET",
+      "endpoint": "buckets/audit-filters",
+      "declared": [
+        "allow_errors",
+        "bucket_ids",
+        "bucket_names",
+        "context_names",
+        "continuation_token",
+        "filter",
+        "limit",
+        "names",
+        "offset",
+        "sort"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbBucketCorsPolicy",
+      "parameter": "Id",
+      "wireKey": "ids",
+      "method": "GET",
+      "endpoint": "buckets/cross-origin-resource-sharing-policies",
+      "declared": [
+        "allow_errors",
+        "bucket_ids",
+        "bucket_names",
+        "context_names",
+        "continuation_token",
+        "filter",
+        "limit",
+        "names",
+        "offset",
+        "sort"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbBucketCorsPolicy",
+      "parameter": "MemberId",
+      "wireKey": "member_ids",
+      "method": "GET",
+      "endpoint": "buckets/cross-origin-resource-sharing-policies",
+      "declared": [
+        "allow_errors",
+        "bucket_ids",
+        "bucket_names",
+        "context_names",
+        "continuation_token",
+        "filter",
+        "limit",
+        "names",
+        "offset",
+        "sort"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbBucketCorsPolicy",
+      "parameter": "MemberName",
+      "wireKey": "member_names",
+      "method": "GET",
+      "endpoint": "buckets/cross-origin-resource-sharing-policies",
+      "declared": [
+        "allow_errors",
+        "bucket_ids",
+        "bucket_names",
+        "context_names",
+        "continuation_token",
+        "filter",
+        "limit",
+        "names",
+        "offset",
+        "sort"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbBucketCorsPolicy",
+      "parameter": "PolicyName",
+      "wireKey": "policy_names",
+      "method": "GET",
+      "endpoint": "buckets/cross-origin-resource-sharing-policies",
+      "declared": [
+        "allow_errors",
+        "bucket_ids",
+        "bucket_names",
+        "context_names",
+        "continuation_token",
+        "filter",
+        "limit",
+        "names",
+        "offset",
+        "sort"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbBucketCorsPolicyRule",
+      "parameter": "Id",
+      "wireKey": "ids",
+      "method": "GET",
+      "endpoint": "buckets/cross-origin-resource-sharing-policies/rules",
+      "declared": [
+        "allow_errors",
+        "bucket_ids",
+        "bucket_names",
+        "context_names",
+        "continuation_token",
+        "filter",
+        "limit",
+        "names",
+        "offset",
+        "policy_names",
+        "sort"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbBucketCorsPolicyRule",
+      "parameter": "MemberName",
+      "wireKey": "member_names",
+      "method": "GET",
+      "endpoint": "buckets/cross-origin-resource-sharing-policies/rules",
+      "declared": [
+        "allow_errors",
+        "bucket_ids",
+        "bucket_names",
+        "context_names",
+        "continuation_token",
+        "filter",
+        "limit",
+        "names",
+        "offset",
+        "policy_names",
+        "sort"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbCertificateGroupCertificate",
+      "parameter": "Id",
+      "wireKey": "ids",
+      "method": "GET",
+      "endpoint": "certificate-groups/certificates",
+      "declared": [
+        "certificate_group_ids",
+        "certificate_group_names",
+        "certificate_ids",
+        "certificate_names",
+        "continuation_token",
+        "filter",
+        "limit",
+        "offset",
+        "sort"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbCertificateGroupCertificate",
+      "parameter": "Name",
+      "wireKey": "names",
+      "method": "GET",
+      "endpoint": "certificate-groups/certificates",
+      "declared": [
+        "certificate_group_ids",
+        "certificate_group_names",
+        "certificate_ids",
+        "certificate_names",
+        "continuation_token",
+        "filter",
+        "limit",
+        "offset",
+        "sort"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbFileLock",
+      "parameter": "Id",
+      "wireKey": "ids",
+      "method": "GET",
+      "endpoint": "file-systems/locks",
+      "declared": [
+        "allow_errors",
+        "client_names",
+        "context_names",
+        "continuation_token",
+        "file_system_ids",
+        "file_system_names",
+        "filter",
+        "inodes",
+        "limit",
+        "names",
+        "paths"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbFileLock",
+      "parameter": "Sort",
+      "wireKey": "sort",
+      "method": "GET",
+      "endpoint": "file-systems/locks",
+      "declared": [
+        "allow_errors",
+        "client_names",
+        "context_names",
+        "continuation_token",
+        "file_system_ids",
+        "file_system_names",
+        "filter",
+        "inodes",
+        "limit",
+        "names",
+        "paths"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbFileLockClient",
+      "parameter": "Id",
+      "wireKey": "ids",
+      "method": "GET",
+      "endpoint": "file-systems/locks/clients",
+      "declared": [
+        "allow_errors",
+        "context_names",
+        "continuation_token",
+        "filter",
+        "limit"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbFileLockClient",
+      "parameter": "Name",
+      "wireKey": "names",
+      "method": "GET",
+      "endpoint": "file-systems/locks/clients",
+      "declared": [
+        "allow_errors",
+        "context_names",
+        "continuation_token",
+        "filter",
+        "limit"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbFileLockClient",
+      "parameter": "Sort",
+      "wireKey": "sort",
+      "method": "GET",
+      "endpoint": "file-systems/locks/clients",
+      "declared": [
+        "allow_errors",
+        "context_names",
+        "continuation_token",
+        "filter",
+        "limit"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbFileSystemGroupPerformance",
+      "parameter": "EndTime",
+      "wireKey": "end_time",
+      "method": "GET",
+      "endpoint": "file-systems/groups/performance",
+      "declared": [
+        "file_system_ids",
+        "file_system_names",
+        "filter",
+        "gids",
+        "group_names",
+        "limit",
+        "names",
+        "sort",
+        "total_only"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbFileSystemGroupPerformance",
+      "parameter": "Resolution",
+      "wireKey": "resolution",
+      "method": "GET",
+      "endpoint": "file-systems/groups/performance",
+      "declared": [
+        "file_system_ids",
+        "file_system_names",
+        "filter",
+        "gids",
+        "group_names",
+        "limit",
+        "names",
+        "sort",
+        "total_only"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbFileSystemGroupPerformance",
+      "parameter": "StartTime",
+      "wireKey": "start_time",
+      "method": "GET",
+      "endpoint": "file-systems/groups/performance",
+      "declared": [
+        "file_system_ids",
+        "file_system_names",
+        "filter",
+        "gids",
+        "group_names",
+        "limit",
+        "names",
+        "sort",
+        "total_only"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbFileSystemSession",
+      "parameter": "Filter",
+      "wireKey": "filter",
+      "method": "GET",
+      "endpoint": "file-systems/sessions",
+      "declared": [
+        "allow_errors",
+        "client_names",
+        "context_names",
+        "continuation_token",
+        "limit",
+        "names",
+        "protocols",
+        "user_names"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbFileSystemSession",
+      "parameter": "Sort",
+      "wireKey": "sort",
+      "method": "GET",
+      "endpoint": "file-systems/sessions",
+      "declared": [
+        "allow_errors",
+        "client_names",
+        "context_names",
+        "continuation_token",
+        "limit",
+        "names",
+        "protocols",
+        "user_names"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbFileSystemSnapshot",
+      "parameter": "Name",
+      "wireKey": "names",
+      "method": "GET",
+      "endpoint": "file-system-snapshots",
+      "declared": [
+        "allow_errors",
+        "context_names",
+        "continuation_token",
+        "destroyed",
+        "filter",
+        "ids",
+        "limit",
+        "names_or_owner_names",
+        "offset",
+        "owner_ids",
+        "sort",
+        "total_only"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbFileSystemSnapshot",
+      "parameter": "SourceName",
+      "wireKey": "source_names",
+      "method": "GET",
+      "endpoint": "file-system-snapshots",
+      "declared": [
+        "allow_errors",
+        "context_names",
+        "continuation_token",
+        "destroyed",
+        "filter",
+        "ids",
+        "limit",
+        "names_or_owner_names",
+        "offset",
+        "owner_ids",
+        "sort",
+        "total_only"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbFileSystemSnapshotTransfer",
+      "parameter": "Name",
+      "wireKey": "names",
+      "method": "GET",
+      "endpoint": "file-system-snapshots/transfer",
+      "declared": [
+        "allow_errors",
+        "context_names",
+        "continuation_token",
+        "filter",
+        "ids",
+        "limit",
+        "names_or_owner_names",
+        "offset",
+        "sort",
+        "total_only"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbFileSystemUserPerformance",
+      "parameter": "EndTime",
+      "wireKey": "end_time",
+      "method": "GET",
+      "endpoint": "file-systems/users/performance",
+      "declared": [
+        "file_system_ids",
+        "file_system_names",
+        "filter",
+        "limit",
+        "names",
+        "sort",
+        "total_only",
+        "uids",
+        "user_names"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbFileSystemUserPerformance",
+      "parameter": "Resolution",
+      "wireKey": "resolution",
+      "method": "GET",
+      "endpoint": "file-systems/users/performance",
+      "declared": [
+        "file_system_ids",
+        "file_system_names",
+        "filter",
+        "limit",
+        "names",
+        "sort",
+        "total_only",
+        "uids",
+        "user_names"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbFileSystemUserPerformance",
+      "parameter": "StartTime",
+      "wireKey": "start_time",
+      "method": "GET",
+      "endpoint": "file-systems/users/performance",
+      "declared": [
+        "file_system_ids",
+        "file_system_names",
+        "filter",
+        "limit",
+        "names",
+        "sort",
+        "total_only",
+        "uids",
+        "user_names"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbFleetKey",
+      "parameter": "Name",
+      "wireKey": "names",
+      "method": "GET",
+      "endpoint": "fleets/fleet-key",
+      "declared": [
+        "continuation_token",
+        "filter",
+        "limit",
+        "offset",
+        "sort",
+        "total_only"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbKeytabDownload",
+      "parameter": "Filter",
+      "wireKey": "filter",
+      "method": "GET",
+      "endpoint": "keytabs/download",
+      "declared": [
+        "keytab_ids",
+        "keytab_names"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbKeytabDownload",
+      "parameter": "Id",
+      "wireKey": "ids",
+      "method": "GET",
+      "endpoint": "keytabs/download",
+      "declared": [
+        "keytab_ids",
+        "keytab_names"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbKeytabDownload",
+      "parameter": "Limit",
+      "wireKey": "limit",
+      "method": "GET",
+      "endpoint": "keytabs/download",
+      "declared": [
+        "keytab_ids",
+        "keytab_names"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbKeytabDownload",
+      "parameter": "Name",
+      "wireKey": "names",
+      "method": "GET",
+      "endpoint": "keytabs/download",
+      "declared": [
+        "keytab_ids",
+        "keytab_names"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbKeytabDownload",
+      "parameter": "Sort",
+      "wireKey": "sort",
+      "method": "GET",
+      "endpoint": "keytabs/download",
+      "declared": [
+        "keytab_ids",
+        "keytab_names"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbLegalHoldEntity",
+      "parameter": "Filter",
+      "wireKey": "filter",
+      "method": "GET",
+      "endpoint": "legal-holds/held-entities",
+      "declared": [
+        "continuation_token",
+        "file_system_ids",
+        "file_system_names",
+        "ids",
+        "limit",
+        "names",
+        "paths"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbLegalHoldEntity",
+      "parameter": "HoldId",
+      "wireKey": "hold_ids",
+      "method": "GET",
+      "endpoint": "legal-holds/held-entities",
+      "declared": [
+        "continuation_token",
+        "file_system_ids",
+        "file_system_names",
+        "ids",
+        "limit",
+        "names",
+        "paths"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbLegalHoldEntity",
+      "parameter": "HoldName",
+      "wireKey": "hold_names",
+      "method": "GET",
+      "endpoint": "legal-holds/held-entities",
+      "declared": [
+        "continuation_token",
+        "file_system_ids",
+        "file_system_names",
+        "ids",
+        "limit",
+        "names",
+        "paths"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbLegalHoldEntity",
+      "parameter": "MemberId",
+      "wireKey": "member_ids",
+      "method": "GET",
+      "endpoint": "legal-holds/held-entities",
+      "declared": [
+        "continuation_token",
+        "file_system_ids",
+        "file_system_names",
+        "ids",
+        "limit",
+        "names",
+        "paths"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbLegalHoldEntity",
+      "parameter": "MemberName",
+      "wireKey": "member_names",
+      "method": "GET",
+      "endpoint": "legal-holds/held-entities",
+      "declared": [
+        "continuation_token",
+        "file_system_ids",
+        "file_system_names",
+        "ids",
+        "limit",
+        "names",
+        "paths"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbLegalHoldEntity",
+      "parameter": "Sort",
+      "wireKey": "sort",
+      "method": "GET",
+      "endpoint": "legal-holds/held-entities",
+      "declared": [
+        "continuation_token",
+        "file_system_ids",
+        "file_system_names",
+        "ids",
+        "limit",
+        "names",
+        "paths"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbLog",
+      "parameter": "Filter",
+      "wireKey": "filter",
+      "method": "GET",
+      "endpoint": "logs",
+      "declared": [
+        "end_time",
+        "start_time"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbLog",
+      "parameter": "Limit",
+      "wireKey": "limit",
+      "method": "GET",
+      "endpoint": "logs",
+      "declared": [
+        "end_time",
+        "start_time"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbLog",
+      "parameter": "Sort",
+      "wireKey": "sort",
+      "method": "GET",
+      "endpoint": "logs",
+      "declared": [
+        "end_time",
+        "start_time"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbNetworkConnectionStatistics",
+      "parameter": "Name",
+      "wireKey": "names",
+      "method": "GET",
+      "endpoint": "network-interfaces/network-connection-statistics",
+      "declared": [
+        "current_state",
+        "filter",
+        "limit",
+        "local_host",
+        "local_port",
+        "offset",
+        "remote_host",
+        "remote_port",
+        "sort"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbNetworkInterfaceNeighbor",
+      "parameter": "Name",
+      "wireKey": "names",
+      "method": "GET",
+      "endpoint": "network-interfaces/neighbors",
+      "declared": [
+        "continuation_token",
+        "filter",
+        "limit",
+        "local_port_names",
+        "offset",
+        "sort",
+        "total_item_count"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbNodeGroupNode",
+      "parameter": "GroupId",
+      "wireKey": "group_ids",
+      "method": "GET",
+      "endpoint": "node-groups/nodes",
+      "declared": [
+        "continuation_token",
+        "filter",
+        "limit",
+        "node_group_ids",
+        "node_group_names",
+        "node_ids",
+        "node_names",
+        "offset",
+        "sort"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbNodeGroupNode",
+      "parameter": "GroupName",
+      "wireKey": "group_names",
+      "method": "GET",
+      "endpoint": "node-groups/nodes",
+      "declared": [
+        "continuation_token",
+        "filter",
+        "limit",
+        "node_group_ids",
+        "node_group_names",
+        "node_ids",
+        "node_names",
+        "offset",
+        "sort"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbNodeGroupNode",
+      "parameter": "MemberId",
+      "wireKey": "member_ids",
+      "method": "GET",
+      "endpoint": "node-groups/nodes",
+      "declared": [
+        "continuation_token",
+        "filter",
+        "limit",
+        "node_group_ids",
+        "node_group_names",
+        "node_ids",
+        "node_names",
+        "offset",
+        "sort"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbNodeGroupNode",
+      "parameter": "MemberName",
+      "wireKey": "member_names",
+      "method": "GET",
+      "endpoint": "node-groups/nodes",
+      "declared": [
+        "continuation_token",
+        "filter",
+        "limit",
+        "node_group_ids",
+        "node_group_names",
+        "node_ids",
+        "node_names",
+        "offset",
+        "sort"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbObjectStoreAccessKey",
+      "parameter": "Id",
+      "wireKey": "ids",
+      "method": "GET",
+      "endpoint": "object-store-access-keys",
+      "declared": [
+        "allow_errors",
+        "context_names",
+        "continuation_token",
+        "filter",
+        "limit",
+        "names",
+        "offset",
+        "sort"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbObjectStoreRoleAccessPolicy",
+      "parameter": "RoleId",
+      "wireKey": "role_ids",
+      "method": "GET",
+      "endpoint": "object-store-roles/object-store-access-policies",
+      "declared": [
+        "allow_errors",
+        "context_names",
+        "continuation_token",
+        "filter",
+        "limit",
+        "member_ids",
+        "member_names",
+        "offset",
+        "policy_ids",
+        "policy_names",
+        "sort"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbObjectStoreRoleAccessPolicy",
+      "parameter": "RoleName",
+      "wireKey": "role_names",
+      "method": "GET",
+      "endpoint": "object-store-roles/object-store-access-policies",
+      "declared": [
+        "allow_errors",
+        "context_names",
+        "continuation_token",
+        "filter",
+        "limit",
+        "member_ids",
+        "member_names",
+        "offset",
+        "policy_ids",
+        "policy_names",
+        "sort"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbObjectStoreTrustPolicyRule",
+      "parameter": "PolicyId",
+      "wireKey": "policy_ids",
+      "method": "GET",
+      "endpoint": "object-store-roles/object-store-trust-policies/rules",
+      "declared": [
+        "allow_errors",
+        "context_names",
+        "continuation_token",
+        "filter",
+        "indices",
+        "limit",
+        "names",
+        "offset",
+        "policy_names",
+        "role_ids",
+        "role_names",
+        "sort"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbOpenFile",
+      "parameter": "Filter",
+      "wireKey": "filter",
+      "method": "GET",
+      "endpoint": "file-systems/open-files",
+      "declared": [
+        "client_names",
+        "continuation_token",
+        "file_system_ids",
+        "file_system_names",
+        "ids",
+        "limit",
+        "paths",
+        "protocols",
+        "session_names",
+        "user_names"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbOpenFile",
+      "parameter": "Name",
+      "wireKey": "names",
+      "method": "GET",
+      "endpoint": "file-systems/open-files",
+      "declared": [
+        "client_names",
+        "continuation_token",
+        "file_system_ids",
+        "file_system_names",
+        "ids",
+        "limit",
+        "paths",
+        "protocols",
+        "session_names",
+        "user_names"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbOpenFile",
+      "parameter": "Sort",
+      "wireKey": "sort",
+      "method": "GET",
+      "endpoint": "file-systems/open-files",
+      "declared": [
+        "client_names",
+        "continuation_token",
+        "file_system_ids",
+        "file_system_names",
+        "ids",
+        "limit",
+        "paths",
+        "protocols",
+        "session_names",
+        "user_names"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbRealmDefaults",
+      "parameter": "Name",
+      "wireKey": "names",
+      "method": "GET",
+      "endpoint": "realms/defaults",
+      "declared": [
+        "allow_errors",
+        "context_names",
+        "continuation_token",
+        "filter",
+        "limit",
+        "offset",
+        "realm_ids",
+        "realm_names",
+        "sort"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbResourceAccess",
+      "parameter": "Name",
+      "wireKey": "names",
+      "method": "GET",
+      "endpoint": "resource-accesses",
+      "declared": [
+        "continuation_token",
+        "filter",
+        "ids",
+        "limit",
+        "offset",
+        "sort"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbSupport",
+      "parameter": "Filter",
+      "wireKey": "filter",
+      "method": "GET",
+      "endpoint": "support",
+      "declared": [
+        "ids",
+        "names"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbSupport",
+      "parameter": "Limit",
+      "wireKey": "limit",
+      "method": "GET",
+      "endpoint": "support",
+      "declared": [
+        "ids",
+        "names"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbSupport",
+      "parameter": "Sort",
+      "wireKey": "sort",
+      "method": "GET",
+      "endpoint": "support",
+      "declared": [
+        "ids",
+        "names"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbUserGroupQuotaPolicyRule",
+      "parameter": "PolicyId",
+      "wireKey": "policy_ids",
+      "method": "GET",
+      "endpoint": "user-group-quota-policies/rules",
+      "declared": [
+        "allow_errors",
+        "context_names",
+        "continuation_token",
+        "filter",
+        "ids",
+        "limit",
+        "names",
+        "offset",
+        "sort"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbUserGroupQuotaPolicyRule",
+      "parameter": "PolicyName",
+      "wireKey": "policy_names",
+      "method": "GET",
+      "endpoint": "user-group-quota-policies/rules",
+      "declared": [
+        "allow_errors",
+        "context_names",
+        "continuation_token",
+        "filter",
+        "ids",
+        "limit",
+        "names",
+        "offset",
+        "sort"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbWorkload",
+      "parameter": "Filter",
+      "wireKey": "filter",
+      "method": "GET",
+      "endpoint": "workloads",
+      "declared": [
+        "allow_errors",
+        "context_names",
+        "continuation_token",
+        "destroyed",
+        "ids",
+        "limit",
+        "names"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbWorkload",
+      "parameter": "Sort",
+      "wireKey": "sort",
+      "method": "GET",
+      "endpoint": "workloads",
+      "declared": [
+        "allow_errors",
+        "context_names",
+        "continuation_token",
+        "destroyed",
+        "ids",
+        "limit",
+        "names"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbWorkloadPlacementRecommendation",
+      "parameter": "Filter",
+      "wireKey": "filter",
+      "method": "GET",
+      "endpoint": "workloads/placement-recommendations",
+      "declared": [
+        "allow_errors",
+        "context_names",
+        "continuation_token",
+        "ids",
+        "limit",
+        "names"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Get-PfbWorkloadPlacementRecommendation",
+      "parameter": "Sort",
+      "wireKey": "sort",
+      "method": "GET",
+      "endpoint": "workloads/placement-recommendations",
+      "declared": [
+        "allow_errors",
+        "context_names",
+        "continuation_token",
+        "ids",
+        "limit",
+        "names"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Invoke-PfbNetworkPing",
+      "parameter": "SourceName",
+      "wireKey": "source.name",
+      "method": "GET",
+      "endpoint": "network-interfaces/ping",
+      "declared": [
+        "component_name",
+        "count",
+        "destination",
+        "packet_size",
+        "print_latency",
+        "resolve_hostname",
+        "source"
+      ]
+    },
+    {
+      "severity": "WRONG-RESULTS",
+      "cmdlet": "Invoke-PfbNetworkTrace",
+      "parameter": "SourceName",
+      "wireKey": "source.name",
+      "method": "GET",
+      "endpoint": "network-interfaces/trace",
+      "declared": [
+        "component_name",
+        "destination",
+        "discover_mtu",
+        "fragment_packet",
+        "method",
+        "port",
+        "resolve_hostname",
+        "source"
+      ]
+    },
+    {
+      "severity": "CREATE",
+      "cmdlet": "New-PfbBucketAccessPolicy",
+      "parameter": "MemberName",
+      "wireKey": "member_names",
+      "method": "POST",
+      "endpoint": "buckets/bucket-access-policies",
+      "declared": [
+        "bucket_ids",
+        "bucket_names",
+        "context_names"
+      ]
+    },
+    {
+      "severity": "CREATE",
+      "cmdlet": "New-PfbBucketAccessPolicy",
+      "parameter": "PolicyName",
+      "wireKey": "policy_names",
+      "method": "POST",
+      "endpoint": "buckets/bucket-access-policies",
+      "declared": [
+        "bucket_ids",
+        "bucket_names",
+        "context_names"
+      ]
+    },
+    {
+      "severity": "CREATE",
+      "cmdlet": "New-PfbBucketAccessPolicyRule",
+      "parameter": "MemberName",
+      "wireKey": "member_names",
+      "method": "POST",
+      "endpoint": "buckets/bucket-access-policies/rules",
+      "declared": [
+        "bucket_ids",
+        "bucket_names",
+        "context_names",
+        "names",
+        "policy_names"
+      ]
+    },
+    {
+      "severity": "CREATE",
+      "cmdlet": "New-PfbBucketAuditFilter",
+      "parameter": "MemberName",
+      "wireKey": "member_names",
+      "method": "POST",
+      "endpoint": "buckets/audit-filters",
+      "declared": [
+        "bucket_ids",
+        "bucket_names",
+        "context_names",
+        "names"
+      ]
+    },
+    {
+      "severity": "CREATE",
+      "cmdlet": "New-PfbBucketCorsPolicy",
+      "parameter": "MemberName",
+      "wireKey": "member_names",
+      "method": "POST",
+      "endpoint": "buckets/cross-origin-resource-sharing-policies",
+      "declared": [
+        "bucket_ids",
+        "bucket_names",
+        "context_names"
+      ]
+    },
+    {
+      "severity": "CREATE",
+      "cmdlet": "New-PfbBucketCorsPolicy",
+      "parameter": "PolicyName",
+      "wireKey": "policy_names",
+      "method": "POST",
+      "endpoint": "buckets/cross-origin-resource-sharing-policies",
+      "declared": [
+        "bucket_ids",
+        "bucket_names",
+        "context_names"
+      ]
+    },
+    {
+      "severity": "CREATE",
+      "cmdlet": "New-PfbNlmReclamation",
+      "parameter": "Name",
+      "wireKey": "names",
+      "method": "POST",
+      "endpoint": "file-systems/locks/nlm-reclamations",
+      "declared": [
+        "context_names"
+      ]
+    },
+    {
+      "severity": "CREATE",
+      "cmdlet": "New-PfbObjectStoreRoleAccessPolicy",
+      "parameter": "RoleName",
+      "wireKey": "role_names",
+      "method": "POST",
+      "endpoint": "object-store-roles/object-store-access-policies",
+      "declared": [
+        "context_names",
+        "member_ids",
+        "member_names",
+        "policy_ids",
+        "policy_names"
+      ]
+    },
+    {
+      "severity": "DESTRUCTIVE",
+      "cmdlet": "Remove-PfbBucketAccessPolicy",
+      "parameter": "MemberName",
+      "wireKey": "member_names",
+      "method": "DELETE",
+      "endpoint": "buckets/bucket-access-policies",
+      "declared": [
+        "bucket_ids",
+        "bucket_names",
+        "context_names",
+        "names"
+      ]
+    },
+    {
+      "severity": "DESTRUCTIVE",
+      "cmdlet": "Remove-PfbBucketAccessPolicy",
+      "parameter": "PolicyName",
+      "wireKey": "policy_names",
+      "method": "DELETE",
+      "endpoint": "buckets/bucket-access-policies",
+      "declared": [
+        "bucket_ids",
+        "bucket_names",
+        "context_names",
+        "names"
+      ]
+    },
+    {
+      "severity": "DESTRUCTIVE",
+      "cmdlet": "Remove-PfbBucketAuditFilter",
+      "parameter": "MemberId",
+      "wireKey": "member_ids",
+      "method": "DELETE",
+      "endpoint": "buckets/audit-filters",
+      "declared": [
+        "bucket_ids",
+        "bucket_names",
+        "context_names",
+        "names"
+      ]
+    },
+    {
+      "severity": "DESTRUCTIVE",
+      "cmdlet": "Remove-PfbBucketAuditFilter",
+      "parameter": "MemberName",
+      "wireKey": "member_names",
+      "method": "DELETE",
+      "endpoint": "buckets/audit-filters",
+      "declared": [
+        "bucket_ids",
+        "bucket_names",
+        "context_names",
+        "names"
+      ]
+    },
+    {
+      "severity": "DESTRUCTIVE",
+      "cmdlet": "Remove-PfbBucketCorsPolicy",
+      "parameter": "MemberId",
+      "wireKey": "member_ids",
+      "method": "DELETE",
+      "endpoint": "buckets/cross-origin-resource-sharing-policies",
+      "declared": [
+        "bucket_ids",
+        "bucket_names",
+        "context_names",
+        "names"
+      ]
+    },
+    {
+      "severity": "DESTRUCTIVE",
+      "cmdlet": "Remove-PfbBucketCorsPolicy",
+      "parameter": "MemberName",
+      "wireKey": "member_names",
+      "method": "DELETE",
+      "endpoint": "buckets/cross-origin-resource-sharing-policies",
+      "declared": [
+        "bucket_ids",
+        "bucket_names",
+        "context_names",
+        "names"
+      ]
+    },
+    {
+      "severity": "DESTRUCTIVE",
+      "cmdlet": "Remove-PfbBucketCorsPolicy",
+      "parameter": "PolicyName",
+      "wireKey": "policy_names",
+      "method": "DELETE",
+      "endpoint": "buckets/cross-origin-resource-sharing-policies",
+      "declared": [
+        "bucket_ids",
+        "bucket_names",
+        "context_names",
+        "names"
+      ]
+    },
+    {
+      "severity": "DESTRUCTIVE",
+      "cmdlet": "Remove-PfbFileLock",
+      "parameter": "Id",
+      "wireKey": "ids",
+      "method": "DELETE",
+      "endpoint": "file-systems/locks",
+      "declared": [
+        "client_names",
+        "context_names",
+        "file_system_ids",
+        "file_system_names",
+        "inodes",
+        "names",
+        "paths",
+        "recursive"
+      ]
+    },
+    {
+      "severity": "DESTRUCTIVE",
+      "cmdlet": "Remove-PfbFleetMember",
+      "parameter": "FleetName",
+      "wireKey": "fleet_names",
+      "method": "DELETE",
+      "endpoint": "fleets/members",
+      "declared": [
+        "member_ids",
+        "member_names",
+        "unreachable"
+      ]
+    },
+    {
+      "severity": "DESTRUCTIVE",
+      "cmdlet": "Remove-PfbLocalGroup",
+      "parameter": "Id",
+      "wireKey": "ids",
+      "method": "DELETE",
+      "endpoint": "directory-services/local/groups",
+      "declared": [
+        "context_names",
+        "gids",
+        "local_directory_service_ids",
+        "local_directory_service_names",
+        "names",
+        "sids"
+      ]
+    },
+    {
+      "severity": "DESTRUCTIVE",
+      "cmdlet": "Remove-PfbNetworkAccessRule",
+      "parameter": "PolicyId",
+      "wireKey": "policy_ids",
+      "method": "DELETE",
+      "endpoint": "network-access-policies/rules",
+      "declared": [
+        "ids",
+        "names",
+        "versions"
+      ]
+    },
+    {
+      "severity": "DESTRUCTIVE",
+      "cmdlet": "Remove-PfbNetworkAccessRule",
+      "parameter": "PolicyName",
+      "wireKey": "policy_names",
+      "method": "DELETE",
+      "endpoint": "network-access-policies/rules",
+      "declared": [
+        "ids",
+        "names",
+        "versions"
+      ]
+    },
+    {
+      "severity": "DESTRUCTIVE",
+      "cmdlet": "Remove-PfbNfsExportRule",
+      "parameter": "PolicyId",
+      "wireKey": "policy_ids",
+      "method": "DELETE",
+      "endpoint": "nfs-export-policies/rules",
+      "declared": [
+        "context_names",
+        "ids",
+        "names",
+        "versions"
+      ]
+    },
+    {
+      "severity": "DESTRUCTIVE",
+      "cmdlet": "Remove-PfbNfsExportRule",
+      "parameter": "PolicyName",
+      "wireKey": "policy_names",
+      "method": "DELETE",
+      "endpoint": "nfs-export-policies/rules",
+      "declared": [
+        "context_names",
+        "ids",
+        "names",
+        "versions"
+      ]
+    },
+    {
+      "severity": "DESTRUCTIVE",
+      "cmdlet": "Remove-PfbNodeGroupNode",
+      "parameter": "GroupName",
+      "wireKey": "group_names",
+      "method": "DELETE",
+      "endpoint": "node-groups/nodes",
+      "declared": [
+        "node_group_ids",
+        "node_group_names",
+        "node_ids",
+        "node_names"
+      ]
+    },
+    {
+      "severity": "DESTRUCTIVE",
+      "cmdlet": "Remove-PfbNodeGroupNode",
+      "parameter": "MemberName",
+      "wireKey": "member_names",
+      "method": "DELETE",
+      "endpoint": "node-groups/nodes",
+      "declared": [
+        "node_group_ids",
+        "node_group_names",
+        "node_ids",
+        "node_names"
+      ]
+    },
+    {
+      "severity": "DESTRUCTIVE",
+      "cmdlet": "Remove-PfbObjectStoreAccessKey",
+      "parameter": "Id",
+      "wireKey": "ids",
+      "method": "DELETE",
+      "endpoint": "object-store-access-keys",
+      "declared": [
+        "context_names",
+        "names"
+      ]
+    },
+    {
+      "severity": "DESTRUCTIVE",
+      "cmdlet": "Remove-PfbObjectStoreRoleAccessPolicy",
+      "parameter": "RoleName",
+      "wireKey": "role_names",
+      "method": "DELETE",
+      "endpoint": "object-store-roles/object-store-access-policies",
+      "declared": [
+        "context_names",
+        "member_ids",
+        "member_names",
+        "policy_ids",
+        "policy_names"
+      ]
+    },
+    {
+      "severity": "DESTRUCTIVE",
+      "cmdlet": "Remove-PfbOpenFile",
+      "parameter": "Name",
+      "wireKey": "names",
+      "method": "DELETE",
+      "endpoint": "file-systems/open-files",
+      "declared": [
+        "ids"
+      ]
+    },
+    {
+      "severity": "DESTRUCTIVE",
+      "cmdlet": "Remove-PfbResourceAccess",
+      "parameter": "Name",
+      "wireKey": "names",
+      "method": "DELETE",
+      "endpoint": "resource-accesses",
+      "declared": [
+        "ids"
+      ]
+    },
+    {
+      "severity": "DESTRUCTIVE",
+      "cmdlet": "Remove-PfbSmbClientRule",
+      "parameter": "PolicyId",
+      "wireKey": "policy_ids",
+      "method": "DELETE",
+      "endpoint": "smb-client-policies/rules",
+      "declared": [
+        "context_names",
+        "ids",
+        "names",
+        "versions"
+      ]
+    },
+    {
+      "severity": "DESTRUCTIVE",
+      "cmdlet": "Remove-PfbSmbClientRule",
+      "parameter": "PolicyName",
+      "wireKey": "policy_names",
+      "method": "DELETE",
+      "endpoint": "smb-client-policies/rules",
+      "declared": [
+        "context_names",
+        "ids",
+        "names",
+        "versions"
+      ]
+    }
+  ],
+  "noSurvivingSelector": [
+    {
+      "cmdlet": "Get-PfbBucketAuditFilter",
+      "method": "GET",
+      "endpoint": "buckets/audit-filters"
+    },
+    {
+      "cmdlet": "Get-PfbCertificateGroupCertificate",
+      "method": "GET",
+      "endpoint": "certificate-groups/certificates"
+    },
+    {
+      "cmdlet": "Get-PfbFileLockClient",
+      "method": "GET",
+      "endpoint": "file-systems/locks/clients"
+    },
+    {
+      "cmdlet": "Get-PfbFleetKey",
+      "method": "GET",
+      "endpoint": "fleets/fleet-key"
+    },
+    {
+      "cmdlet": "Get-PfbKeytabDownload",
+      "method": "GET",
+      "endpoint": "keytabs/download"
+    },
+    {
+      "cmdlet": "Get-PfbLegalHoldEntity",
+      "method": "GET",
+      "endpoint": "legal-holds/held-entities"
+    },
+    {
+      "cmdlet": "Get-PfbNetworkConnectionStatistics",
+      "method": "GET",
+      "endpoint": "network-interfaces/network-connection-statistics"
+    },
+    {
+      "cmdlet": "Get-PfbNetworkInterfaceNeighbor",
+      "method": "GET",
+      "endpoint": "network-interfaces/neighbors"
+    },
+    {
+      "cmdlet": "Get-PfbNodeGroupNode",
+      "method": "GET",
+      "endpoint": "node-groups/nodes"
+    },
+    {
+      "cmdlet": "Get-PfbRealmDefaults",
+      "method": "GET",
+      "endpoint": "realms/defaults"
+    },
+    {
+      "cmdlet": "New-PfbBucketAccessPolicy",
+      "method": "POST",
+      "endpoint": "buckets/bucket-access-policies"
+    },
+    {
+      "cmdlet": "New-PfbBucketAuditFilter",
+      "method": "POST",
+      "endpoint": "buckets/audit-filters"
+    },
+    {
+      "cmdlet": "New-PfbBucketCorsPolicy",
+      "method": "POST",
+      "endpoint": "buckets/cross-origin-resource-sharing-policies"
+    },
+    {
+      "cmdlet": "New-PfbNlmReclamation",
+      "method": "POST",
+      "endpoint": "file-systems/locks/nlm-reclamations"
+    },
+    {
+      "cmdlet": "Remove-PfbBucketAccessPolicy",
+      "method": "DELETE",
+      "endpoint": "buckets/bucket-access-policies"
+    },
+    {
+      "cmdlet": "Remove-PfbBucketAuditFilter",
+      "method": "DELETE",
+      "endpoint": "buckets/audit-filters"
+    },
+    {
+      "cmdlet": "Remove-PfbBucketCorsPolicy",
+      "method": "DELETE",
+      "endpoint": "buckets/cross-origin-resource-sharing-policies"
+    },
+    {
+      "cmdlet": "Remove-PfbNodeGroupNode",
+      "method": "DELETE",
+      "endpoint": "node-groups/nodes"
+    }
+  ]
+}

--- a/Reports/README.md
+++ b/Reports/README.md
@@ -25,6 +25,9 @@ locally first — see `tools/README.md`'s `Update-PfbApiSpecs.ps1` step):
 
 | `PfbPipelineSelectorMap.json` / `.md` | "Can a piped object bind this cmdlet's selector, or does it stringify into the filter?" — issue #90. Every pipeline-bound selector probed against its resource family's real response shape, by invoking the actual cmdlet with the HTTP layer shadowed. Verdicts are observed, never inferred. | `tools/Build-PfbPipelineSelectorMap.ps1` |
 
+All of the above are **reporting only** — none of them edit any `Public/` cmdlet. A human
+(or an agent, on request) reads a report and decides what, if anything, to build next.
+
 ### `PfbDeadKeyReport.json` — what `noSurvivingSelector` does *not* cover
 
 The `noSurvivingSelector` list is the report's highest-severity class: every selector-shaped
@@ -46,9 +49,6 @@ here — the full account, with the measurements behind each, is the comment abo
   suppresses its operation's group however dead that operation's real query selectors are. A
   request-body `name` can never act as a query selector, so this is under-reporting — the safe
   direction — rather than a wrong answer.
-
-All of the above are **reporting only** — none of them edit any `Public/` cmdlet. A human
-(or an agent, on request) reads a report and decides what, if anything, to build next.
 
 **Orienting yourself cold:** if you've been handed this repo and told "something changed
 in the API," start at `PfbApiDriftReport.md` — it's the newest, most targeted summary and

--- a/Reports/README.md
+++ b/Reports/README.md
@@ -10,6 +10,7 @@ locally first — see `tools/README.md`'s `Update-PfbApiSpecs.ps1` step):
 ./tools/Build-PfbValueEnumMap.ps1
 ./tools/Build-PfbFieldCmdletMap.ps1
 ./tools/Build-PfbApiDriftReport.ps1
+./tools/Build-PfbDeadKeyReport.ps1
 ./tools/Build-PfbPipelineSelectorMap.ps1
 ```
 
@@ -20,6 +21,7 @@ locally first — see `tools/README.md`'s `Update-PfbApiSpecs.ps1` step):
 | `PfbFieldCmdletMap.json` | "Which typed `Public/` parameters lacking a `ValidateSet` today should get one?" | `tools/Build-PfbFieldCmdletMap.ps1` |
 | `PfbFieldCmdletMapping.md` | Same, as a readable table. | `tools/Build-PfbFieldCmdletMap.ps1` |
 | `PfbApiDriftReport.json` / `.md` | "What's changed in the API that this module hasn't caught up to yet?" — new endpoints with no cmdlet, new parameters on endpoints we already call, drift on existing `ValidateSet`s, and new `ValidateSet` candidates. Pass `-SinceVersion '<prior version>'` to isolate just the newest release's additions (uncovered endpoints + parameter gaps only) instead of the full backlog. | `tools/Build-PfbApiDriftReport.ps1` |
+| `PfbDeadKeyReport.json` | "Which Public/ cmdlet query keys does the endpoint silently discard, and which cmdlet operations have no surviving selector?" | `tools/Build-PfbDeadKeyReport.ps1` |
 
 | `PfbPipelineSelectorMap.json` / `.md` | "Can a piped object bind this cmdlet's selector, or does it stringify into the filter?" — issue #90. Every pipeline-bound selector probed against its resource family's real response shape, by invoking the actual cmdlet with the HTTP layer shadowed. Verdicts are observed, never inferred. | `tools/Build-PfbPipelineSelectorMap.ps1` |
 

--- a/Reports/README.md
+++ b/Reports/README.md
@@ -25,6 +25,28 @@ locally first — see `tools/README.md`'s `Update-PfbApiSpecs.ps1` step):
 
 | `PfbPipelineSelectorMap.json` / `.md` | "Can a piped object bind this cmdlet's selector, or does it stringify into the filter?" — issue #90. Every pipeline-bound selector probed against its resource family's real response shape, by invoking the actual cmdlet with the HTTP layer shadowed. Verdicts are observed, never inferred. | `tools/Build-PfbPipelineSelectorMap.ps1` |
 
+### `PfbDeadKeyReport.json` — what `noSurvivingSelector` does *not* cover
+
+The `noSurvivingSelector` list is the report's highest-severity class: every selector-shaped
+query key the operation sends is undeclared, so the request arrives with no usable selector.
+It **deliberately under-reports**, and a consumer that reads it as complete (for example when
+deriving a refusal rail) will have holes it does not know about. Three narrowings, summarised
+here — the full account, with the measurements behind each, is the comment above
+`$noSurvivingSelectorRecords` in `tools/Build-PfbDeadKeyReport.ps1`:
+
+- **It is operation-scoped, not cmdlet-scoped.** Group identity is (cmdlet, method, endpoint).
+  A selector skipped as `endpoint/method ambiguous` carries a null method/endpoint and so forms
+  its own null-keyed group; it cannot suppress the same cmdlet's real group. 10 such records
+  exist today.
+- **It means "no *identifiable* selector was skipped."** A parameter whose wire name could not
+  be resolved is dropped before the shape test — the shape of an unresolvable name is
+  unknowable — so the 125 `wire name unresolved` records fall entirely outside the rule.
+- **`Update-Pfb*` cmdlets carrying `-NewName` can never appear.** Their body-surface `name`
+  (plus `ServicePrincipalNames` / `SubjectAlternativeNames`) is selector-shaped by name, so it
+  suppresses its operation's group however dead that operation's real query selectors are. A
+  request-body `name` can never act as a query selector, so this is under-reporting — the safe
+  direction — rather than a wrong answer.
+
 All of the above are **reporting only** — none of them edit any `Public/` cmdlet. A human
 (or an agent, on request) reads a report and decides what, if anything, to build next.
 

--- a/Tests/Build-PfbDeadKeyReport.Tests.ps1
+++ b/Tests/Build-PfbDeadKeyReport.Tests.ps1
@@ -9,9 +9,15 @@
     REGENERATING and comparing, and by driving the classifier over synthetic fixtures whose
     expected answers are known independently of the real repo's contents.
 
+    TWO DESCRIBES, split on a dependency boundary: regeneration needs the real tools/specs
+    cache, the real Public/ tree and the committed artifact; synthetic classification needs
+    only a fixture it builds itself. One shared BeforeAll would have let a broken fixture red
+    the two regeneration tests, reporting the real generator as broken when it was fine.
+    The total It count is unchanged by the split, so 5.1 still contributes exactly six skips.
+
     WHY EVERY DESCRIBE CARRIES -Skip:($PSVersionTable.PSVersion.Major -lt 7):
     the generator carries `#Requires -Version 7.0`, so it cannot run on Windows PowerShell 5.1
-    at all. It is invoked ONLY from the gated Describe's own BeforeAll. Do not add an ungated
+    at all. It is invoked ONLY from a gated Describe's own BeforeAll. Do not add an ungated
     block to this file and do not move the BeforeAll to file scope: a `#Requires -Version 7.0`
     script pulled in by an UNGATED BeforeAll kills every test in the file with a CONTAINER
     FAILURE rather than skipping them. That happened in this repo, at a cost of 65 tests -- see
@@ -28,7 +34,15 @@
     like one level up. So the cache check throws.
 #>
 
-Describe 'Build-PfbDeadKeyReport (regeneration gate, spec cache required, PS7 only)' -Skip:($PSVersionTable.PSVersion.Major -lt 7) {
+Describe 'Build-PfbDeadKeyReport regeneration (real spec cache required, PS7 only)' -Skip:($PSVersionTable.PSVersion.Major -lt 7) {
+
+    # SPLIT FROM THE SYNTHETIC BLOCK BELOW ON PURPOSE, and the seam is a dependency boundary
+    # rather than a stylistic one: this half needs the real ~50MB tools/specs cache, the real
+    # Public/ tree and the committed artifact; the half below needs a fixture and nothing else.
+    # Sharing one BeforeAll made a throw anywhere red all six tests, so a broken FIXTURE would
+    # have reported the real generator as broken. Splitting also stops the synthetic half
+    # depending on a cache it never reads. Both halves keep the PS7 gate, and the total It
+    # count is unchanged, so 5.1 still contributes exactly six skips.
 
     BeforeAll {
         $script:repoRoot = Split-Path -Parent $PSScriptRoot
@@ -38,12 +52,16 @@ Describe 'Build-PfbDeadKeyReport (regeneration gate, spec cache required, PS7 on
 
         # HARD FAILURE, not a skip -- see the header. Assert-PfbSpecCache.ps1 throws when the
         # directory is absent or holds fewer than its floor of fb*.json files.
-        & (Join-Path $repoRoot 'scripts/Assert-PfbSpecCache.ps1') -SpecsDirectory $specsDirectory | Out-Null
+        #
+        # Deliberately NOT piped to Out-Null: that script reports its count with Write-Host,
+        # which bypasses the pipeline, so the line would suppress nothing while reading as
+        # though it did. Its "<path> contains N spec file(s)." appearing in the Pester output
+        # is the useful confirmation that the cache this half depends on actually arrived.
+        & (Join-Path $repoRoot 'scripts/Assert-PfbSpecCache.ps1') -SpecsDirectory $specsDirectory
 
         $script:workRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("PfbDeadKeyGate_" + [guid]::NewGuid().ToString('N'))
         New-Item -ItemType Directory -Path $workRoot -Force | Out-Null
 
-        # --- Assertions 1 and 2: two real regenerations, from two different working dirs -----
         $script:regeneratedPath = Join-Path $workRoot 'regenerated.json'
         & $generatorPath -OutputPath $regeneratedPath | Out-Null
 
@@ -55,8 +73,54 @@ Describe 'Build-PfbDeadKeyReport (regeneration gate, spec cache required, PS7 on
         finally {
             Pop-Location
         }
+    }
 
-        # --- Assertions 3-6: a synthetic Public/, capability map and spec ---------------------
+    AfterAll {
+        if ($script:workRoot -and (Test-Path -LiteralPath $script:workRoot)) {
+            Remove-Item -LiteralPath $script:workRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'regenerates byte-for-byte identically to the committed Reports/PfbDeadKeyReport.json' {
+        # THE stale-artifact check. Reds when the generator, the Public/ cmdlets, or the pinned
+        # spec moved without the artifact being regenerated and committed alongside them.
+        $committedBytes = [System.IO.File]::ReadAllBytes($committedReportPath)
+        $regeneratedBytes = [System.IO.File]::ReadAllBytes($regeneratedPath)
+        $regeneratedBytes.Length | Should -Be $committedBytes.Length -Because "the committed artifact is stale: regenerating produced $($regeneratedBytes.Length) bytes against the committed $($committedBytes.Length). Re-run tools/Build-PfbDeadKeyReport.ps1 and commit the result."
+
+        $firstDifference = -1
+        for ($i = 0; $i -lt [Math]::Min($committedBytes.Length, $regeneratedBytes.Length); $i++) {
+            if ($committedBytes[$i] -ne $regeneratedBytes[$i]) { $firstDifference = $i; break }
+        }
+        $firstDifference | Should -Be -1 -Because "the committed artifact is stale: it first diverges from a fresh regeneration at byte $firstDifference. Re-run tools/Build-PfbDeadKeyReport.ps1 and commit the result."
+    }
+
+    It 'produces the same bytes when regenerated from a different working directory' {
+        # Location independence, asserted rather than assumed: an absolute path or a
+        # CWD-relative default leaking into the artifact makes a regeneration from a git
+        # worktree rewrite lines that did not semantically change, burying the real diff.
+        $fromRepoRoot = [System.IO.File]::ReadAllBytes($regeneratedPath)
+        $fromElsewhere = [System.IO.File]::ReadAllBytes($regeneratedElsewherePath)
+        $fromElsewhere.Length | Should -Be $fromRepoRoot.Length -Because 'the generated report must not depend on the process working directory'
+
+        $firstDifference = -1
+        for ($i = 0; $i -lt [Math]::Min($fromRepoRoot.Length, $fromElsewhere.Length); $i++) {
+            if ($fromRepoRoot[$i] -ne $fromElsewhere[$i]) { $firstDifference = $i; break }
+        }
+        $firstDifference | Should -Be -1 -Because "regenerating from '$workRoot' instead of the repo root changed the output at byte $firstDifference -- the generator is resolving something against the working directory"
+    }
+}
+
+Describe 'Build-PfbDeadKeyReport classification (synthetic fixture, no spec cache, PS7 only)' -Skip:($PSVersionTable.PSVersion.Major -lt 7) {
+
+    BeforeAll {
+        $script:repoRoot = Split-Path -Parent $PSScriptRoot
+        $script:generatorPath = Join-Path $repoRoot 'tools/Build-PfbDeadKeyReport.ps1'
+        $script:workRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("PfbDeadKeyFixture_" + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $workRoot -Force | Out-Null
+
+        # No Assert-PfbSpecCache call here, and that is the point of the split: every input this
+        # block reads is built below, so the real cache is irrelevant to it.
         # EVERY spec fixture node is a [PSCustomObject], never a bare @{}. Resolve-PfbRef's loop
         # condition tests `$current.PSObject.Properties.Name -contains '$ref'`, which NEVER
         # matches on a hashtable, so a @{} fixture silently drops every $ref'd parameter and the
@@ -195,35 +259,6 @@ function Get-PfbSyntheticContext {
         if ($script:workRoot -and (Test-Path -LiteralPath $script:workRoot)) {
             Remove-Item -LiteralPath $script:workRoot -Recurse -Force -ErrorAction SilentlyContinue
         }
-    }
-
-    It 'regenerates byte-for-byte identically to the committed Reports/PfbDeadKeyReport.json' {
-        # THE stale-artifact check. Reds when the generator, the Public/ cmdlets, or the pinned
-        # spec moved without the artifact being regenerated and committed alongside them.
-        $committedBytes = [System.IO.File]::ReadAllBytes($committedReportPath)
-        $regeneratedBytes = [System.IO.File]::ReadAllBytes($regeneratedPath)
-        $regeneratedBytes.Length | Should -Be $committedBytes.Length -Because "the committed artifact is stale: regenerating produced $($regeneratedBytes.Length) bytes against the committed $($committedBytes.Length). Re-run tools/Build-PfbDeadKeyReport.ps1 and commit the result."
-
-        $firstDifference = -1
-        for ($i = 0; $i -lt [Math]::Min($committedBytes.Length, $regeneratedBytes.Length); $i++) {
-            if ($committedBytes[$i] -ne $regeneratedBytes[$i]) { $firstDifference = $i; break }
-        }
-        $firstDifference | Should -Be -1 -Because "the committed artifact is stale: it first diverges from a fresh regeneration at byte $firstDifference. Re-run tools/Build-PfbDeadKeyReport.ps1 and commit the result."
-    }
-
-    It 'produces the same bytes when regenerated from a different working directory' {
-        # Location independence, asserted rather than assumed: an absolute path or a
-        # CWD-relative default leaking into the artifact makes a regeneration from a git
-        # worktree rewrite lines that did not semantically change, burying the real diff.
-        $fromRepoRoot = [System.IO.File]::ReadAllBytes($regeneratedPath)
-        $fromElsewhere = [System.IO.File]::ReadAllBytes($regeneratedElsewherePath)
-        $fromElsewhere.Length | Should -Be $fromRepoRoot.Length -Because 'the generated report must not depend on the process working directory'
-
-        $firstDifference = -1
-        for ($i = 0; $i -lt [Math]::Min($fromRepoRoot.Length, $fromElsewhere.Length); $i++) {
-            if ($fromRepoRoot[$i] -ne $fromElsewhere[$i]) { $firstDifference = $i; break }
-        }
-        $firstDifference | Should -Be -1 -Because "regenerating from '$workRoot' instead of the repo root changed the output at byte $firstDifference -- the generator is resolving something against the working directory"
     }
 
     It 'classifies a synthetic undeclared query key as a dead key, with the verb-derived severity' {

--- a/Tests/Build-PfbDeadKeyReport.Tests.ps1
+++ b/Tests/Build-PfbDeadKeyReport.Tests.ps1
@@ -59,14 +59,14 @@ Describe 'Build-PfbDeadKeyReport regeneration (real spec cache required, PS7 onl
         # is the useful confirmation that the cache this half depends on actually arrived.
         & (Join-Path $repoRoot 'scripts/Assert-PfbSpecCache.ps1') -SpecsDirectory $specsDirectory
 
-        $script:workRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("PfbDeadKeyGate_" + [guid]::NewGuid().ToString('N'))
-        New-Item -ItemType Directory -Path $workRoot -Force | Out-Null
+        $script:regenWorkRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("PfbDeadKeyGate_" + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $regenWorkRoot -Force | Out-Null
 
-        $script:regeneratedPath = Join-Path $workRoot 'regenerated.json'
+        $script:regeneratedPath = Join-Path $regenWorkRoot 'regenerated.json'
         & $generatorPath -OutputPath $regeneratedPath | Out-Null
 
-        $script:regeneratedElsewherePath = Join-Path $workRoot 'regenerated-elsewhere.json'
-        Push-Location $workRoot
+        $script:regeneratedElsewherePath = Join-Path $regenWorkRoot 'regenerated-elsewhere.json'
+        Push-Location $regenWorkRoot
         try {
             & $generatorPath -OutputPath $regeneratedElsewherePath | Out-Null
         }
@@ -76,8 +76,15 @@ Describe 'Build-PfbDeadKeyReport regeneration (real spec cache required, PS7 onl
     }
 
     AfterAll {
-        if ($script:workRoot -and (Test-Path -LiteralPath $script:workRoot)) {
-            Remove-Item -LiteralPath $script:workRoot -Recurse -Force -ErrorAction SilentlyContinue
+        # Its OWN variable, not a name shared with the block below -- a shared $script:workRoot
+        # crossed exactly the boundary the split exists to isolate, and left this AfterAll able
+        # to delete the other block's directory. Guarded with Get-Variable rather than a bare
+        # truthiness test because this AfterAll still runs when BeforeAll threw before the
+        # assignment (an absent spec cache does exactly that), and reading an undefined variable
+        # would throw under StrictMode, turning a clear cache failure into a confusing second one.
+        $existing = Get-Variable -Name 'regenWorkRoot' -Scope Script -ErrorAction SilentlyContinue
+        if ($existing -and $existing.Value -and (Test-Path -LiteralPath $existing.Value)) {
+            Remove-Item -LiteralPath $existing.Value -Recurse -Force -ErrorAction SilentlyContinue
         }
     }
 
@@ -107,7 +114,7 @@ Describe 'Build-PfbDeadKeyReport regeneration (real spec cache required, PS7 onl
         for ($i = 0; $i -lt [Math]::Min($fromRepoRoot.Length, $fromElsewhere.Length); $i++) {
             if ($fromRepoRoot[$i] -ne $fromElsewhere[$i]) { $firstDifference = $i; break }
         }
-        $firstDifference | Should -Be -1 -Because "regenerating from '$workRoot' instead of the repo root changed the output at byte $firstDifference -- the generator is resolving something against the working directory"
+        $firstDifference | Should -Be -1 -Because "regenerating from '$regenWorkRoot' instead of the repo root changed the output at byte $firstDifference -- the generator is resolving something against the working directory"
     }
 }
 
@@ -116,8 +123,8 @@ Describe 'Build-PfbDeadKeyReport classification (synthetic fixture, no spec cach
     BeforeAll {
         $script:repoRoot = Split-Path -Parent $PSScriptRoot
         $script:generatorPath = Join-Path $repoRoot 'tools/Build-PfbDeadKeyReport.ps1'
-        $script:workRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("PfbDeadKeyFixture_" + [guid]::NewGuid().ToString('N'))
-        New-Item -ItemType Directory -Path $workRoot -Force | Out-Null
+        $script:fixtureWorkRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("PfbDeadKeyFixture_" + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $fixtureWorkRoot -Force | Out-Null
 
         # No Assert-PfbSpecCache call here, and that is the point of the split: every input this
         # block reads is built below, so the real cache is irrelevant to it.
@@ -134,8 +141,8 @@ Describe 'Build-PfbDeadKeyReport classification (synthetic fixture, no spec cach
         # selector would vanish, and assertion 3's cmdlet would wrongly join noSurvivingSelector.
         # That makes the hollow-fixture trap detectable rather than silent.
         $script:fixtureVersion = '9.9'
-        $script:fixtureSpecsDirectory = Join-Path $workRoot 'specs'
-        $script:fixturePublicDirectory = Join-Path $workRoot 'Public'
+        $script:fixtureSpecsDirectory = Join-Path $fixtureWorkRoot 'specs'
+        $script:fixturePublicDirectory = Join-Path $fixtureWorkRoot 'Public'
         New-Item -ItemType Directory -Path $fixtureSpecsDirectory -Force | Out-Null
         New-Item -ItemType Directory -Path $fixturePublicDirectory -Force | Out-Null
 
@@ -179,7 +186,7 @@ Describe 'Build-PfbDeadKeyReport classification (synthetic fixture, no spec cach
         $fixtureSpec | ConvertTo-Json -Depth 20 |
             Set-Content -LiteralPath (Join-Path $fixtureSpecsDirectory "fb$fixtureVersion.json") -Encoding UTF8
 
-        $fixtureCapabilityMapPath = Join-Path $workRoot 'PfbFixtureCapabilityMap.json'
+        $fixtureCapabilityMapPath = Join-Path $fixtureWorkRoot 'PfbFixtureCapabilityMap.json'
         ([PSCustomObject]@{ generatedFrom = @($fixtureVersion) } | ConvertTo-Json -Depth 5) |
             Set-Content -LiteralPath $fixtureCapabilityMapPath -Encoding UTF8
 
@@ -239,7 +246,7 @@ function Get-PfbSyntheticContext {
 }
 '@
 
-        $script:syntheticReportPath = Join-Path $workRoot 'synthetic.json'
+        $script:syntheticReportPath = Join-Path $fixtureWorkRoot 'synthetic.json'
         & $generatorPath `
             -SpecsDirectory $fixtureSpecsDirectory `
             -PublicDirectory $fixturePublicDirectory `
@@ -256,8 +263,10 @@ function Get-PfbSyntheticContext {
     }
 
     AfterAll {
-        if ($script:workRoot -and (Test-Path -LiteralPath $script:workRoot)) {
-            Remove-Item -LiteralPath $script:workRoot -Recurse -Force -ErrorAction SilentlyContinue
+        # Its own variable and its own guard -- see the note on the sibling block's AfterAll.
+        $existing = Get-Variable -Name 'fixtureWorkRoot' -Scope Script -ErrorAction SilentlyContinue
+        if ($existing -and $existing.Value -and (Test-Path -LiteralPath $existing.Value)) {
+            Remove-Item -LiteralPath $existing.Value -Recurse -Force -ErrorAction SilentlyContinue
         }
     }
 

--- a/Tests/Build-PfbDeadKeyReport.Tests.ps1
+++ b/Tests/Build-PfbDeadKeyReport.Tests.ps1
@@ -91,15 +91,44 @@ Describe 'Build-PfbDeadKeyReport regeneration (real spec cache required, PS7 onl
     It 'regenerates byte-for-byte identically to the committed Reports/PfbDeadKeyReport.json' {
         # THE stale-artifact check. Reds when the generator, the Public/ cmdlets, or the pinned
         # spec moved without the artifact being regenerated and committed alongside them.
-        $committedBytes = [System.IO.File]::ReadAllBytes($committedReportPath)
-        $regeneratedBytes = [System.IO.File]::ReadAllBytes($regeneratedPath)
-        $regeneratedBytes.Length | Should -Be $committedBytes.Length -Because "the committed artifact is stale: regenerating produced $($regeneratedBytes.Length) bytes against the committed $($committedBytes.Length). Re-run tools/Build-PfbDeadKeyReport.ps1 and commit the result."
+        #
+        # BOTH SIDES ARE NEWLINE-NORMALISED -- both, not just the one that happened to break.
+        # That is this repo's already-written answer to exactly this problem: see
+        # Get-PfbSelectorArtifactHash at Tests/PfbPipelineSelectorRail.Tests.ps1:47-76, whose doc
+        # comment names the CI run that hit it (31830362870) and ends "Normalise both, not the
+        # one that happened to break." The committed blob is LF; the generator ends in
+        # Set-Content, which emits [Environment]::NewLine, so a Windows regeneration is CRLF.
+        # There is no .gitattributes in this repo, so a checkout's endings are whatever the
+        # clone's core.autocrlf says -- CI is green on a raw byte compare only because
+        # autocrlf=true on the Windows runners happens to make the checkout CRLF too. A
+        # contributor with core.autocrlf=false or input would get an LF checkout against a CRLF
+        # regeneration and be told "the committed artifact is stale", which is false, and would
+        # commit a 53KB whitespace-only diff that then breaks the Linux legs.
+        #
+        # ReadAllText also drops a byte-order mark, which is correct here for the same reason it
+        # is correct there: content is what this test asserts. Real content drift still reds --
+        # a one-character change inside a wireKey was measured to fail this It after this
+        # normalisation was added.
+        #
+        # The SECOND comparison below deliberately stays a RAW BYTE compare: both of its sides
+        # are generator output on one platform with no checkout in between, so byte-for-byte is
+        # both correct and strictly stronger there. Do not "make them consistent".
+        $committedText = [System.IO.File]::ReadAllText($committedReportPath) -replace "`r`n", "`n"
+        $regeneratedText = [System.IO.File]::ReadAllText($regeneratedPath) -replace "`r`n", "`n"
+        $regeneratedText.Length | Should -Be $committedText.Length -Because "the committed artifact is stale: regenerating produced $($regeneratedText.Length) newline-normalised characters against the committed $($committedText.Length). Re-run tools/Build-PfbDeadKeyReport.ps1 and commit the result."
 
+        # Located in the NORMALISED text, so the offset it reports is an offset into the thing
+        # actually being compared rather than into the raw bytes.
         $firstDifference = -1
-        for ($i = 0; $i -lt [Math]::Min($committedBytes.Length, $regeneratedBytes.Length); $i++) {
-            if ($committedBytes[$i] -ne $regeneratedBytes[$i]) { $firstDifference = $i; break }
+        for ($i = 0; $i -lt [Math]::Min($committedText.Length, $regeneratedText.Length); $i++) {
+            if ($committedText[$i] -ne $regeneratedText[$i]) { $firstDifference = $i; break }
         }
-        $firstDifference | Should -Be -1 -Because "the committed artifact is stale: it first diverges from a fresh regeneration at byte $firstDifference. Re-run tools/Build-PfbDeadKeyReport.ps1 and commit the result."
+        $context = ''
+        if ($firstDifference -ge 0) {
+            $start = [Math]::Max(0, $firstDifference - 40)
+            $context = " Committed text around it: '" + $committedText.Substring($start, [Math]::Min(80, $committedText.Length - $start)) + "'."
+        }
+        $firstDifference | Should -Be -1 -Because "the committed artifact is stale: it first diverges from a fresh regeneration at normalised character $firstDifference.$context Re-run tools/Build-PfbDeadKeyReport.ps1 and commit the result."
     }
 
     It 'produces the same bytes when regenerated from a different working directory' {

--- a/Tests/Build-PfbDeadKeyReport.Tests.ps1
+++ b/Tests/Build-PfbDeadKeyReport.Tests.ps1
@@ -1,0 +1,267 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+<#
+.SYNOPSIS
+    Regeneration gate for tools/Build-PfbDeadKeyReport.ps1 -- catches a STALE committed artifact.
+.DESCRIPTION
+    Tests/CommittedDeadKeyReport.Tests.ps1 reads only the committed
+    Reports/PfbDeadKeyReport.json, so it runs on every CI leg but is blind to one thing: whether
+    that artifact still reflects the code and the pinned spec. This file closes that hole by
+    REGENERATING and comparing, and by driving the classifier over synthetic fixtures whose
+    expected answers are known independently of the real repo's contents.
+
+    WHY EVERY DESCRIBE CARRIES -Skip:($PSVersionTable.PSVersion.Major -lt 7):
+    the generator carries `#Requires -Version 7.0`, so it cannot run on Windows PowerShell 5.1
+    at all. It is invoked ONLY from the gated Describe's own BeforeAll. Do not add an ungated
+    block to this file and do not move the BeforeAll to file scope: a `#Requires -Version 7.0`
+    script pulled in by an UNGATED BeforeAll kills every test in the file with a CONTAINER
+    FAILURE rather than skipping them. That happened in this repo, at a cost of 65 tests -- see
+    the header of Tests/CommittedDriftReport.Tests.ps1 and the run-pester-tests skill.
+
+    WHY A MISSING SPEC CACHE IS A HARD FAILURE AND NOT A SKIP:
+    the PS7 version gate is a genuine, permanent property of the runner, so it is a real skip.
+    An absent tools/specs cache is not. In CI it can never legitimately be absent -- the
+    prepare-specs job builds it and both test legs download it -- so failing loudly there is
+    never spurious. Locally, the hook that copies tools/specs into a new worktree FAILS OPEN,
+    and "treat a skip as a failure" is a convention that depends on a human reading the run
+    summary. A human not reading a summary is exactly what issue #63 was, and a silently
+    hollow dead-key gate is exactly what the incident this whole gate exists to prevent looks
+    like one level up. So the cache check throws.
+#>
+
+Describe 'Build-PfbDeadKeyReport (regeneration gate, spec cache required, PS7 only)' -Skip:($PSVersionTable.PSVersion.Major -lt 7) {
+
+    BeforeAll {
+        $script:repoRoot = Split-Path -Parent $PSScriptRoot
+        $script:generatorPath = Join-Path $repoRoot 'tools/Build-PfbDeadKeyReport.ps1'
+        $script:committedReportPath = Join-Path $repoRoot 'Reports/PfbDeadKeyReport.json'
+        $script:specsDirectory = Join-Path $repoRoot 'tools/specs'
+
+        # HARD FAILURE, not a skip -- see the header. Assert-PfbSpecCache.ps1 throws when the
+        # directory is absent or holds fewer than its floor of fb*.json files.
+        & (Join-Path $repoRoot 'scripts/Assert-PfbSpecCache.ps1') -SpecsDirectory $specsDirectory | Out-Null
+
+        $script:workRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("PfbDeadKeyGate_" + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $workRoot -Force | Out-Null
+
+        # --- Assertions 1 and 2: two real regenerations, from two different working dirs -----
+        $script:regeneratedPath = Join-Path $workRoot 'regenerated.json'
+        & $generatorPath -OutputPath $regeneratedPath | Out-Null
+
+        $script:regeneratedElsewherePath = Join-Path $workRoot 'regenerated-elsewhere.json'
+        Push-Location $workRoot
+        try {
+            & $generatorPath -OutputPath $regeneratedElsewherePath | Out-Null
+        }
+        finally {
+            Pop-Location
+        }
+
+        # --- Assertions 3-6: a synthetic Public/, capability map and spec ---------------------
+        # EVERY spec fixture node is a [PSCustomObject], never a bare @{}. Resolve-PfbRef's loop
+        # condition tests `$current.PSObject.Properties.Name -contains '$ref'`, which NEVER
+        # matches on a hashtable, so a @{} fixture silently drops every $ref'd parameter and the
+        # test passes while proving nothing (the trap is noted in tools/lib/PfbSpecTools.ps1).
+        # The fixture is serialised to disk here because the generator loads its spec from a
+        # file -- keeping the in-memory shape correct anyway means this fixture stays valid if
+        # it is ever handed to Resolve-PfbRef directly, and preserves property order.
+        #
+        # 'synthetic/dead' DELETE declares its 'names' parameter THROUGH A $ref on purpose: if
+        # ref resolution ever regressed, 'names' would read as undeclared, the surviving
+        # selector would vanish, and assertion 3's cmdlet would wrongly join noSurvivingSelector.
+        # That makes the hollow-fixture trap detectable rather than silent.
+        $script:fixtureVersion = '9.9'
+        $script:fixtureSpecsDirectory = Join-Path $workRoot 'specs'
+        $script:fixturePublicDirectory = Join-Path $workRoot 'Public'
+        New-Item -ItemType Directory -Path $fixtureSpecsDirectory -Force | Out-Null
+        New-Item -ItemType Directory -Path $fixturePublicDirectory -Force | Out-Null
+
+        $fixtureSpec = [PSCustomObject]@{
+            components = [PSCustomObject]@{
+                parameters = [PSCustomObject]@{
+                    NamesParam = [PSCustomObject]@{ name = 'names'; 'in' = 'query' }
+                }
+            }
+            paths      = [PSCustomObject]@{
+                "/api/$fixtureVersion/synthetic/dead"        = [PSCustomObject]@{
+                    delete = [PSCustomObject]@{
+                        parameters = @(
+                            [PSCustomObject]@{ '$ref' = '#/components/parameters/NamesParam' }
+                        )
+                    }
+                }
+                "/api/$fixtureVersion/synthetic/no-selector" = [PSCustomObject]@{
+                    delete = [PSCustomObject]@{
+                        parameters = @(
+                            [PSCustomObject]@{ name = 'ids'; 'in' = 'query' }
+                        )
+                    }
+                }
+                "/api/$fixtureVersion/synthetic/paging"      = [PSCustomObject]@{
+                    get = [PSCustomObject]@{
+                        parameters = @(
+                            [PSCustomObject]@{ name = 'names'; 'in' = 'query' }
+                        )
+                    }
+                }
+                "/api/$fixtureVersion/synthetic/context"     = [PSCustomObject]@{
+                    get = [PSCustomObject]@{
+                        parameters = @(
+                            [PSCustomObject]@{ name = 'names'; 'in' = 'query' }
+                        )
+                    }
+                }
+            }
+        }
+        $fixtureSpec | ConvertTo-Json -Depth 20 |
+            Set-Content -LiteralPath (Join-Path $fixtureSpecsDirectory "fb$fixtureVersion.json") -Encoding UTF8
+
+        $fixtureCapabilityMapPath = Join-Path $workRoot 'PfbFixtureCapabilityMap.json'
+        ([PSCustomObject]@{ generatedFrom = @($fixtureVersion) } | ConvertTo-Json -Depth 5) |
+            Set-Content -LiteralPath $fixtureCapabilityMapPath -Encoding UTF8
+
+        # A DESTRUCTIVE dead key ('policy_names') alongside a SURVIVING selector ('names'), so
+        # this operation must be reported as a dead key and must NOT be a no-surviving-selector.
+        Set-Content -LiteralPath (Join-Path $fixturePublicDirectory 'Remove-PfbSyntheticDeadKey.ps1') -Encoding UTF8 -Value @'
+function Remove-PfbSyntheticDeadKey {
+    [CmdletBinding()]
+    param(
+        [Parameter()] [string[]]$Name,
+        [Parameter()] [string[]]$PolicyName,
+        [Parameter()] [PSCustomObject]$Array
+    )
+    $queryParams = @{ 'names' = $Name; 'policy_names' = $PolicyName }
+    Invoke-PfbApiRequest -Array $Array -Method DELETE -Endpoint 'synthetic/dead' -QueryParams $queryParams
+}
+'@
+
+        # Its ONLY selector is dead, so the DELETE would arrive unselected -- the motivating
+        # incident's exact shape.
+        Set-Content -LiteralPath (Join-Path $fixturePublicDirectory 'Remove-PfbSyntheticNoSelector.ps1') -Encoding UTF8 -Value @'
+function Remove-PfbSyntheticNoSelector {
+    [CmdletBinding()]
+    param(
+        [Parameter()] [string[]]$MemberName,
+        [Parameter()] [PSCustomObject]$Array
+    )
+    $queryParams = @{ 'member_names' = $MemberName }
+    Invoke-PfbApiRequest -Array $Array -Method DELETE -Endpoint 'synthetic/no-selector' -QueryParams $queryParams
+}
+'@
+
+        # A dead PAGING key. Wrong results, but nothing about it is a selector.
+        Set-Content -LiteralPath (Join-Path $fixturePublicDirectory 'Get-PfbSyntheticPaging.ps1') -Encoding UTF8 -Value @'
+function Get-PfbSyntheticPaging {
+    [CmdletBinding()]
+    param(
+        [Parameter()] [int]$Limit,
+        [Parameter()] [PSCustomObject]$Array
+    )
+    $queryParams = @{ 'limit' = $Limit }
+    Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'synthetic/paging' -QueryParams $queryParams
+}
+'@
+
+        # context_names is Fusion FLEET ROUTING, not a selector: dropping it changes which
+        # array answers, never which objects are acted on.
+        Set-Content -LiteralPath (Join-Path $fixturePublicDirectory 'Get-PfbSyntheticContext.ps1') -Encoding UTF8 -Value @'
+function Get-PfbSyntheticContext {
+    [CmdletBinding()]
+    param(
+        [Parameter()] [string[]]$ContextName,
+        [Parameter()] [PSCustomObject]$Array
+    )
+    $queryParams = @{ 'context_names' = $ContextName }
+    Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'synthetic/context' -QueryParams $queryParams
+}
+'@
+
+        $script:syntheticReportPath = Join-Path $workRoot 'synthetic.json'
+        & $generatorPath `
+            -SpecsDirectory $fixtureSpecsDirectory `
+            -PublicDirectory $fixturePublicDirectory `
+            -CapabilityMapPath $fixtureCapabilityMapPath `
+            -OutputPath $syntheticReportPath | Out-Null
+        $script:syntheticReport = Get-Content -LiteralPath $syntheticReportPath -Raw | ConvertFrom-Json
+
+        $script:syntheticDeadKeyText = @(@($syntheticReport.deadKeys) | ForEach-Object {
+            "$($_.severity) $($_.cmdlet) -$($_.parameter) -> '$($_.wireKey)' on $($_.method) $($_.endpoint) (declared: $(@($_.declared) -join ', '))"
+        }) -join '; '
+        $script:syntheticNssText = @(@($syntheticReport.noSurvivingSelector) | ForEach-Object {
+            "$($_.cmdlet) $($_.method) $($_.endpoint)"
+        }) -join '; '
+    }
+
+    AfterAll {
+        if ($script:workRoot -and (Test-Path -LiteralPath $script:workRoot)) {
+            Remove-Item -LiteralPath $script:workRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'regenerates byte-for-byte identically to the committed Reports/PfbDeadKeyReport.json' {
+        # THE stale-artifact check. Reds when the generator, the Public/ cmdlets, or the pinned
+        # spec moved without the artifact being regenerated and committed alongside them.
+        $committedBytes = [System.IO.File]::ReadAllBytes($committedReportPath)
+        $regeneratedBytes = [System.IO.File]::ReadAllBytes($regeneratedPath)
+        $regeneratedBytes.Length | Should -Be $committedBytes.Length -Because "the committed artifact is stale: regenerating produced $($regeneratedBytes.Length) bytes against the committed $($committedBytes.Length). Re-run tools/Build-PfbDeadKeyReport.ps1 and commit the result."
+
+        $firstDifference = -1
+        for ($i = 0; $i -lt [Math]::Min($committedBytes.Length, $regeneratedBytes.Length); $i++) {
+            if ($committedBytes[$i] -ne $regeneratedBytes[$i]) { $firstDifference = $i; break }
+        }
+        $firstDifference | Should -Be -1 -Because "the committed artifact is stale: it first diverges from a fresh regeneration at byte $firstDifference. Re-run tools/Build-PfbDeadKeyReport.ps1 and commit the result."
+    }
+
+    It 'produces the same bytes when regenerated from a different working directory' {
+        # Location independence, asserted rather than assumed: an absolute path or a
+        # CWD-relative default leaking into the artifact makes a regeneration from a git
+        # worktree rewrite lines that did not semantically change, burying the real diff.
+        $fromRepoRoot = [System.IO.File]::ReadAllBytes($regeneratedPath)
+        $fromElsewhere = [System.IO.File]::ReadAllBytes($regeneratedElsewherePath)
+        $fromElsewhere.Length | Should -Be $fromRepoRoot.Length -Because 'the generated report must not depend on the process working directory'
+
+        $firstDifference = -1
+        for ($i = 0; $i -lt [Math]::Min($fromRepoRoot.Length, $fromElsewhere.Length); $i++) {
+            if ($fromRepoRoot[$i] -ne $fromElsewhere[$i]) { $firstDifference = $i; break }
+        }
+        $firstDifference | Should -Be -1 -Because "regenerating from '$workRoot' instead of the repo root changed the output at byte $firstDifference -- the generator is resolving something against the working directory"
+    }
+
+    It 'classifies a synthetic undeclared query key as a dead key, with the verb-derived severity' {
+        $entry = @(@($syntheticReport.deadKeys) | Where-Object { $_.cmdlet -eq 'Remove-PfbSyntheticDeadKey' -and $_.parameter -eq 'PolicyName' })
+        @($entry).Count | Should -Be 1 -Because "Remove-PfbSyntheticDeadKey -PolicyName writes 'policy_names' on DELETE synthetic/dead, which declares only 'names', so it must be reported exactly once. Reported dead keys were: $syntheticDeadKeyText"
+        $entry[0].severity | Should -Be 'DESTRUCTIVE' -Because "DELETE is destructive, so an undeclared key on it must be classified DESTRUCTIVE, not $($entry[0].severity)"
+        $entry[0].wireKey | Should -Be 'policy_names'
+        $entry[0].method | Should -Be 'DELETE'
+        $entry[0].endpoint | Should -Be 'synthetic/dead'
+        @($entry[0].declared) | Should -Be @('names') -Because "the declared-key list is what a reader fixes the cmdlet from, and it must survive `$ref resolution -- 'names' is declared on this fixture THROUGH a `$ref"
+
+        $surviving = @(@($syntheticReport.deadKeys) | Where-Object { $_.cmdlet -eq 'Remove-PfbSyntheticDeadKey' -and $_.parameter -eq 'Name' })
+        @($surviving) | Should -BeNullOrEmpty -Because "-Name writes the declared key 'names', so it is not dead; if it is reported dead then `$ref resolution regressed and this whole fixture is hollow"
+    }
+
+    It 'reports a synthetic cmdlet whose only selector is dead as noSurvivingSelector' {
+        $group = @(@($syntheticReport.noSurvivingSelector) | Where-Object { $_.cmdlet -eq 'Remove-PfbSyntheticNoSelector' })
+        @($group).Count | Should -Be 1 -Because "Remove-PfbSyntheticNoSelector -MemberName writes 'member_names' on DELETE synthetic/no-selector, which declares only 'ids'. Its only selector is dead, so the DELETE arrives unselected -- the motivating incident. Reported groups were: $syntheticNssText"
+        $group[0].method | Should -Be 'DELETE'
+        $group[0].endpoint | Should -Be 'synthetic/no-selector'
+    }
+
+    It 'does not report a paging-only dead key as noSurvivingSelector' {
+        # A dead 'limit' returns the wrong page, never the wrong objects. Folding it into the
+        # highest-severity class would drown the entries that actually mean "unselected write".
+        @(@($syntheticReport.deadKeys) | Where-Object { $_.cmdlet -eq 'Get-PfbSyntheticPaging' }).Count |
+            Should -Be 1 -Because "the fixture is only meaningful if 'limit' IS reported dead on GET synthetic/paging. Reported dead keys were: $syntheticDeadKeyText"
+        @(@($syntheticReport.noSurvivingSelector) | Where-Object { $_.cmdlet -eq 'Get-PfbSyntheticPaging' }) |
+            Should -BeNullOrEmpty -Because "'limit' is a paging key, not a selector, so a cmdlet whose only dead key is 'limit' must not be reported as having no surviving selector. Reported groups were: $syntheticNssText"
+    }
+
+    It 'does not report a context_names-only dead key as noSurvivingSelector' {
+        # context_names is Fusion fleet ROUTING -- it chooses which array answers, not which
+        # objects are acted on. Test-PfbDeadKeySelectorName excludes it by exact name for this
+        # reason, and a suffix regex on '_names' would wrongly catch it.
+        @(@($syntheticReport.deadKeys) | Where-Object { $_.cmdlet -eq 'Get-PfbSyntheticContext' }).Count |
+            Should -Be 1 -Because "the fixture is only meaningful if 'context_names' IS reported dead on GET synthetic/context. Reported dead keys were: $syntheticDeadKeyText"
+        @(@($syntheticReport.noSurvivingSelector) | Where-Object { $_.cmdlet -eq 'Get-PfbSyntheticContext' }) |
+            Should -BeNullOrEmpty -Because "context_names is a fleet-routing key, not a selector, so it must never make a cmdlet look as though it has no surviving selector. Reported groups were: $syntheticNssText"
+    }
+}

--- a/Tests/Build-PfbDeadKeyReport.Tests.ps1
+++ b/Tests/Build-PfbDeadKeyReport.Tests.ps1
@@ -88,7 +88,7 @@ Describe 'Build-PfbDeadKeyReport regeneration (real spec cache required, PS7 onl
         }
     }
 
-    It 'regenerates byte-for-byte identically to the committed Reports/PfbDeadKeyReport.json' {
+    It 'regenerates content-identically to the committed Reports/PfbDeadKeyReport.json' {
         # THE stale-artifact check. Reds when the generator, the Public/ cmdlets, or the pinned
         # spec moved without the artifact being regenerated and committed alongside them.
         #

--- a/Tests/CommittedDeadKeyReport.Tests.ps1
+++ b/Tests/CommittedDeadKeyReport.Tests.ps1
@@ -160,9 +160,11 @@ BeforeAll {
     # this: growth in 'wire name unresolved' or 'endpoint/method ambiguous' means keys that WERE
     # evaluable stopped being evaluated, which genuinely does shrink what this gate covers.
     #
-    # 'body property' is still constrained, just not here: the reconciliation invariant
-    # (keysEvaluated + every skip reason == parametersInventoried) reds if the body-property
-    # count moves without a matching move in the inventory. It is unceilinged, not unwatched.
+    # Reconciliation still catches arithmetic inconsistency, but it does NOT catch a realistic
+    # reclassification that moves one record from keysEvaluated into this bucket while preserving
+    # the total. The keysEvaluated floor is the remaining coverage-collapse check, with deliberate
+    # headroom from its measured 1757. This reason is unceilinged because that weaker watch is the
+    # accepted cost of avoiding false reds on legitimate body-surface work.
     $script:baselineUnceilingedSkipReasons = @('body property')
 }
 
@@ -345,8 +347,10 @@ Describe 'Committed dead-key report (REGRESSION guard, no spec cache required)' 
         #
         # Together they close a specific hole in the floors above: the floors ask whether the
         # headline numbers are big enough, and these ask whether they add up. A collapse that
-        # scaled every counter proportionally would clear neither. The second half is also what
-        # still constrains the 'body property' skip count now that its ceiling has been removed.
+        # scaled every counter proportionally would clear neither. They assert arithmetic
+        # consistency, not stability of any individual skip-reason count: moving one record from
+        # keysEvaluated into 'body property' preserves this equation and is watched only by the
+        # deliberately loose keysEvaluated floor.
         $skipTotal = 0
         foreach ($reason in $committedReport.counts.skipReasons.PSObject.Properties) { $skipTotal += [int]$reason.Value }
         ([int]$committedReport.counts.ok + [int]$committedReport.counts.deadKey) |

--- a/Tests/CommittedDeadKeyReport.Tests.ps1
+++ b/Tests/CommittedDeadKeyReport.Tests.ps1
@@ -1,0 +1,287 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+<#
+.SYNOPSIS
+    REGRESSION guard over the COMMITTED Reports/PfbDeadKeyReport.json.
+.DESCRIPTION
+    A cmdlet parameter that is written into a query key the endpoint does not DECLARE is
+    silently discarded by the array: a GET returns the unfiltered collection, and a DELETE
+    arrives with no selector at all. The motivating incident aimed a DELETE at another admin's
+    API token using an undeclared key, so the request arrived unselected and destroyed the
+    caller's own token. tools/Build-PfbDeadKeyReport.ps1 finds those keys; this file is what
+    makes a NEWLY INTRODUCED one a red build instead of a live-array surprise.
+
+    WHY THIS FILE READS THE COMMITTED ARTIFACT AND NEVER REGENERATES:
+      1. The gate must run on EVERY CI leg, including Windows PowerShell 5.1. The generator
+         carries `#Requires -Version 7.0` and cannot run there at all, and it needs the
+         gitignored ~50MB tools/specs cache, which a bare runner does not have.
+      2. The failure mode worth catching is a STALE COMMITTED ARTIFACT. A gate that
+         regenerates before asserting can never catch it -- it would compare fresh output
+         against itself. Tests/Build-PfbDeadKeyReport.Tests.ps1 (PS7-gated) owns the
+         regeneration comparison; this file owns what was actually shipped.
+
+    MONOTONE, NOT EXACT -- read before "tightening" anything here.
+    Every set assertion below is "nothing NEW appeared", never "the set is exactly this".
+    An exact-equality gate fails on the very PR that FIXES a dead key, and so forces an
+    artifact regeneration into every later fix -- the anti-pattern the second Describe of
+    Tests/CommittedDriftReport.Tests.ps1 argues against at length ("a test asserting 'not yet
+    implemented' fails on the PR that implements the thing"). The stated goal is that the set
+    cannot GROW silently, which is a monotone property. A SHRINK MUST PASS. The generator was
+    verified to survive an empty deadKeys set, so a future PR that fixes every dead key must
+    not red this file either.
+
+    HOW THE BASELINE WAS DERIVED, and what would / would not red this file:
+    The artifact is itself the committed thing, so the baseline is the artifact as committed
+    at the HEAD this file was written against (bde3270, specVersion 2.28): 126 deadKeys
+    (22 DESTRUCTIVE / 8 CREATE / 96 WRONG-RESULTS) and 18 noSurvivingSelector groups. The
+    DESTRUCTIVE identities and the noSurvivingSelector identities were read out of that file
+    and pinned below as ALLOWLISTS; the counts were pinned as CEILINGS. Therefore:
+      REDS   -- a dead key appearing on a destructive verb that is not already pinned; a new
+                noSurvivingSelector group; any count going UP; a new skip reason; an absolute
+                path in the artifact; the artifact's ordering not matching the generator's
+                ordinal comparer.
+      PASSES -- any entry disappearing, any count going DOWN, all the way to zero.
+    Renaming a cmdlet or moving an endpoint changes an identity, so it reads as "new" and
+    reds. That is intended: it wants a human to re-confirm the key is still declared, and the
+    fix is a one-line edit to the pinned list in the same reviewed diff.
+
+    5.1 CONSTRAINT: no `ConvertFrom-Json -Depth` (not a 5.1 parameter), no ternaries, no `??`.
+    The ordinal comparer mirrored below was executed under Windows PowerShell 5.1.26100 and
+    confirmed to yield true ordinal order there, including on mixed case.
+#>
+
+BeforeAll {
+    $script:repoRoot = Split-Path -Parent $PSScriptRoot
+    $script:committedReportPath = Join-Path $repoRoot 'Reports/PfbDeadKeyReport.json'
+    $script:committedReport = Get-Content -Path $committedReportPath -Raw | ConvertFrom-Json
+
+    # --- Pinned baseline, read out of the committed artifact at HEAD bde3270 -------------
+    # Identity of a dead key = cmdlet|parameter|wireKey|method|endpoint. Identity of a
+    # no-surviving-selector group = cmdlet|method|endpoint (exactly the fields the artifact
+    # carries for each; there is no file/line in either record).
+    $script:baselineDestructive = @(
+        'Remove-PfbBucketAccessPolicy|MemberName|member_names|DELETE|buckets/bucket-access-policies'
+        'Remove-PfbBucketAccessPolicy|PolicyName|policy_names|DELETE|buckets/bucket-access-policies'
+        'Remove-PfbBucketAuditFilter|MemberId|member_ids|DELETE|buckets/audit-filters'
+        'Remove-PfbBucketAuditFilter|MemberName|member_names|DELETE|buckets/audit-filters'
+        'Remove-PfbBucketCorsPolicy|MemberId|member_ids|DELETE|buckets/cross-origin-resource-sharing-policies'
+        'Remove-PfbBucketCorsPolicy|MemberName|member_names|DELETE|buckets/cross-origin-resource-sharing-policies'
+        'Remove-PfbBucketCorsPolicy|PolicyName|policy_names|DELETE|buckets/cross-origin-resource-sharing-policies'
+        'Remove-PfbFileLock|Id|ids|DELETE|file-systems/locks'
+        'Remove-PfbFleetMember|FleetName|fleet_names|DELETE|fleets/members'
+        'Remove-PfbLocalGroup|Id|ids|DELETE|directory-services/local/groups'
+        'Remove-PfbNetworkAccessRule|PolicyId|policy_ids|DELETE|network-access-policies/rules'
+        'Remove-PfbNetworkAccessRule|PolicyName|policy_names|DELETE|network-access-policies/rules'
+        'Remove-PfbNfsExportRule|PolicyId|policy_ids|DELETE|nfs-export-policies/rules'
+        'Remove-PfbNfsExportRule|PolicyName|policy_names|DELETE|nfs-export-policies/rules'
+        'Remove-PfbNodeGroupNode|GroupName|group_names|DELETE|node-groups/nodes'
+        'Remove-PfbNodeGroupNode|MemberName|member_names|DELETE|node-groups/nodes'
+        'Remove-PfbObjectStoreAccessKey|Id|ids|DELETE|object-store-access-keys'
+        'Remove-PfbObjectStoreRoleAccessPolicy|RoleName|role_names|DELETE|object-store-roles/object-store-access-policies'
+        'Remove-PfbOpenFile|Name|names|DELETE|file-systems/open-files'
+        'Remove-PfbResourceAccess|Name|names|DELETE|resource-accesses'
+        'Remove-PfbSmbClientRule|PolicyId|policy_ids|DELETE|smb-client-policies/rules'
+        'Remove-PfbSmbClientRule|PolicyName|policy_names|DELETE|smb-client-policies/rules'
+    )
+    $script:baselineNoSurvivingSelector = @(
+        'Get-PfbBucketAuditFilter|GET|buckets/audit-filters'
+        'Get-PfbCertificateGroupCertificate|GET|certificate-groups/certificates'
+        'Get-PfbFileLockClient|GET|file-systems/locks/clients'
+        'Get-PfbFleetKey|GET|fleets/fleet-key'
+        'Get-PfbKeytabDownload|GET|keytabs/download'
+        'Get-PfbLegalHoldEntity|GET|legal-holds/held-entities'
+        'Get-PfbNetworkConnectionStatistics|GET|network-interfaces/network-connection-statistics'
+        'Get-PfbNetworkInterfaceNeighbor|GET|network-interfaces/neighbors'
+        'Get-PfbNodeGroupNode|GET|node-groups/nodes'
+        'Get-PfbRealmDefaults|GET|realms/defaults'
+        'New-PfbBucketAccessPolicy|POST|buckets/bucket-access-policies'
+        'New-PfbBucketAuditFilter|POST|buckets/audit-filters'
+        'New-PfbBucketCorsPolicy|POST|buckets/cross-origin-resource-sharing-policies'
+        'New-PfbNlmReclamation|POST|file-systems/locks/nlm-reclamations'
+        'Remove-PfbBucketAccessPolicy|DELETE|buckets/bucket-access-policies'
+        'Remove-PfbBucketAuditFilter|DELETE|buckets/audit-filters'
+        'Remove-PfbBucketCorsPolicy|DELETE|buckets/cross-origin-resource-sharing-policies'
+        'Remove-PfbNodeGroupNode|DELETE|node-groups/nodes'
+    )
+    # CEILINGS, not pins -- see the monotone note above.
+    $script:baselineDeadKeyCount = 126
+    $script:baselineNoSurvivingSelectorCount = 18
+    $script:baselineSkipReasons = @{
+        'wire name unresolved'           = 125
+        'body property'                  = 278
+        'endpoint/method ambiguous'      = 14
+        'endpoint/verb absent from spec' = 0
+    }
+}
+
+Describe 'Committed dead-key report (REGRESSION guard, no spec cache required)' {
+
+    It 'the committed report exists and carries a non-empty deadKeys set' {
+        # ANTI-VACUITY, first in the file. If this fails every scan below is meaningless, so
+        # it fails first and loudly rather than passing silently over a missing or empty file.
+        #
+        # This is the ONE place the report's current contents are asserted non-empty rather
+        # than merely bounded, and it is deliberately about the ARTIFACT being a real tracked
+        # input -- not about how many dead keys remain. If a future PR genuinely fixes every
+        # dead key, this line is the one to relax (to a structural "deadKeys property exists"
+        # check); nothing else in this file needs touching, because everything else asserts
+        # only that nothing NEW appeared.
+        Test-Path $committedReportPath | Should -BeTrue -Because 'Reports/PfbDeadKeyReport.json is a tracked artifact, not a build cache'
+        $committedReport.PSObject.Properties.Name | Should -Contain 'deadKeys' -Because 'a deadKeys property that vanished entirely would otherwise be indistinguishable from one holding an empty list'
+        $committedReport.PSObject.Properties.Name | Should -Contain 'noSurvivingSelector' -Because 'a noSurvivingSelector property that vanished would make the highest-severity scan below vacuous'
+        @($committedReport.deadKeys).Count | Should -BeGreaterThan 0 -Because 'a report with no deadKeys would make every scan below vacuous'
+    }
+
+    It 'introduces no NEW dead key on a destructive verb' {
+        # DESTRUCTIVE == DELETE/PATCH/PUT (Get-PfbDeadKeySeverity). These are the entries where
+        # a discarded key means the request arrives with no selector, so a new one is the
+        # motivating incident happening again.
+        $scanned = 0
+        $offenders = foreach ($entry in @($committedReport.deadKeys)) {
+            if ($entry.severity -ne 'DESTRUCTIVE') { continue }
+            $scanned++
+            $identity = '{0}|{1}|{2}|{3}|{4}' -f $entry.cmdlet, $entry.parameter, $entry.wireKey, $entry.method, $entry.endpoint
+            if ($baselineDestructive -notcontains $identity) {
+                "NEW DESTRUCTIVE dead key: $($entry.cmdlet) -$($entry.parameter) writes query key '$($entry.wireKey)', which $($entry.method) $($entry.endpoint) does not declare. That endpoint/verb declares only: $(@($entry.declared) -join ', '). The request will arrive without that selector."
+            }
+        }
+        $scanned | Should -BeGreaterThan 0 -Because 'a vacuous scan would pass this test without checking anything'
+        @($offenders) | Should -BeNullOrEmpty -Because "a destructive verb carrying an undeclared query key is the incident this gate exists to prevent. Either declare/rename the key, or -- if this is a deliberate, reviewed addition -- add its identity to `$baselineDestructive in this file."
+    }
+
+    It 'introduces no NEW noSurvivingSelector entry' {
+        # The highest-severity class in the artifact: EVERY selector-shaped key the operation
+        # sends is dead, so the request carries no usable selector at all. A new one here is
+        # strictly worse than a new DESTRUCTIVE dead key alongside a surviving selector.
+        $scanned = 0
+        $offenders = foreach ($group in @($committedReport.noSurvivingSelector)) {
+            $scanned++
+            $identity = '{0}|{1}|{2}' -f $group.cmdlet, $group.method, $group.endpoint
+            if ($baselineNoSurvivingSelector -notcontains $identity) {
+                $deadKeysForGroup = @(@($committedReport.deadKeys) | Where-Object {
+                    $_.cmdlet -eq $group.cmdlet -and $_.method -eq $group.method -and $_.endpoint -eq $group.endpoint
+                })
+                $detail = @($deadKeysForGroup | ForEach-Object { "-$($_.parameter) -> '$($_.wireKey)'" }) -join '; '
+                $declared = @()
+                if ($deadKeysForGroup.Count -gt 0) { $declared = @($deadKeysForGroup[0].declared) }
+                "NEW noSurvivingSelector: $($group.cmdlet) ($($group.method) $($group.endpoint)) has no surviving selector -- every selector-shaped key it sends is undeclared [$detail]. That endpoint/verb declares only: $($declared -join ', ')."
+            }
+        }
+        $scanned | Should -BeGreaterThan 0 -Because 'a vacuous scan would pass this test without checking anything'
+        @($offenders) | Should -BeNullOrEmpty -Because "an operation with no surviving selector sends an unselected request. Either declare/rename a selector, or -- if this is a deliberate, reviewed addition -- add its identity to `$baselineNoSurvivingSelector in this file."
+    }
+
+    It 'grows no count: dead keys, no-surviving-selector groups, and every skip reason are <= the committed figures' {
+        # <= and never ==, on purpose: an exact pin reds on the PR that FIXES a dead key.
+        @($committedReport.deadKeys).Count | Should -BeLessOrEqual $baselineDeadKeyCount -Because "the committed dead-key count must not grow past the $baselineDeadKeyCount baseline; it is $(@($committedReport.deadKeys).Count)"
+        @($committedReport.noSurvivingSelector).Count | Should -BeLessOrEqual $baselineNoSurvivingSelectorCount -Because "the committed no-surviving-selector count must not grow past the $baselineNoSurvivingSelectorCount baseline; it is $(@($committedReport.noSurvivingSelector).Count)"
+
+        # A skip is a key the generator could not evaluate at all, so a rising skip count hides
+        # dead keys just as effectively as a rising dead-key count -- and does it while the
+        # headline numbers look flat or better.
+        $scanned = 0
+        $offenders = foreach ($reason in $committedReport.counts.skipReasons.PSObject.Properties) {
+            $scanned++
+            if (-not $baselineSkipReasons.ContainsKey($reason.Name)) {
+                "UNKNOWN skip reason '$($reason.Name)' (count $($reason.Value)) -- the generator gained a skip class the baseline in this test does not know about"
+                continue
+            }
+            if ([int]$reason.Value -gt [int]$baselineSkipReasons[$reason.Name]) {
+                "skip reason '$($reason.Name)' grew from $($baselineSkipReasons[$reason.Name]) to $($reason.Value) -- those keys are now unevaluable, not proven safe"
+            }
+        }
+        $scanned | Should -BeGreaterThan 0 -Because 'a vacuous scan would pass this test without checking anything'
+        @($offenders) | Should -BeNullOrEmpty -Because 'a skipped key is unevaluated, so a growing skip count silently shrinks what this gate covers'
+    }
+
+    It 'emits no absolute path anywhere in the committed artifact' {
+        # Two concrete harms, both observed on the sibling drift artifacts before their guards
+        # existed: it publishes a developer's home-directory path to a public repo, and it makes
+        # the committed file depend on WHERE it was generated, so a regeneration from a worktree
+        # rewrites lines that did not semantically change. The inventory this generator consumes
+        # carries a File field holding a full path, so the risk is live rather than theoretical.
+        #
+        # Iterative walk rather than a recursive function: it keeps the whole scan inside this
+        # It block, where a function defined in BeforeAll would be one more scope subtlety on a
+        # file that has to behave identically on 5.1 and 7.
+        $scanned = 0
+        $offenders = [System.Collections.Generic.List[string]]::new()
+        $pending = [System.Collections.Generic.List[object]]::new()
+        $pending.Add([PSCustomObject]@{ Path = '$'; Value = $committedReport })
+        while ($pending.Count -gt 0) {
+            $item = $pending[$pending.Count - 1]
+            $pending.RemoveAt($pending.Count - 1)
+            $value = $item.Value
+            if ($null -eq $value) { continue }
+            if ($value -is [string]) {
+                $scanned++
+                if ($value -match '^[A-Za-z]:[\\/]' -or $value -match '^[\\/]{1,2}') {
+                    $offenders.Add("$($item.Path) = '$value'")
+                }
+                continue
+            }
+            if ($value -is [System.Collections.IEnumerable]) {
+                $index = 0
+                foreach ($element in $value) {
+                    $pending.Add([PSCustomObject]@{ Path = "$($item.Path)[$index]"; Value = $element })
+                    $index++
+                }
+                continue
+            }
+            if ($value -is [PSCustomObject]) {
+                foreach ($property in $value.PSObject.Properties) {
+                    $pending.Add([PSCustomObject]@{ Path = "$($item.Path).$($property.Name)"; Value = $property.Value })
+                }
+            }
+            # Anything else (int, bool) carries no path and needs no scan.
+        }
+        $scanned | Should -BeGreaterThan 0 -Because 'a vacuous scan would pass this test without checking anything'
+        @($offenders) | Should -BeNullOrEmpty -Because 'every string in the committed report must be repo-relative: an absolute path publishes a local checkout location and makes the artifact depend on where it was generated'
+    }
+
+    It 'holds the ordering the generator produced, under the same ordinal mechanism' {
+        # Mirrors Sort-PfbDeadKeyRecords in tools/Build-PfbDeadKeyReport.ps1 verbatim: a
+        # [System.Comparison[object]] over [string]::Compare(..., Ordinal) on the NAMED
+        # PROPERTIES, not on a joined key. It cannot be dot-sourced -- the helper lives inside
+        # a self-executing `#Requires -Version 7.0` script, so importing it would run the whole
+        # generator and would be impossible on 5.1 -- so it is reimplemented here.
+        #
+        # Ordinal, not Sort-Object -Culture '': invariant LINGUISTIC order is not stable
+        # between 5.1 and 7 (issue #85), and this file runs on both. The comparer below was
+        # executed under Windows PowerShell 5.1.26100 and confirmed to yield true ordinal
+        # order, including on mixed case.
+        #
+        # deadKeys sorts on cmdlet then parameter; noSurvivingSelector on cmdlet, method,
+        # then endpoint. Both property sets are real fields of the emitted records.
+        $sortByOrdinal = {
+            param($records, $properties)
+            $list = [System.Collections.Generic.List[object]]::new()
+            foreach ($record in $records) { $list.Add($record) }
+            $list.Sort([System.Comparison[object]]{
+                param($left, $right)
+                foreach ($propertyName in $properties) {
+                    $comparison = [string]::Compare(
+                        [string]$left.$propertyName,
+                        [string]$right.$propertyName,
+                        [System.StringComparison]::Ordinal)
+                    if ($comparison -ne 0) { return $comparison }
+                }
+                return 0
+            })
+            # @(...) because a List.Sort over an empty collection emits nothing at all, and a
+            # bare $null would throw on .Count under StrictMode.
+            return @($list)
+        }
+
+        $deadKeys = @($committedReport.deadKeys)
+        $deadKeys.Count | Should -BeGreaterThan 0 -Because 'a vacuous scan would pass this test without checking anything'
+        $deadKeyActual = @($deadKeys | ForEach-Object { '{0}|{1}' -f $_.cmdlet, $_.parameter })
+        $deadKeyExpected = @((& $sortByOrdinal $deadKeys @('cmdlet', 'parameter')) | ForEach-Object { '{0}|{1}' -f $_.cmdlet, $_.parameter })
+        ($deadKeyActual -join "`n") | Should -Be ($deadKeyExpected -join "`n") -Because 'deadKeys must be committed in ordinal order on (cmdlet, parameter); an unsorted artifact produces churn diffs that bury the real change'
+
+        $groups = @($committedReport.noSurvivingSelector)
+        $groups.Count | Should -BeGreaterThan 0 -Because 'a vacuous scan would pass this test without checking anything'
+        $groupActual = @($groups | ForEach-Object { '{0}|{1}|{2}' -f $_.cmdlet, $_.method, $_.endpoint })
+        $groupExpected = @((& $sortByOrdinal $groups @('cmdlet', 'method', 'endpoint')) | ForEach-Object { '{0}|{1}|{2}' -f $_.cmdlet, $_.method, $_.endpoint })
+        ($groupActual -join "`n") | Should -Be ($groupExpected -join "`n") -Because 'noSurvivingSelector must be committed in ordinal order on (cmdlet, method, endpoint)'
+    }
+}

--- a/Tests/CommittedDeadKeyReport.Tests.ps1
+++ b/Tests/CommittedDeadKeyReport.Tests.ps1
@@ -34,12 +34,17 @@
     at the HEAD this file was written against (bde3270, specVersion 2.28): 126 deadKeys
     (22 DESTRUCTIVE / 8 CREATE / 96 WRONG-RESULTS) and 18 noSurvivingSelector groups. The
     DESTRUCTIVE identities and the noSurvivingSelector identities were read out of that file
-    and pinned below as ALLOWLISTS; the counts were pinned as CEILINGS. Therefore:
+    and pinned below as ALLOWLISTS; the dead-key and skip counts were pinned as CEILINGS; and
+    the inventory counts were pinned as FLOORS, which is the one direction the monotone design
+    does NOT leave free -- see the coverage-collapse test for why. Therefore:
       REDS   -- a dead key appearing on a destructive verb that is not already pinned; a new
-                noSurvivingSelector group; any count going UP; a new skip reason; an absolute
-                path in the artifact; the artifact's ordering not matching the generator's
-                ordinal comparer.
-      PASSES -- any entry disappearing, any count going DOWN, all the way to zero.
+                noSurvivingSelector group; any dead-key or skip count going UP; a new skip
+                reason; parametersInventoried or keysEvaluated collapsing; an absolute path in
+                the artifact; the artifact's ordering not matching the generator's ordinal
+                comparer.
+      PASSES -- any entry disappearing, any dead-key or skip count going DOWN, all the way to
+                zero (see the SHRINK-TO-ZERO RELAX POINT note on assertion 1 for the single
+                edit the total-zero case needs).
     Renaming a cmdlet or moving an endpoint changes an identity, so it reads as "new" and
     reds. That is intended: it wants a human to re-confirm the key is still declared, and the
     fix is a one-line edit to the pinned list in the same reviewed diff.
@@ -52,6 +57,15 @@
 BeforeAll {
     $script:repoRoot = Split-Path -Parent $PSScriptRoot
     $script:committedReportPath = Join-Path $repoRoot 'Reports/PfbDeadKeyReport.json'
+    # Existence is checked HERE rather than in an It, because an It could never see it fail:
+    # with the file absent, the Get-Content below errors first and Pester turns that into a
+    # container failure, so no It body runs at all. A `Test-Path | Should -BeTrue` in an It
+    # would therefore be an assertion that cannot fail -- exactly what this file's header
+    # argues against elsewhere. The throw exists to replace the raw Get-Content error, which
+    # names the path but not what the reader should do about it.
+    if (-not (Test-Path -LiteralPath $script:committedReportPath)) {
+        throw "Reports/PfbDeadKeyReport.json is missing at '$($script:committedReportPath)'. It is a TRACKED artifact, not a build cache -- do not regenerate it to satisfy this test. Restore it from git (git checkout -- Reports/PfbDeadKeyReport.json); if it was deliberately deleted, this whole gate went with it."
+    }
     $script:committedReport = Get-Content -Path $committedReportPath -Raw | ConvertFrom-Json
 
     # --- Pinned baseline, read out of the committed artifact at HEAD bde3270 -------------
@@ -119,15 +133,31 @@ Describe 'Committed dead-key report (REGRESSION guard, no spec cache required)' 
         # ANTI-VACUITY, first in the file. If this fails every scan below is meaningless, so
         # it fails first and loudly rather than passing silently over a missing or empty file.
         #
-        # This is the ONE place the report's current contents are asserted non-empty rather
-        # than merely bounded, and it is deliberately about the ARTIFACT being a real tracked
-        # input -- not about how many dead keys remain. If a future PR genuinely fixes every
-        # dead key, this line is the one to relax (to a structural "deadKeys property exists"
-        # check); nothing else in this file needs touching, because everything else asserts
-        # only that nothing NEW appeared.
-        Test-Path $committedReportPath | Should -BeTrue -Because 'Reports/PfbDeadKeyReport.json is a tracked artifact, not a build cache'
+        # SHRINK-TO-ZERO RELAX POINT (1 of 3) -- see the note below. This is the only place in
+        # the file that asserts how MUCH is in the report; everything else asserts either that
+        # nothing NEW appeared or that a floor/ceiling holds.
+        #
+        # WHAT A PR THAT FIXES EVERY REMAINING DEAD KEY HAS TO DO, stated precisely because an
+        # earlier version of this comment got it wrong and would have sent that reader in
+        # circles. With `deadKeys: []` the file reds in exactly three places, all tagged
+        # SHRINK-TO-ZERO RELAX POINT: this floor, and the two scan-input floors in the "no NEW
+        # dead key on a destructive verb" and "no NEW noSurvivingSelector" tests, which
+        # deliberately floor on deadKeys because THIS assertion is what guarantees it non-zero.
+        # Relaxing all three together (to the structural property-exists checks immediately
+        # below) is one reviewed edit, and it is a real decision rather than a formality: past
+        # that point the file no longer proves it scanned anything, and its guarantee narrows
+        # to the monotone one. NOTHING ELSE needs touching -- every other assertion here is
+        # already shrink-safe, including both ordering blocks, which no-op on an empty list.
+        #
+        # A PARTIAL fix -- even all 22 destructive entries, or all 18 groups, at once -- needs
+        # no edit at all. That case was constructed and confirmed green.
         $committedReport.PSObject.Properties.Name | Should -Contain 'deadKeys' -Because 'a deadKeys property that vanished entirely would otherwise be indistinguishable from one holding an empty list'
         $committedReport.PSObject.Properties.Name | Should -Contain 'noSurvivingSelector' -Because 'a noSurvivingSelector property that vanished would make the highest-severity scan below vacuous'
+        # Explicitly NOT -BeNullOrEmpty via @(...).Count: `@($null).Count` is 1, so a report
+        # carrying `"deadKeys": null` would sail past a count-only floor and this assertion
+        # would fail neither first nor loudly.
+        $committedReport.deadKeys | Should -Not -BeNullOrEmpty -Because 'a null or empty deadKeys would make every scan below vacuous'
+        $null -ne $committedReport.noSurvivingSelector | Should -BeTrue -Because 'a null noSurvivingSelector is a structurally broken artifact, not an empty one -- the generator always emits an array'
         @($committedReport.deadKeys).Count | Should -BeGreaterThan 0 -Because 'a report with no deadKeys would make every scan below vacuous'
     }
 
@@ -135,16 +165,23 @@ Describe 'Committed dead-key report (REGRESSION guard, no spec cache required)' 
         # DESTRUCTIVE == DELETE/PATCH/PUT (Get-PfbDeadKeySeverity). These are the entries where
         # a discarded key means the request arrives with no selector, so a new one is the
         # motivating incident happening again.
-        $scanned = 0
-        $offenders = foreach ($entry in @($committedReport.deadKeys)) {
+        #
+        # The floor below is on the SCAN INPUT, not on the filtered subset. Counting only the
+        # DESTRUCTIVE matches would make "all 22 destructive dead keys got fixed" -- a tractable
+        # single PR, and the outcome this artifact exists to produce -- red the gate. The filter
+        # is a predicate, not the scan boundary: what still has to be non-empty is the list the
+        # loop walks, which assertion 1 guarantees; what must be free to reach zero is how many
+        # of them match.
+        $scanInput = @($committedReport.deadKeys)
+        $offenders = foreach ($entry in $scanInput) {
             if ($entry.severity -ne 'DESTRUCTIVE') { continue }
-            $scanned++
             $identity = '{0}|{1}|{2}|{3}|{4}' -f $entry.cmdlet, $entry.parameter, $entry.wireKey, $entry.method, $entry.endpoint
             if ($baselineDestructive -notcontains $identity) {
                 "NEW DESTRUCTIVE dead key: $($entry.cmdlet) -$($entry.parameter) writes query key '$($entry.wireKey)', which $($entry.method) $($entry.endpoint) does not declare. That endpoint/verb declares only: $(@($entry.declared) -join ', '). The request will arrive without that selector."
             }
         }
-        $scanned | Should -BeGreaterThan 0 -Because 'a vacuous scan would pass this test without checking anything'
+        # SHRINK-TO-ZERO RELAX POINT (2 of 3).
+        $scanInput.Count | Should -BeGreaterThan 0 -Because 'a vacuous scan would pass this test without checking anything'
         @($offenders) | Should -BeNullOrEmpty -Because "a destructive verb carrying an undeclared query key is the incident this gate exists to prevent. Either declare/rename the key, or -- if this is a deliberate, reviewed addition -- add its identity to `$baselineDestructive in this file."
     }
 
@@ -152,9 +189,13 @@ Describe 'Committed dead-key report (REGRESSION guard, no spec cache required)' 
         # The highest-severity class in the artifact: EVERY selector-shaped key the operation
         # sends is dead, so the request carries no usable selector at all. A new one here is
         # strictly worse than a new DESTRUCTIVE dead key alongside a surviving selector.
-        $scanned = 0
+        #
+        # Same scan-input reasoning as the test above, and here the point is sharper: this
+        # collection has only 18 entries, so "somebody fixed all of them" is one PR. Flooring on
+        # noSurvivingSelector.Count would make the gate red on precisely its own success. The
+        # floor is therefore on deadKeys, which assertion 1 guarantees non-empty and which is a
+        # strict superset of the operations that can produce a group here.
         $offenders = foreach ($group in @($committedReport.noSurvivingSelector)) {
-            $scanned++
             $identity = '{0}|{1}|{2}' -f $group.cmdlet, $group.method, $group.endpoint
             if ($baselineNoSurvivingSelector -notcontains $identity) {
                 $deadKeysForGroup = @(@($committedReport.deadKeys) | Where-Object {
@@ -166,8 +207,39 @@ Describe 'Committed dead-key report (REGRESSION guard, no spec cache required)' 
                 "NEW noSurvivingSelector: $($group.cmdlet) ($($group.method) $($group.endpoint)) has no surviving selector -- every selector-shaped key it sends is undeclared [$detail]. That endpoint/verb declares only: $($declared -join ', ')."
             }
         }
-        $scanned | Should -BeGreaterThan 0 -Because 'a vacuous scan would pass this test without checking anything'
+        # SHRINK-TO-ZERO RELAX POINT (3 of 3).
+        @($committedReport.deadKeys).Count | Should -BeGreaterThan 0 -Because 'a vacuous scan would pass this test without checking anything'
         @($offenders) | Should -BeNullOrEmpty -Because "an operation with no surviving selector sends an unselected request. Either declare/rename a selector, or -- if this is a deliberate, reviewed addition -- add its identity to `$baselineNoSurvivingSelector in this file."
+    }
+
+    It 'keeps the inventory covered: parametersInventoried and keysEvaluated stay above their floors' {
+        # THE COVERAGE-COLLAPSE GUARD. Without it every other assertion in this file can be
+        # satisfied by a report that simply stopped looking: cut parametersInventoried 2174 ->
+        # 900 and keysEvaluated 1757 -> 700, and a third of the dead keys and a third of the
+        # groups vanish from the gate's view with every ceiling and every allowlist still
+        # cleared. That was reproduced against this file before this test existed -- all six
+        # tests passed. A gate reporting safety it does not provide is worse than no gate.
+        #
+        # The ceilings below cannot cover it: a regression in the AST inventory walk or the
+        # wire-name resolver drops the dead-key and skip counts too, so every one of them moves
+        # in the direction the ceilings call "better". Nor can the PS7 regeneration gate: that
+        # catches a generator change made WITHOUT regenerating, and a PR that changes the
+        # generator and regenerates passes both files.
+        #
+        # FLOORS, NOT PINS, for the reason scripts/Assert-PfbSpecCache.ps1 gives for its own
+        # floor of 20 against 29 published specs: this asserts "the mechanism still ran over
+        # the corpus", and the real figures move with ordinary cmdlet churn and with genuine
+        # reclassification. Pinning them would turn every unrelated cmdlet addition into a red
+        # build. Measured at the baseline commit (specVersion 2.28): parametersInventoried
+        # 2174, keysEvaluated 1757 -- so the headroom below is 174 and 157 respectively, and
+        # the 900/700 collapse misses by a wide margin.
+        #
+        # deadKey and the skip counts are deliberately NOT floored. Those must be free to fall
+        # to zero; that is the whole monotone design, and flooring them would recreate the bug
+        # this file was sent back for.
+        $committedReport.counts.parametersInventoried | Should -BeGreaterOrEqual 2000 -Because "the AST inventory must still be walking the whole of Public/: it reported $($committedReport.counts.parametersInventoried) parameters against a measured 2174. A large drop is a coverage collapse, not an improvement -- the keys that disappeared were not proven safe, they stopped being looked at."
+        $committedReport.counts.keysEvaluated | Should -BeGreaterOrEqual 1600 -Because "the classifier must still be evaluating the bulk of the inventory: it reported $($committedReport.counts.keysEvaluated) evaluated keys against a measured 1757. Every key that stops being evaluated leaves the gate's view silently."
+        $committedReport.counts.ok | Should -BeGreaterOrEqual 0 -Because 'ok = keysEvaluated - deadKey, so a negative value means the two counters disagree and the artifact is internally inconsistent'
     }
 
     It 'grows no count: dead keys, no-surviving-selector groups, and every skip reason are <= the committed figures' {
@@ -272,16 +344,23 @@ Describe 'Committed dead-key report (REGRESSION guard, no spec cache required)' 
             return @($list)
         }
 
+        # Both blocks are guarded rather than floored. An ordering assertion over an empty list
+        # is trivially satisfied, so a floor here would only mean "reds when the collection it
+        # is checking the order of became empty" -- which for noSurvivingSelector is 18 fixes
+        # away and is the outcome the artifact exists to produce. Non-vacuity for this file
+        # lives in assertion 1, not here.
         $deadKeys = @($committedReport.deadKeys)
-        $deadKeys.Count | Should -BeGreaterThan 0 -Because 'a vacuous scan would pass this test without checking anything'
-        $deadKeyActual = @($deadKeys | ForEach-Object { '{0}|{1}' -f $_.cmdlet, $_.parameter })
-        $deadKeyExpected = @((& $sortByOrdinal $deadKeys @('cmdlet', 'parameter')) | ForEach-Object { '{0}|{1}' -f $_.cmdlet, $_.parameter })
-        ($deadKeyActual -join "`n") | Should -Be ($deadKeyExpected -join "`n") -Because 'deadKeys must be committed in ordinal order on (cmdlet, parameter); an unsorted artifact produces churn diffs that bury the real change'
+        if ($deadKeys.Count -gt 0) {
+            $deadKeyActual = @($deadKeys | ForEach-Object { '{0}|{1}' -f $_.cmdlet, $_.parameter })
+            $deadKeyExpected = @((& $sortByOrdinal $deadKeys @('cmdlet', 'parameter')) | ForEach-Object { '{0}|{1}' -f $_.cmdlet, $_.parameter })
+            ($deadKeyActual -join "`n") | Should -Be ($deadKeyExpected -join "`n") -Because 'deadKeys must be committed in ordinal order on (cmdlet, parameter); an unsorted artifact produces churn diffs that bury the real change'
+        }
 
         $groups = @($committedReport.noSurvivingSelector)
-        $groups.Count | Should -BeGreaterThan 0 -Because 'a vacuous scan would pass this test without checking anything'
-        $groupActual = @($groups | ForEach-Object { '{0}|{1}|{2}' -f $_.cmdlet, $_.method, $_.endpoint })
-        $groupExpected = @((& $sortByOrdinal $groups @('cmdlet', 'method', 'endpoint')) | ForEach-Object { '{0}|{1}|{2}' -f $_.cmdlet, $_.method, $_.endpoint })
-        ($groupActual -join "`n") | Should -Be ($groupExpected -join "`n") -Because 'noSurvivingSelector must be committed in ordinal order on (cmdlet, method, endpoint)'
+        if ($groups.Count -gt 0) {
+            $groupActual = @($groups | ForEach-Object { '{0}|{1}|{2}' -f $_.cmdlet, $_.method, $_.endpoint })
+            $groupExpected = @((& $sortByOrdinal $groups @('cmdlet', 'method', 'endpoint')) | ForEach-Object { '{0}|{1}|{2}' -f $_.cmdlet, $_.method, $_.endpoint })
+            ($groupActual -join "`n") | Should -Be ($groupExpected -join "`n") -Because 'noSurvivingSelector must be committed in ordinal order on (cmdlet, method, endpoint)'
+        }
     }
 }

--- a/Tests/CommittedDeadKeyReport.Tests.ps1
+++ b/Tests/CommittedDeadKeyReport.Tests.ps1
@@ -43,8 +43,14 @@
                 the artifact; the artifact's ordering not matching the generator's ordinal
                 comparer.
       PASSES -- any entry disappearing, any dead-key or skip count going DOWN, all the way to
-                zero (see the SHRINK-TO-ZERO RELAX POINT note on assertion 1 for the single
-                edit the total-zero case needs).
+                zero. Only the total-zero case needs an edit, and only to one assertion; see
+                the SHRINK-TO-ZERO RELAX POINT note on assertion 1.
+
+    NON-VACUITY IS ASSERTED AS A PROPERTY OF EACH SCAN, not of the collection it walks: every
+    scan counts the elements it visited and asserts that count EQUALS its input size. That is
+    strictly stronger than a greater-than-zero floor -- which a loop silently skipping most of
+    its entries would pass -- and, unlike a floor, it stays true when the collection legitimately
+    empties out. File-level non-vacuity lives in assertion 1 alone.
     Renaming a cmdlet or moving an endpoint changes an identity, so it reads as "new" and
     reds. That is intended: it wants a human to re-confirm the key is still declared, and the
     fix is a one-line edit to the pinned list in the same reviewed diff.
@@ -133,24 +139,26 @@ Describe 'Committed dead-key report (REGRESSION guard, no spec cache required)' 
         # ANTI-VACUITY, first in the file. If this fails every scan below is meaningless, so
         # it fails first and loudly rather than passing silently over a missing or empty file.
         #
-        # SHRINK-TO-ZERO RELAX POINT (1 of 3) -- see the note below. This is the only place in
-        # the file that asserts how MUCH is in the report; everything else asserts either that
-        # nothing NEW appeared or that a floor/ceiling holds.
+        # SHRINK-TO-ZERO RELAX POINT -- the ONLY one in this file. This is the only place that
+        # asserts how MUCH is in the report; everything else asserts either that nothing NEW
+        # appeared, or that a floor/ceiling holds, or that a scan visited everything it was
+        # handed. Those are all satisfied by an empty artifact.
         #
         # WHAT A PR THAT FIXES EVERY REMAINING DEAD KEY HAS TO DO, stated precisely because an
         # earlier version of this comment got it wrong and would have sent that reader in
-        # circles. With `deadKeys: []` the file reds in exactly three places, all tagged
-        # SHRINK-TO-ZERO RELAX POINT: this floor, and the two scan-input floors in the "no NEW
-        # dead key on a destructive verb" and "no NEW noSurvivingSelector" tests, which
-        # deliberately floor on deadKeys because THIS assertion is what guarantees it non-zero.
-        # Relaxing all three together (to the structural property-exists checks immediately
-        # below) is one reviewed edit, and it is a real decision rather than a formality: past
-        # that point the file no longer proves it scanned anything, and its guarantee narrows
-        # to the monotone one. NOTHING ELSE needs touching -- every other assertion here is
-        # already shrink-safe, including both ordering blocks, which no-op on an empty list.
+        # circles. With `deadKeys: []` and `noSurvivingSelector: []` the file reds HERE and
+        # nowhere else. The edit is to drop the two non-emptiness assertions at the bottom of
+        # this block -- the `Should -Not -BeNullOrEmpty` on deadKeys and the `-BeGreaterThan 0`
+        # on its count -- keeping the structural property-exists and non-null checks above
+        # them, which still separate "empty artifact" from "broken artifact". Nothing else
+        # needs touching: the two scans assert an equality against their own input size, which
+        # is trivially true at zero, and both ordering blocks no-op on an empty list.
+        #
+        # It is a real decision rather than a formality: past that point the file no longer
+        # proves it scanned anything, and its guarantee narrows to the monotone one.
         #
         # A PARTIAL fix -- even all 22 destructive entries, or all 18 groups, at once -- needs
-        # no edit at all. That case was constructed and confirmed green.
+        # no edit at all. Every one of these cases was constructed and confirmed.
         $committedReport.PSObject.Properties.Name | Should -Contain 'deadKeys' -Because 'a deadKeys property that vanished entirely would otherwise be indistinguishable from one holding an empty list'
         $committedReport.PSObject.Properties.Name | Should -Contain 'noSurvivingSelector' -Because 'a noSurvivingSelector property that vanished would make the highest-severity scan below vacuous'
         # Explicitly NOT -BeNullOrEmpty via @(...).Count: `@($null).Count` is 1, so a report
@@ -166,22 +174,31 @@ Describe 'Committed dead-key report (REGRESSION guard, no spec cache required)' 
         # a discarded key means the request arrives with no selector, so a new one is the
         # motivating incident happening again.
         #
-        # The floor below is on the SCAN INPUT, not on the filtered subset. Counting only the
-        # DESTRUCTIVE matches would make "all 22 destructive dead keys got fixed" -- a tractable
-        # single PR, and the outcome this artifact exists to produce -- red the gate. The filter
-        # is a predicate, not the scan boundary: what still has to be non-empty is the list the
-        # loop walks, which assertion 1 guarantees; what must be free to reach zero is how many
-        # of them match.
+        # NON-VACUITY IS A PROPERTY OF THE SCAN, NOT OF THE COLLECTION. The question worth
+        # asking is not "was there anything to look at" but "did this loop visit everything it
+        # was handed", so the assertion below is an EQUALITY against the full input size rather
+        # than a greater-than-zero floor. Three consequences, all deliberate:
+        #   - It is strictly stronger. `> 0` proved only that the loop ran at least once, so a
+        #     `continue` bug that silently skipped most entries passed it. Equality catches
+        #     that, and was confirmed to by construction.
+        #   - It is trivially satisfied at zero (0 -eq 0), so the case where a future PR fixes
+        #     every dead key needs no edit here at all. Counting the DESTRUCTIVE matches instead
+        #     would have made "all 22 destructive dead keys got fixed" -- a tractable single PR,
+        #     and the outcome this artifact exists to produce -- red the gate.
+        #   - It keeps this test self-sufficient: it proves its own faithfulness without
+        #     depending on assertion 1 having run first.
+        # File-level non-vacuity lives in assertion 1 alone.
         $scanInput = @($committedReport.deadKeys)
+        $scanned = 0
         $offenders = foreach ($entry in $scanInput) {
+            $scanned++
             if ($entry.severity -ne 'DESTRUCTIVE') { continue }
             $identity = '{0}|{1}|{2}|{3}|{4}' -f $entry.cmdlet, $entry.parameter, $entry.wireKey, $entry.method, $entry.endpoint
             if ($baselineDestructive -notcontains $identity) {
                 "NEW DESTRUCTIVE dead key: $($entry.cmdlet) -$($entry.parameter) writes query key '$($entry.wireKey)', which $($entry.method) $($entry.endpoint) does not declare. That endpoint/verb declares only: $(@($entry.declared) -join ', '). The request will arrive without that selector."
             }
         }
-        # SHRINK-TO-ZERO RELAX POINT (2 of 3).
-        $scanInput.Count | Should -BeGreaterThan 0 -Because 'a vacuous scan would pass this test without checking anything'
+        $scanned | Should -Be $scanInput.Count -Because "the scan must visit every dead key, not silently skip some: it visited $scanned of $($scanInput.Count)"
         @($offenders) | Should -BeNullOrEmpty -Because "a destructive verb carrying an undeclared query key is the incident this gate exists to prevent. Either declare/rename the key, or -- if this is a deliberate, reviewed addition -- add its identity to `$baselineDestructive in this file."
     }
 
@@ -190,12 +207,14 @@ Describe 'Committed dead-key report (REGRESSION guard, no spec cache required)' 
         # sends is dead, so the request carries no usable selector at all. A new one here is
         # strictly worse than a new DESTRUCTIVE dead key alongside a surviving selector.
         #
-        # Same scan-input reasoning as the test above, and here the point is sharper: this
-        # collection has only 18 entries, so "somebody fixed all of them" is one PR. Flooring on
-        # noSurvivingSelector.Count would make the gate red on precisely its own success. The
-        # floor is therefore on deadKeys, which assertion 1 guarantees non-empty and which is a
-        # strict superset of the operations that can produce a group here.
-        $offenders = foreach ($group in @($committedReport.noSurvivingSelector)) {
+        # Same visit-everything reasoning as the test above, and here the payoff is sharper:
+        # this collection has only 18 entries, so "somebody fixed all of them" is one PR. Any
+        # non-emptiness floor -- on this collection or on deadKeys -- would make the gate red on
+        # precisely its own success. An equality against the input size does not.
+        $scanInput = @($committedReport.noSurvivingSelector)
+        $scanned = 0
+        $offenders = foreach ($group in $scanInput) {
+            $scanned++
             $identity = '{0}|{1}|{2}' -f $group.cmdlet, $group.method, $group.endpoint
             if ($baselineNoSurvivingSelector -notcontains $identity) {
                 $deadKeysForGroup = @(@($committedReport.deadKeys) | Where-Object {
@@ -207,8 +226,7 @@ Describe 'Committed dead-key report (REGRESSION guard, no spec cache required)' 
                 "NEW noSurvivingSelector: $($group.cmdlet) ($($group.method) $($group.endpoint)) has no surviving selector -- every selector-shaped key it sends is undeclared [$detail]. That endpoint/verb declares only: $($declared -join ', ')."
             }
         }
-        # SHRINK-TO-ZERO RELAX POINT (3 of 3).
-        @($committedReport.deadKeys).Count | Should -BeGreaterThan 0 -Because 'a vacuous scan would pass this test without checking anything'
+        $scanned | Should -Be $scanInput.Count -Because "the scan must visit every noSurvivingSelector group, not silently skip some: it visited $scanned of $($scanInput.Count)"
         @($offenders) | Should -BeNullOrEmpty -Because "an operation with no surviving selector sends an unselected request. Either declare/rename a selector, or -- if this is a deliberate, reviewed addition -- add its identity to `$baselineNoSurvivingSelector in this file."
     }
 

--- a/Tests/CommittedDeadKeyReport.Tests.ps1
+++ b/Tests/CommittedDeadKeyReport.Tests.ps1
@@ -25,9 +25,13 @@
     artifact regeneration into every later fix -- the anti-pattern the second Describe of
     Tests/CommittedDriftReport.Tests.ps1 argues against at length ("a test asserting 'not yet
     implemented' fails on the PR that implements the thing"). The stated goal is that the set
-    cannot GROW silently, which is a monotone property. A SHRINK MUST PASS. The generator was
-    verified to survive an empty deadKeys set, so a future PR that fixes every dead key must
-    not red this file either.
+    cannot GROW silently, which is a monotone property. A SHRINK MUST PASS, all the way to
+    zero: the generator was verified to survive an empty deadKeys set. A PR that fixes EVERY
+    dead key reds this file in exactly one place -- the two non-emptiness assertions at the
+    bottom of assertion 1 -- and nowhere else, and the edit that case needs is stated precisely
+    at the SHRINK-TO-ZERO RELAX POINT note on assertion 1, which is the single authority for it.
+    Any PARTIAL fix, up to and including all 22 destructive entries or all 18 groups at once,
+    needs no edit at all.
 
     HOW THE BASELINE WAS DERIVED, and what would / would not red this file:
     The artifact is itself the committed thing, so the baseline is the artifact as committed
@@ -38,10 +42,13 @@
     the inventory counts were pinned as FLOORS, which is the one direction the monotone design
     does NOT leave free -- see the coverage-collapse test for why. Therefore:
       REDS   -- a dead key appearing on a destructive verb that is not already pinned; a new
-                noSurvivingSelector group; any dead-key or skip count going UP; a new skip
-                reason; parametersInventoried or keysEvaluated collapsing; an absolute path in
-                the artifact; the artifact's ordering not matching the generator's ordinal
-                comparer.
+                noSurvivingSelector group; the dead-key count or a CEILINGED skip count going
+                UP; a new skip reason; a severity outside the known vocabulary;
+                parametersInventoried or keysEvaluated collapsing; the counts failing to
+                reconcile; an absolute path in the artifact; the artifact's ordering not
+                matching the generator's ordinal comparer. ('body property' is a known skip
+                reason that is deliberately NOT ceilinged -- see $baselineUnceilingedSkipReasons
+                in BeforeAll.)
       PASSES -- any entry disappearing, any dead-key or skip count going DOWN, all the way to
                 zero. Only the total-zero case needs an edit, and only to one assertion; see
                 the SHRINK-TO-ZERO RELAX POINT note on assertion 1.
@@ -138,10 +145,25 @@ BeforeAll {
     $script:baselineNoSurvivingSelectorCount = 18
     $script:baselineSkipReasons = @{
         'wire name unresolved'           = 125
-        'body property'                  = 278
         'endpoint/method ambiguous'      = 14
         'endpoint/verb absent from spec' = 0
     }
+    # KNOWN skip reasons that are deliberately NOT ceilinged. Do not read this as an oversight
+    # and put 'body property' back into the hashtable above.
+    #
+    # 'body property' was ceilinged at 278 and had to come out: bumping it to 279 -- i.e. any
+    # unrelated PR adding a single body-surface parameter -- red the gate with "those keys are
+    # now unevaluable, not proven safe", which asserts a safety regression that did not happen.
+    # A new body parameter was never evaluable AS A QUERY KEY in the first place, so its
+    # non-evaluation is not lost coverage. Body-surface parameters are explicitly P1's scope, so
+    # the ceiling red a PR that had done nothing wrong. The other three reasons are not like
+    # this: growth in 'wire name unresolved' or 'endpoint/method ambiguous' means keys that WERE
+    # evaluable stopped being evaluated, which genuinely does shrink what this gate covers.
+    #
+    # 'body property' is still constrained, just not here: the reconciliation invariant
+    # (keysEvaluated + every skip reason == parametersInventoried) reds if the body-property
+    # count moves without a matching move in the inventory. It is unceilinged, not unwatched.
+    $script:baselineUnceilingedSkipReasons = @('body property')
 }
 
 Describe 'Committed dead-key report (REGRESSION guard, no spec cache required)' {
@@ -170,6 +192,14 @@ Describe 'Committed dead-key report (REGRESSION guard, no spec cache required)' 
         #
         # A PARTIAL fix -- even all 22 destructive entries, or all 18 groups, at once -- needs
         # no edit at all. Every one of these cases was constructed and confirmed.
+        # specVersion is asserted PRESENT AND VERSION-SHAPED, never pinned to a value. It is the
+        # spec the whole report was computed against, so an artifact that lost it is not
+        # interpretable at all -- and nothing else on the ungated leg looked at it (it was
+        # constrained only indirectly, through the skip ceilings, and finding 3 loosens those).
+        # A pin to '2.28' would red the routine REST-version-bump PR, which is exactly the
+        # exact-equality anti-pattern this file's header argues against.
+        $committedReport.PSObject.Properties.Name | Should -Contain 'specVersion' -Because 'the report is only interpretable against the spec version it was computed from; an artifact that dropped specVersion is structurally broken'
+        [string]$committedReport.specVersion | Should -Match '^\d+\.\d+$' -Because "specVersion must look like a REST API version (e.g. 2.28); it is '$($committedReport.specVersion)'. Deliberately a SHAPE and not a pin -- pinning it would red the PR that bumps the spec."
         $committedReport.PSObject.Properties.Name | Should -Contain 'deadKeys' -Because 'a deadKeys property that vanished entirely would otherwise be indistinguishable from one holding an empty list'
         $committedReport.PSObject.Properties.Name | Should -Contain 'noSurvivingSelector' -Because 'a noSurvivingSelector property that vanished would make the highest-severity scan below vacuous'
         # Explicitly NOT -BeNullOrEmpty via @(...).Count: `@($null).Count` is 1, so a report
@@ -203,6 +233,31 @@ Describe 'Committed dead-key report (REGRESSION guard, no spec cache required)' 
         $scanned = 0
         $offenders = foreach ($entry in $scanInput) {
             $scanned++
+            # THE PREDICATE BELOW IS ANCHORED TO THE SEVERITY VOCABULARY, and it is anchored
+            # BECAUSE THE UNANCHORED FORM WAS MEASURED VACUOUS. `-ne 'DESTRUCTIVE'` matches
+            # nothing at all if the vocabulary moves, and two mutations were run that each
+            # produced P7 F0 -- a clean green with this file's highest-value assertion covering
+            # zero entries:
+            #   1. delete the `severity` property from the artifact -- `$null -ne 'DESTRUCTIVE'`
+            #      is true for all 126 records, so every entry `continue`s;
+            #   2. rename the vocabulary in the generator (DESTRUCTIVE -> DELETE-RISK) and
+            #      regenerate honestly -- same total skip, no failure anywhere.
+            # The only thing otherwise pinning the vocabulary is one synthetic assertion in
+            # Tests/Build-PfbDeadKeyReport.Tests.ps1, which is PS7-gated -- so on the 5.1 leg,
+            # the leg this ungated file exists to serve, the 22-identity destructive allowlist
+            # had no proof it matched anything. This assertion makes a renamed or dropped
+            # severity a red instead of a silent full-skip.
+            #
+            # It is NOT a floor on a filtered subset (Task 4 round 1, finding 1 -- do not go
+            # back to counting matches). It is a per-record property assertion inside the scan
+            # that already visits every record, so it costs nothing at zero dead keys: a
+            # `foreach` over an empty collection never evaluates it.
+            $entry.severity | Should -BeIn @('DESTRUCTIVE', 'CREATE', 'WRONG-RESULTS') -Because "the severity vocabulary is what the filter below keys on, so an unrecognised or missing severity means the DESTRUCTIVE filter silently matches nothing: $($entry.cmdlet) -$($entry.parameter) carries severity '$($entry.severity)'. If the generator's vocabulary changed deliberately, update this list AND the filter below in the same reviewed diff."
+            # `declared` is what a reader fixes the cmdlet from, and it is interpolated into the
+            # offender message below -- where a missing property renders as an empty string and
+            # degrades the message silently. Asserted here, on the ungated leg, because nothing
+            # else on 5.1 checked it at all.
+            $entry.PSObject.Properties.Name | Should -Contain 'declared' -Because "every dead-key record must carry the declared-key list a reader fixes the cmdlet from; $($entry.cmdlet) -$($entry.parameter) has none, and its absence would render as an empty list in this test's own failure message rather than as an error"
             if ($entry.severity -ne 'DESTRUCTIVE') { continue }
             $identity = '{0}|{1}|{2}|{3}|{4}' -f $entry.cmdlet, $entry.parameter, $entry.wireKey, $entry.method, $entry.endpoint
             if ($baselineDestructive -notcontains $identity) {
@@ -268,17 +323,30 @@ Describe 'Committed dead-key report (REGRESSION guard, no spec cache required)' 
         # this file was sent back for.
         $committedReport.counts.parametersInventoried | Should -BeGreaterOrEqual 2000 -Because "the AST inventory must still be walking the whole of Public/: it reported $($committedReport.counts.parametersInventoried) parameters against a measured 2174. A large drop is a coverage collapse, not an improvement -- the keys that disappeared were not proven safe, they stopped being looked at."
         $committedReport.counts.keysEvaluated | Should -BeGreaterOrEqual 1600 -Because "the classifier must still be evaluating the bulk of the inventory: it reported $($committedReport.counts.keysEvaluated) evaluated keys against a measured 1757. Every key that stops being evaluated leaves the gate's view silently."
-        # THE RECONCILIATION, both halves. An earlier version asserted `ok >= 0`, which cannot
-        # fail on any generated artifact: the generator computes ok as
-        # evaluatedRecords.Count - deadKeyRecords.Count with dead keys a strict subset of
-        # evaluated records, so it is non-negative by construction and only a hand-edit could
-        # trip it. These two are the invariants that line was reaching for, and they can fail --
-        # on a generator arithmetic bug, on a hand-edit, and on a partial regeneration that
-        # updates one counter and not another.
+        # THE RECONCILIATION, both halves -- and the two halves are NOT of equal strength. Said
+        # plainly, because an earlier version of this comment overclaimed the first one:
         #
-        # They also close a specific hole in the floors above: the floors ask whether the
+        #   FIRST (ok + deadKey == keysEvaluated) IS TRUE BY CONSTRUCTION for any GENERATED
+        #   artifact, on any input. The generator computes ok as
+        #   evaluatedRecords.Count - deadKeyRecords.Count and keysEvaluated as
+        #   evaluatedRecords.Count, so the identity holds arithmetically whatever the classifier
+        #   did. It cannot catch a generator bug and it cannot catch a "partial regeneration"
+        #   either -- there is no such thing here, the manifest is serialised whole in one
+        #   ConvertTo-Json / Set-Content. What it CAN catch is a HAND-EDITED artifact, which is
+        #   why it is kept: it is one line, and it is a strictly better use of that line than the
+        #   `ok >= 0` it replaced (which was non-negative by construction too, so it could not
+        #   even catch the hand-edit).
+        #
+        #   SECOND (keysEvaluated + all skip reasons == parametersInventoried) is the one with
+        #   real content against a GENERATOR bug: evaluation and skipping are counted on
+        #   different paths, so a record that falls through both is invisible to the floors above
+        #   and reds here. Proven, not assumed -- dropping a third of the inventory records and
+        #   regenerating reds this half.
+        #
+        # Together they close a specific hole in the floors above: the floors ask whether the
         # headline numbers are big enough, and these ask whether they add up. A collapse that
-        # scaled every counter proportionally would clear neither.
+        # scaled every counter proportionally would clear neither. The second half is also what
+        # still constrains the 'body property' skip count now that its ceiling has been removed.
         $skipTotal = 0
         foreach ($reason in $committedReport.counts.skipReasons.PSObject.Properties) { $skipTotal += [int]$reason.Value }
         ([int]$committedReport.counts.ok + [int]$committedReport.counts.deadKey) |
@@ -298,10 +366,15 @@ Describe 'Committed dead-key report (REGRESSION guard, no spec cache required)' 
         $scanned = 0
         $offenders = foreach ($reason in $committedReport.counts.skipReasons.PSObject.Properties) {
             $scanned++
-            if (-not $baselineSkipReasons.ContainsKey($reason.Name)) {
+            if (-not $baselineSkipReasons.ContainsKey($reason.Name) -and $baselineUnceilingedSkipReasons -notcontains $reason.Name) {
                 "UNKNOWN skip reason '$($reason.Name)' (count $($reason.Value)) -- the generator gained a skip class the baseline in this test does not know about"
                 continue
             }
+            # Known, but deliberately not ceilinged -- see $baselineUnceilingedSkipReasons in
+            # BeforeAll for why 'body property' is the odd one out and what still constrains it.
+            # Still VISITED and still counted toward the visit-everything equality below: this
+            # is a change to what the scan enforces per reason, not to the scan.
+            if ($baselineUnceilingedSkipReasons -contains $reason.Name) { continue }
             if ([int]$reason.Value -gt [int]$baselineSkipReasons[$reason.Name]) {
                 "skip reason '$($reason.Name)' grew from $($baselineSkipReasons[$reason.Name]) to $($reason.Value) -- those keys are now unevaluable, not proven safe"
             }

--- a/Tests/CommittedDeadKeyReport.Tests.ps1
+++ b/Tests/CommittedDeadKeyReport.Tests.ps1
@@ -46,11 +46,22 @@
                 zero. Only the total-zero case needs an edit, and only to one assertion; see
                 the SHRINK-TO-ZERO RELAX POINT note on assertion 1.
 
-    NON-VACUITY IS ASSERTED AS A PROPERTY OF EACH SCAN, not of the collection it walks: every
-    scan counts the elements it visited and asserts that count EQUALS its input size. That is
-    strictly stronger than a greater-than-zero floor -- which a loop silently skipping most of
-    its entries would pass -- and, unlike a floor, it stays true when the collection legitimately
-    empties out. File-level non-vacuity lives in assertion 1 alone.
+    NON-VACUITY IS ASSERTED AS A PROPERTY OF EACH SCAN, not of the collection it walks. Every
+    scan counts what it visited and asserts a bound tied to its input's REAL SIZE -- never a
+    bare `> 0`, which proves only that a loop ran once and which a loop silently skipping most
+    of its entries passes. The bound takes one of two forms, depending on whether the input size
+    is knowable in advance:
+
+      EQUALITY, where it is. The three scans over a materialised collection -- destructive dead
+      keys, noSurvivingSelector groups, and skip reasons -- each assert visited == input count.
+
+      A CONTENT-DERIVED FLOOR, where it is not. The absolute-path scan is a recursive descent
+      with no collection to measure, so it asserts it visited at least 5 strings per dead-key
+      record: enough to prove it descended into the deadKeys subtree rather than skimming the
+      top level. A `> 0` floor there was measured at one string away from vacuous.
+
+    Both forms are trivially satisfied at zero dead keys (0 == 0, and >= 0), so neither costs
+    shrink-safety. File-level non-vacuity lives in assertion 1 alone.
     Renaming a cmdlet or moving an endpoint changes an identity, so it reads as "new" and
     reds. That is intended: it wants a human to re-confirm the key is still declared, and the
     fix is a one-line edit to the pinned list in the same reviewed diff.
@@ -257,7 +268,23 @@ Describe 'Committed dead-key report (REGRESSION guard, no spec cache required)' 
         # this file was sent back for.
         $committedReport.counts.parametersInventoried | Should -BeGreaterOrEqual 2000 -Because "the AST inventory must still be walking the whole of Public/: it reported $($committedReport.counts.parametersInventoried) parameters against a measured 2174. A large drop is a coverage collapse, not an improvement -- the keys that disappeared were not proven safe, they stopped being looked at."
         $committedReport.counts.keysEvaluated | Should -BeGreaterOrEqual 1600 -Because "the classifier must still be evaluating the bulk of the inventory: it reported $($committedReport.counts.keysEvaluated) evaluated keys against a measured 1757. Every key that stops being evaluated leaves the gate's view silently."
-        $committedReport.counts.ok | Should -BeGreaterOrEqual 0 -Because 'ok = keysEvaluated - deadKey, so a negative value means the two counters disagree and the artifact is internally inconsistent'
+        # THE RECONCILIATION, both halves. An earlier version asserted `ok >= 0`, which cannot
+        # fail on any generated artifact: the generator computes ok as
+        # evaluatedRecords.Count - deadKeyRecords.Count with dead keys a strict subset of
+        # evaluated records, so it is non-negative by construction and only a hand-edit could
+        # trip it. These two are the invariants that line was reaching for, and they can fail --
+        # on a generator arithmetic bug, on a hand-edit, and on a partial regeneration that
+        # updates one counter and not another.
+        #
+        # They also close a specific hole in the floors above: the floors ask whether the
+        # headline numbers are big enough, and these ask whether they add up. A collapse that
+        # scaled every counter proportionally would clear neither.
+        $skipTotal = 0
+        foreach ($reason in $committedReport.counts.skipReasons.PSObject.Properties) { $skipTotal += [int]$reason.Value }
+        ([int]$committedReport.counts.ok + [int]$committedReport.counts.deadKey) |
+            Should -Be ([int]$committedReport.counts.keysEvaluated) -Because "every evaluated key is either OK or dead, so ok + deadKey must equal keysEvaluated: $($committedReport.counts.ok) + $($committedReport.counts.deadKey) = $([int]$committedReport.counts.ok + [int]$committedReport.counts.deadKey), against keysEvaluated $($committedReport.counts.keysEvaluated)"
+        ([int]$committedReport.counts.keysEvaluated + $skipTotal) |
+            Should -Be ([int]$committedReport.counts.parametersInventoried) -Because "every inventoried parameter is either evaluated or skipped for exactly one reason, so keysEvaluated + all skip reasons must equal parametersInventoried: $($committedReport.counts.keysEvaluated) + $skipTotal = $([int]$committedReport.counts.keysEvaluated + $skipTotal), against parametersInventoried $($committedReport.counts.parametersInventoried)"
     }
 
     It 'grows no count: dead keys, no-surviving-selector groups, and every skip reason are <= the committed figures' {
@@ -279,7 +306,11 @@ Describe 'Committed dead-key report (REGRESSION guard, no spec cache required)' 
                 "skip reason '$($reason.Name)' grew from $($baselineSkipReasons[$reason.Name]) to $($reason.Value) -- those keys are now unevaluable, not proven safe"
             }
         }
-        $scanned | Should -BeGreaterThan 0 -Because 'a vacuous scan would pass this test without checking anything'
+        # EQUALITY, not a floor: the input size is trivially knowable here. A scan visiting 1 of
+        # 4 skip-reason properties passes a `> 0` floor while hiding a 14 -> 999 growth in one of
+        # the three it never looked at.
+        $skipReasonCount = @($committedReport.counts.skipReasons.PSObject.Properties).Count
+        $scanned | Should -Be $skipReasonCount -Because "the scan must visit every skip reason, not silently skip some: it visited $scanned of $skipReasonCount"
         @($offenders) | Should -BeNullOrEmpty -Because 'a skipped key is unevaluated, so a growing skip count silently shrinks what this gate covers'
     }
 
@@ -324,7 +355,23 @@ Describe 'Committed dead-key report (REGRESSION guard, no spec cache required)' 
             }
             # Anything else (int, bool) carries no path and needs no scan.
         }
-        $scanned | Should -BeGreaterThan 0 -Because 'a vacuous scan would pass this test without checking anything'
+        # THE FLOOR IS TIED TO THE ARTIFACT'S REAL CONTENT, and it has to be. This is the one
+        # scan whose input size is not knowable in advance -- it is a recursive descent, so
+        # there is no collection to measure -- and a `> 0` floor here was demonstrably one
+        # string away from vacuous: replacing the IEnumerable descent branch above with a bare
+        # `continue` dropped $scanned from 1600 to 1 (top-level specVersion, the only string
+        # reachable without descending) and every test in this file still passed. The very fact
+        # that made the floor look shrink-safe -- specVersion is always present -- is what held
+        # it up while the walk scanned nothing.
+        #
+        # Each deadKeys record carries at least five string fields (severity, cmdlet, parameter,
+        # wireKey, method, endpoint -- six, floored at five so a future field rename cannot red
+        # this), so the walk must reach at least 5x the dead-key count in strings or it did not
+        # descend into the subtree where a leaked path would actually live. Deliberately
+        # expressed against deadKeys.Count rather than a constant: at zero dead keys it reads
+        # `>= 0` and still passes, so this stays shrink-safe.
+        $expectedMinimumStrings = 5 * @($committedReport.deadKeys).Count
+        $scanned | Should -BeGreaterOrEqual $expectedMinimumStrings -Because "the walk must descend into the deadKeys records, not just skim the top level: it visited $scanned strings against the $expectedMinimumStrings that $(@($committedReport.deadKeys).Count) dead-key records carry between them. A walk that stops descending scans nothing and reports clean."
         @($offenders) | Should -BeNullOrEmpty -Because 'every string in the committed report must be repo-relative: an absolute path publishes a local checkout location and makes the artifact depend on where it was generated'
     }
 

--- a/Tests/PfbSpecTools.DeclaredQueryKey.Tests.ps1
+++ b/Tests/PfbSpecTools.DeclaredQueryKey.Tests.ps1
@@ -1,0 +1,155 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+<#
+.SYNOPSIS
+    Unit tests for Get-PfbDeclaredQueryKey (tools/lib/PfbSpecTools.ps1).
+.DESCRIPTION
+    Pure-function unit tests against in-memory synthetic spec objects — no network access
+    and no dependency on the cached specs in tools/specs/, so this file runs with no spec
+    cache present.
+
+    Every fixture node is a [PSCustomObject], never a bare @{} hashtable: Resolve-PfbRef
+    tests for a '$ref' property via $current.PSObject.Properties.Name -contains '$ref',
+    which never matches on a hashtable (see tools/lib/PfbSpecTools.ps1 for the trap note).
+    A hashtable fixture would silently drop every $ref'd parameter and the $ref test would
+    pass while proving nothing.
+#>
+
+BeforeAll {
+    $repoRoot = Split-Path -Parent $PSScriptRoot
+    . (Join-Path $repoRoot 'tools/lib/PfbSpecTools.ps1')
+}
+
+Describe 'Get-PfbDeclaredQueryKey' {
+
+    BeforeAll {
+        $script:spec = [PSCustomObject]@{
+            components = [PSCustomObject]@{
+                parameters = [PSCustomObject]@{
+                    NamesParam = [PSCustomObject]@{
+                        name = 'names'
+                        'in' = 'query'
+                    }
+                }
+            }
+            paths      = [PSCustomObject]@{
+                '/api/2.28/inline'     = [PSCustomObject]@{
+                    get = [PSCustomObject]@{
+                        parameters = @(
+                            [PSCustomObject]@{ name = 'filter'; 'in' = 'query' }
+                            [PSCustomObject]@{ name = 'limit'; 'in' = 'query' }
+                        )
+                    }
+                }
+                '/api/2.28/reffed'     = [PSCustomObject]@{
+                    get = [PSCustomObject]@{
+                        parameters = @(
+                            [PSCustomObject]@{ '$ref' = '#/components/parameters/NamesParam' }
+                        )
+                    }
+                }
+                '/api/2.28/pathparam'  = [PSCustomObject]@{
+                    get = [PSCustomObject]@{
+                        parameters = @(
+                            [PSCustomObject]@{ name = 'id'; 'in' = 'path' }
+                            [PSCustomObject]@{ name = 'filter'; 'in' = 'query' }
+                        )
+                    }
+                }
+                '/api/2.28/noparams'   = [PSCustomObject]@{
+                    get = [PSCustomObject]@{
+                        responses = [PSCustomObject]@{ '200' = [PSCustomObject]@{} }
+                    }
+                }
+                '/api/2.28/single'     = [PSCustomObject]@{
+                    get = [PSCustomObject]@{
+                        parameters = @(
+                            [PSCustomObject]@{ name = 'names'; 'in' = 'query' }
+                        )
+                    }
+                }
+                '/api/2.28/getonly'    = [PSCustomObject]@{
+                    get = [PSCustomObject]@{
+                        parameters = @(
+                            [PSCustomObject]@{ name = 'names'; 'in' = 'query' }
+                        )
+                    }
+                }
+                '/api/2.28/emptyverb'  = [PSCustomObject]@{
+                    delete = [PSCustomObject]@{}
+                }
+                '/api/2.28/casing'     = [PSCustomObject]@{
+                    delete = [PSCustomObject]@{
+                        parameters = @(
+                            [PSCustomObject]@{ name = 'ids'; 'in' = 'query' }
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    It 'returns an inline query parameter' {
+        $result = Get-PfbDeclaredQueryKey -Spec $script:spec -Endpoint 'inline' -Method 'GET' -Version '2.28'
+        $result | Should -Contain 'filter'
+        $result | Should -Contain 'limit'
+        $result.Count | Should -Be 2
+    }
+
+    It 'resolves and returns a $ref''d query parameter' {
+        $result = Get-PfbDeclaredQueryKey -Spec $script:spec -Endpoint 'reffed' -Method 'GET' -Version '2.28'
+        $result | Should -Contain 'names'
+        $result.Count | Should -Be 1
+    }
+
+    It 'excludes a path-located parameter' {
+        $result = Get-PfbDeclaredQueryKey -Spec $script:spec -Endpoint 'pathparam' -Method 'GET' -Version '2.28'
+        $result | Should -Contain 'filter'
+        $result | Should -Not -Contain 'id'
+        $result.Count | Should -Be 1
+    }
+
+    It 'returns an empty array, not $null, for an operation with no parameters' {
+        $result = Get-PfbDeclaredQueryKey -Spec $script:spec -Endpoint 'noparams' -Method 'GET' -Version '2.28'
+        $null -eq $result | Should -BeFalse
+        $result -is [string[]] | Should -BeTrue
+        $result.Count | Should -Be 0
+    }
+
+    It 'returns an array, not a bare string, for a single declared key' {
+        $result = Get-PfbDeclaredQueryKey -Spec $script:spec -Endpoint 'single' -Method 'GET' -Version '2.28'
+        $result -is [string] | Should -BeFalse
+        $result -is [string[]] | Should -BeTrue
+        $result.Count | Should -Be 1
+    }
+
+    It 'returns $null for an absent path' {
+        $result = Get-PfbDeclaredQueryKey -Spec $script:spec -Endpoint 'does-not-exist' -Method 'GET' -Version '2.28'
+        $null -eq $result | Should -BeTrue
+    }
+
+    It 'returns $null for a present path with an absent verb' {
+        $result = Get-PfbDeclaredQueryKey -Spec $script:spec -Endpoint 'getonly' -Method 'DELETE' -Version '2.28'
+        $null -eq $result | Should -BeTrue
+    }
+
+    It 'returns an empty array, not $null, for a present but empty operation node' {
+        $result = Get-PfbDeclaredQueryKey -Spec $script:spec -Endpoint 'emptyverb' -Method 'DELETE' -Version '2.28'
+        $null -eq $result | Should -BeFalse
+        $result -is [string[]] | Should -BeTrue
+        $result.Count | Should -Be 0
+    }
+
+    It 'resolves an endpoint literal with no leading slash' {
+        $withoutSlash = Get-PfbDeclaredQueryKey -Spec $script:spec -Endpoint 'inline' -Method 'GET' -Version '2.28'
+        $withSlash = Get-PfbDeclaredQueryKey -Spec $script:spec -Endpoint '/inline' -Method 'GET' -Version '2.28'
+        $withoutSlash | Should -Contain 'filter'
+        ($withoutSlash -join ',') | Should -Be ($withSlash -join ',')
+    }
+
+    It 'treats method casing as insensitive' {
+        $upper = Get-PfbDeclaredQueryKey -Spec $script:spec -Endpoint 'casing' -Method 'DELETE' -Version '2.28'
+        $lower = Get-PfbDeclaredQueryKey -Spec $script:spec -Endpoint 'casing' -Method 'delete' -Version '2.28'
+        $upper | Should -Contain 'ids'
+        ($upper -join ',') | Should -Be ($lower -join ',')
+    }
+}

--- a/Tests/coverage-baseline.psd1
+++ b/Tests/coverage-baseline.psd1
@@ -55,11 +55,15 @@
             'Rail A - no unwaived selector coercion'
             'Rail B - committed map matches regeneration'
             # Dead-key gate. The COMMITTED guard is ungated and so is listed under winps51
-            # too; the regeneration gate is PS7-only (the generator carries
-            # `#Requires -Version 7.0`), so like the issue-#90 rails above it belongs to this
-            # block alone -- requiring it on 5.1 would be a permanent false red.
+            # too; the two halves of the generator gate are PS7-only (the generator carries
+            # `#Requires -Version 7.0`), so like the issue-#90 rails above they belong to this
+            # block alone -- requiring them on 5.1 would be a permanent false red. They are
+            # split on a dependency boundary: the first needs the real tools/specs cache, the
+            # second builds its own fixture and reads no cache at all, so a broken fixture
+            # cannot make the real generator look broken.
             'Committed dead-key report (REGRESSION guard, no spec cache required)'
-            'Build-PfbDeadKeyReport (regeneration gate, spec cache required, PS7 only)'
+            'Build-PfbDeadKeyReport regeneration (real spec cache required, PS7 only)'
+            'Build-PfbDeadKeyReport classification (synthetic fixture, no spec cache, PS7 only)'
         )
     }
     winps51 = @{

--- a/Tests/coverage-baseline.psd1
+++ b/Tests/coverage-baseline.psd1
@@ -113,9 +113,10 @@
             'Build-PfbValueEnumMap: hand-written ValidateSet citations'
             # Dead-key gate, ungated half. It reads only the committed
             # Reports/PfbDeadKeyReport.json -- no spec cache, no PowerShell 7, no skip path --
-            # so it must contribute executed tests on BOTH legs. Its PS7-only sibling,
-            # 'Build-PfbDeadKeyReport (regeneration gate, spec cache required, PS7 only)', is
-            # deliberately absent from this list and appears under pwsh7 only.
+            # so it must contribute executed tests on BOTH legs. Its two PS7-only siblings,
+            # 'Build-PfbDeadKeyReport regeneration (real spec cache required, PS7 only)' and
+            # 'Build-PfbDeadKeyReport classification (synthetic fixture, no spec cache, PS7
+            # only)', are deliberately absent from this list and appear under pwsh7 only.
             'Committed dead-key report (REGRESSION guard, no spec cache required)'
         )
     }

--- a/Tests/coverage-baseline.psd1
+++ b/Tests/coverage-baseline.psd1
@@ -54,6 +54,12 @@
             # see, since a cacheless runner leaves it contributing neither a pass nor a skip.
             'Rail A - no unwaived selector coercion'
             'Rail B - committed map matches regeneration'
+            # Dead-key gate. The COMMITTED guard is ungated and so is listed under winps51
+            # too; the regeneration gate is PS7-only (the generator carries
+            # `#Requires -Version 7.0`), so like the issue-#90 rails above it belongs to this
+            # block alone -- requiring it on 5.1 would be a permanent false red.
+            'Committed dead-key report (REGRESSION guard, no spec cache required)'
+            'Build-PfbDeadKeyReport (regeneration gate, spec cache required, PS7 only)'
         )
     }
     winps51 = @{
@@ -101,6 +107,12 @@
             # Ungated for the same reason: it parses tracked .ps1 files via the AST, so it needs
             # neither the spec cache nor the generated manifest and has no skip path.
             'Build-PfbValueEnumMap: hand-written ValidateSet citations'
+            # Dead-key gate, ungated half. It reads only the committed
+            # Reports/PfbDeadKeyReport.json -- no spec cache, no PowerShell 7, no skip path --
+            # so it must contribute executed tests on BOTH legs. Its PS7-only sibling,
+            # 'Build-PfbDeadKeyReport (regeneration gate, spec cache required, PS7 only)', is
+            # deliberately absent from this list and appears under pwsh7 only.
+            'Committed dead-key report (REGRESSION guard, no spec cache required)'
         )
     }
 }

--- a/tools/Build-PfbDeadKeyReport.ps1
+++ b/tools/Build-PfbDeadKeyReport.ps1
@@ -40,7 +40,7 @@ if (-not (Test-Path -LiteralPath $CapabilityMapPath)) {
     throw "Capability map not found at '$CapabilityMapPath'. Run Build-PfbCapabilityMap.ps1 first."
 }
 
-$capabilityMap = Get-Content -Path $CapabilityMapPath -Raw | ConvertFrom-Json -Depth 20
+$capabilityMap = Get-Content -LiteralPath $CapabilityMapPath -Raw | ConvertFrom-Json -Depth 20
 $specVersion = $capabilityMap.generatedFrom | Select-Object -Last 1
 if (-not $specVersion) {
     throw "Capability map at '$CapabilityMapPath' has no generatedFrom versions."
@@ -51,31 +51,36 @@ if (-not (Test-Path -LiteralPath $specPath)) {
     throw "Pinned analysed spec 'fb$specVersion.json' (per capability map's generatedFrom) not found under '$SpecsDirectory'. Run Update-PfbApiSpecs.ps1 first, or rebuild the capability map against the specs on disk."
 }
 
-$spec = Get-Content -Path $specPath -Raw | ConvertFrom-Json -Depth 64
+$spec = Get-Content -LiteralPath $specPath -Raw | ConvertFrom-Json -Depth 64
 $inventory = @(Get-PfbCmdletParameterInventory -PublicDirectory $PublicDirectory)
 
 # Task 4 mirrors this exact helper verbatim. It sorts records, not a joined key, using an
-# explicit ordinal comparison on Cmdlet then Parameter. Ordinal is stable between PS7 and
-# Windows PowerShell 5.1; Sort-Object -Culture '' is invariant linguistic and is not.
+# explicit ordinal comparison over the named properties supplied by -Property. Ordinal is
+# stable between PS7 and Windows PowerShell 5.1; Sort-Object -Culture '' is invariant
+# linguistic and is not. Each collection passes only properties that exist in its emitted
+# artifact: deadKeys uses Cmdlet then Parameter, while noSurvivingSelector uses Cmdlet then
+# Method then Endpoint.
 function Sort-PfbDeadKeyRecords {
     param(
+        [AllowEmptyCollection()]
+        [object[]]$Records,
+
         [Parameter(Mandatory)]
-        [object[]]$Records
+        [string[]]$Property
     )
 
     $sorted = [System.Collections.Generic.List[object]]::new()
     foreach ($record in $Records) { $sorted.Add($record) }
     $sorted.Sort([System.Comparison[object]]{
         param($left, $right)
-        $comparison = [string]::Compare(
-            [string]$left.Cmdlet,
-            [string]$right.Cmdlet,
-            [System.StringComparison]::Ordinal)
-        if ($comparison -ne 0) { return $comparison }
-        return [string]::Compare(
-            [string]$left.Parameter,
-            [string]$right.Parameter,
-            [System.StringComparison]::Ordinal)
+        foreach ($propertyName in $Property) {
+            $comparison = [string]::Compare(
+                [string]$left.$propertyName,
+                [string]$right.$propertyName,
+                [System.StringComparison]::Ordinal)
+            if ($comparison -ne 0) { return $comparison }
+        }
+        return 0
     })
     return @($sorted)
 }
@@ -106,7 +111,7 @@ function Get-PfbDeadKeySeverity {
         'PUT'    { return 'DESTRUCTIVE' }
         'POST'   { return 'CREATE' }
         'GET'    { return 'WRONG-RESULTS' }
-        default  { return 'UNKNOWN' }
+        default  { throw "Unsupported HTTP method '$Method' while classifying a dead key." }
     }
 }
 
@@ -116,7 +121,6 @@ $skipReasons = [ordered]@{
     'endpoint/method ambiguous'     = 0
     'endpoint/verb absent from spec' = 0
 }
-$okRecords = [System.Collections.Generic.List[object]]::new()
 $deadKeyRecords = [System.Collections.Generic.List[object]]::new()
 $evaluatedRecords = [System.Collections.Generic.List[object]]::new()
 
@@ -156,7 +160,6 @@ foreach ($record in $inventory) {
     $evaluatedRecords.Add($evaluated)
 
     if ($status -eq 'OK') {
-        $okRecords.Add($evaluated)
         continue
     }
 
@@ -171,24 +174,50 @@ foreach ($record in $inventory) {
     })
 }
 
-# Group evaluated selector records only. A skipped selector is unevaluable, not evidence that
-# every selector is dead. Thus a group is emitted only when it has at least one selector and all
-# of its selector-shaped keys were evaluated and classified as DEAD KEY.
+# A skipped selector is unevaluable, not evidence that every selector is dead. Group all
+# inventory records by operation, then emit only when the group has at least one selector,
+# no selector was skipped for any reason, and every evaluated selector is a DEAD KEY.
 $noSurvivingSelectorRecords = [System.Collections.Generic.List[object]]::new()
-$selectorGroups = @($evaluatedRecords | Where-Object SelectorShaped | Group-Object Cmdlet, Method, Endpoint)
+$allSelectorRecords = [System.Collections.Generic.List[object]]::new()
+foreach ($record in $inventory) {
+    if ($null -eq $record.WireName) { continue }
+    if (Test-PfbDeadKeySelectorName -WireName ([string]$record.WireName)) {
+        $allSelectorRecords.Add([PSCustomObject]@{
+            Cmdlet    = $record.Cmdlet
+            Parameter = $record.Parameter
+            Method    = if ($record.Method) { ([string]$record.Method).ToUpperInvariant() } else { $null }
+            Endpoint  = $record.Endpoint
+            Evaluated = $false
+            Status    = $null
+        })
+    }
+}
+foreach ($evaluated in $evaluatedRecords | Where-Object SelectorShaped) {
+    $match = $allSelectorRecords | Where-Object {
+        $_.Cmdlet -eq $evaluated.Cmdlet -and $_.Parameter -eq $evaluated.Parameter -and
+        $_.Method -eq $evaluated.Method -and $_.Endpoint -eq $evaluated.Endpoint
+    } | Select-Object -First 1
+    if ($match) {
+        $match.Evaluated = $true
+        $match.Status = $evaluated.Status
+    }
+}
+$selectorGroups = @($allSelectorRecords | Group-Object Cmdlet, Method, Endpoint)
 foreach ($group in $selectorGroups) {
-    if (@($group.Group | Where-Object Status -ne 'DEAD KEY').Count -eq 0) {
-        $first = $group.Group | Select-Object -First 1
+    $selectors = @($group.Group)
+    if ($selectors.Count -gt 0 -and
+        @($selectors | Where-Object { -not $_.Evaluated }).Count -eq 0 -and
+        @($selectors | Where-Object { $_.Status -ne 'DEAD KEY' }).Count -eq 0) {
+        $first = $selectors | Select-Object -First 1
         $noSurvivingSelectorRecords.Add([PSCustomObject]@{
-            Cmdlet    = $first.Cmdlet
-            Parameter = "$($first.Method) $($first.Endpoint)"
-            Method    = $first.Method
-            Endpoint  = $first.Endpoint
+            Cmdlet   = $first.Cmdlet
+            Method   = $first.Method
+            Endpoint = $first.Endpoint
         })
     }
 }
 
-$sortedDeadKeys = @(Sort-PfbDeadKeyRecords -Records @($deadKeyRecords) |
+$sortedDeadKeys = @(Sort-PfbDeadKeyRecords -Records @($deadKeyRecords) -Property @('Cmdlet', 'Parameter') |
     ForEach-Object {
         [ordered]@{
             severity  = $_.Severity
@@ -200,7 +229,7 @@ $sortedDeadKeys = @(Sort-PfbDeadKeyRecords -Records @($deadKeyRecords) |
             declared  = @($_.Declared)
         }
     })
-$sortedNoSurvivingSelector = @(Sort-PfbDeadKeyRecords -Records @($noSurvivingSelectorRecords) |
+$sortedNoSurvivingSelector = @(Sort-PfbDeadKeyRecords -Records @($noSurvivingSelectorRecords) -Property @('Cmdlet', 'Method', 'Endpoint') |
     ForEach-Object {
         [ordered]@{
             cmdlet   = $_.Cmdlet
@@ -214,7 +243,7 @@ $manifest = [ordered]@{
     counts      = [ordered]@{
         parametersInventoried = $inventory.Count
         keysEvaluated         = $evaluatedRecords.Count
-        ok                    = $okRecords.Count
+        ok                    = $evaluatedRecords.Count - $deadKeyRecords.Count
         deadKey               = $deadKeyRecords.Count
         skipReasons           = $skipReasons
     }
@@ -226,5 +255,5 @@ $outputDir = Split-Path -Parent $OutputPath
 if (-not (Test-Path -LiteralPath $outputDir)) {
     New-Item -ItemType Directory -Path $outputDir -Force | Out-Null
 }
-$manifest | ConvertTo-Json -Depth 20 | Set-Content -Path $OutputPath -Encoding UTF8
+$manifest | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $OutputPath -Encoding UTF8
 Write-Host "Wrote $($deadKeyRecords.Count) dead keys from $($inventory.Count) inventoried parameters to $OutputPath" -ForegroundColor Green

--- a/tools/Build-PfbDeadKeyReport.ps1
+++ b/tools/Build-PfbDeadKeyReport.ps1
@@ -60,6 +60,20 @@ $inventory = @(Get-PfbCmdletParameterInventory -PublicDirectory $PublicDirectory
 # linguistic and is not. Each collection passes only properties that exist in its emitted
 # artifact: deadKeys uses Cmdlet then Parameter, while noSurvivingSelector uses Cmdlet then
 # Method then Endpoint.
+#
+# THE SORT IS UNSTABLE, and that is safe only because the sort keys are currently unique.
+# List<T>.Sort with a [System.Comparison[object]] is an introsort: it gives no guarantee about
+# the relative order of records whose comparison returns 0. There are 0 duplicate sort keys in
+# the committed artifact today -- (Cmdlet, Parameter) is unique across deadKeys and
+# (Cmdlet, Method, Endpoint) is unique across noSurvivingSelector -- so the output is
+# deterministic and the byte-identity results in Tests/Build-PfbDeadKeyReport.Tests.ps1 are
+# real. A future spec that introduces even ONE tie would make byte-identity depend on .NET's
+# introsort partitioning, and that file's first-difference assertion would then red
+# intermittently and differently across platforms and runtime versions.
+# THE FIX, if that day comes: make the order TOTAL by adding a final tie-break property to each
+# -Property list (WireKey for deadKeys is enough today), here and in the mirrored comparer in
+# Tests/CommittedDeadKeyReport.Tests.ps1. Do not reach for a "stable sort" instead -- a total
+# order is what makes the artifact reproducible.
 function Sort-PfbDeadKeyRecords {
     param(
         [AllowEmptyCollection()]
@@ -202,6 +216,13 @@ foreach ($record in $inventory) {
 # cmdlet carrying a -NewName can appear here regardless of how dead its query selectors are.
 # That errs toward under-reporting, which is the safe direction for a report whose entries
 # are read as destructive-verb hazards.
+#
+# ALL THREE NARROWINGS ABOVE ARE SUMMARISED FOR CONSUMERS in Reports/README.md, under the
+# noSurvivingSelector field's description, with a pointer back to this comment for the full
+# account. Keep the two in step: a downstream consumer reading the field as complete would
+# build a refusal rail with holes it does not know about. They are deliberately NOT carried as
+# a field in the artifact -- that would change its bytes and its schema for a documentation
+# problem.
 $noSurvivingSelectorRecords = [System.Collections.Generic.List[object]]::new()
 $allSelectorRecords = [System.Collections.Generic.List[object]]::new()
 foreach ($record in $inventory) {

--- a/tools/Build-PfbDeadKeyReport.ps1
+++ b/tools/Build-PfbDeadKeyReport.ps1
@@ -1,0 +1,230 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Builds the committed report of cmdlet query keys that their endpoint does not declare.
+.DESCRIPTION
+    Compares the AST-based cmdlet parameter inventory with the query parameters declared by
+    the pinned REST API spec. A dead key is silently discarded by the array, so a GET can return
+    an unfiltered collection and a write can arrive without its selector. This script reports the
+    finding without modifying any Public/ cmdlet.
+.PARAMETER SpecsDirectory
+    Where cached spec JSON files live. Defaults to tools/specs relative to this script.
+.PARAMETER PublicDirectory
+    Where Public/ cmdlet files live. Defaults to Public/ relative to the repo root.
+.PARAMETER CapabilityMapPath
+    Path to the capability-map JSON. Defaults to Data/PfbCapabilityMap.json.
+.PARAMETER OutputPath
+    Where to write Reports/PfbDeadKeyReport.json. Defaults there.
+#>
+[CmdletBinding()]
+param(
+    [string]$SpecsDirectory,
+    [string]$PublicDirectory,
+    [string]$CapabilityMapPath,
+    [string]$OutputPath
+)
+
+$ErrorActionPreference = 'Stop'
+
+$scriptDir = $PSScriptRoot
+. (Join-Path $scriptDir 'lib/PfbSpecTools.ps1')
+. (Join-Path $scriptDir 'lib/PfbCmdletParamTools.ps1')
+
+$repoRoot = Split-Path -Parent $scriptDir
+if (-not $SpecsDirectory)    { $SpecsDirectory = Join-Path $scriptDir 'specs' }
+if (-not $PublicDirectory)   { $PublicDirectory = Join-Path $repoRoot 'Public' }
+if (-not $CapabilityMapPath) { $CapabilityMapPath = Join-Path (Join-Path $repoRoot 'Data') 'PfbCapabilityMap.json' }
+if (-not $OutputPath)        { $OutputPath = Join-Path (Join-Path $repoRoot 'Reports') 'PfbDeadKeyReport.json' }
+
+if (-not (Test-Path -LiteralPath $CapabilityMapPath)) {
+    throw "Capability map not found at '$CapabilityMapPath'. Run Build-PfbCapabilityMap.ps1 first."
+}
+
+$capabilityMap = Get-Content -Path $CapabilityMapPath -Raw | ConvertFrom-Json -Depth 20
+$specVersion = $capabilityMap.generatedFrom | Select-Object -Last 1
+if (-not $specVersion) {
+    throw "Capability map at '$CapabilityMapPath' has no generatedFrom versions."
+}
+
+$specPath = Join-Path $SpecsDirectory "fb$specVersion.json"
+if (-not (Test-Path -LiteralPath $specPath)) {
+    throw "Pinned analysed spec 'fb$specVersion.json' (per capability map's generatedFrom) not found under '$SpecsDirectory'. Run Update-PfbApiSpecs.ps1 first, or rebuild the capability map against the specs on disk."
+}
+
+$spec = Get-Content -Path $specPath -Raw | ConvertFrom-Json -Depth 64
+$inventory = @(Get-PfbCmdletParameterInventory -PublicDirectory $PublicDirectory)
+
+# Task 4 mirrors this exact helper verbatim. It sorts records, not a joined key, using an
+# explicit ordinal comparison on Cmdlet then Parameter. Ordinal is stable between PS7 and
+# Windows PowerShell 5.1; Sort-Object -Culture '' is invariant linguistic and is not.
+function Sort-PfbDeadKeyRecords {
+    param(
+        [Parameter(Mandatory)]
+        [object[]]$Records
+    )
+
+    $sorted = [System.Collections.Generic.List[object]]::new()
+    foreach ($record in $Records) { $sorted.Add($record) }
+    $sorted.Sort([System.Comparison[object]]{
+        param($left, $right)
+        $comparison = [string]::Compare(
+            [string]$left.Cmdlet,
+            [string]$right.Cmdlet,
+            [System.StringComparison]::Ordinal)
+        if ($comparison -ne 0) { return $comparison }
+        return [string]::Compare(
+            [string]$left.Parameter,
+            [string]$right.Parameter,
+            [System.StringComparison]::Ordinal)
+    })
+    return @($sorted)
+}
+
+function Test-PfbDeadKeySelectorName {
+    param(
+        [Parameter(Mandatory)]
+        [string]$WireName
+    )
+
+    # Exact anchors are intentional. In particular, do not use a suffix regex that would
+    # classify usernames, grids, ids_or_names, or context_names as selectors.
+    if ($WireName -in @('names', 'ids', 'name', 'id')) { return $true }
+    if ($WireName -in @('context_names', 'ids_or_names')) { return $false }
+    return $WireName.EndsWith('_names', [System.StringComparison]::Ordinal) -or
+        $WireName.EndsWith('_ids', [System.StringComparison]::Ordinal)
+}
+
+function Get-PfbDeadKeySeverity {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Method
+    )
+
+    switch ($Method.ToUpperInvariant()) {
+        'DELETE' { return 'DESTRUCTIVE' }
+        'PATCH'  { return 'DESTRUCTIVE' }
+        'PUT'    { return 'DESTRUCTIVE' }
+        'POST'   { return 'CREATE' }
+        'GET'    { return 'WRONG-RESULTS' }
+        default  { return 'UNKNOWN' }
+    }
+}
+
+$skipReasons = [ordered]@{
+    'wire name unresolved'          = 0
+    'body property'                 = 0
+    'endpoint/method ambiguous'     = 0
+    'endpoint/verb absent from spec' = 0
+}
+$okRecords = [System.Collections.Generic.List[object]]::new()
+$deadKeyRecords = [System.Collections.Generic.List[object]]::new()
+$evaluatedRecords = [System.Collections.Generic.List[object]]::new()
+
+foreach ($record in $inventory) {
+    if ($null -eq $record.WireName) {
+        $skipReasons['wire name unresolved']++
+        continue
+    }
+    if ($record.WireSurface -eq 'Body') {
+        $skipReasons['body property']++
+        continue
+    }
+    if ([string]::IsNullOrEmpty([string]$record.Endpoint) -or
+        [string]::IsNullOrEmpty([string]$record.Method)) {
+        $skipReasons['endpoint/method ambiguous']++
+        continue
+    }
+
+    $declared = Get-PfbDeclaredQueryKey -Spec $spec -Endpoint $record.Endpoint -Method $record.Method -Version $specVersion
+    if ($null -eq $declared) {
+        $skipReasons['endpoint/verb absent from spec']++
+        continue
+    }
+
+    $method = ([string]$record.Method).ToUpperInvariant()
+    $wireName = [string]$record.WireName
+    $status = if (@($declared) -contains $wireName) { 'OK' } else { 'DEAD KEY' }
+    $evaluated = [PSCustomObject]@{
+        Cmdlet        = $record.Cmdlet
+        Parameter     = $record.Parameter
+        WireName      = $wireName
+        Method        = $method
+        Endpoint      = $record.Endpoint
+        Status        = $status
+        SelectorShaped = Test-PfbDeadKeySelectorName -WireName $wireName
+    }
+    $evaluatedRecords.Add($evaluated)
+
+    if ($status -eq 'OK') {
+        $okRecords.Add($evaluated)
+        continue
+    }
+
+    $deadKeyRecords.Add([PSCustomObject]@{
+        Cmdlet    = $record.Cmdlet
+        Parameter = $record.Parameter
+        Severity  = Get-PfbDeadKeySeverity -Method $method
+        WireKey   = $wireName
+        Method    = $method
+        Endpoint  = $record.Endpoint
+        Declared  = @($declared)
+    })
+}
+
+# Group evaluated selector records only. A skipped selector is unevaluable, not evidence that
+# every selector is dead. Thus a group is emitted only when it has at least one selector and all
+# of its selector-shaped keys were evaluated and classified as DEAD KEY.
+$noSurvivingSelectorRecords = [System.Collections.Generic.List[object]]::new()
+$selectorGroups = @($evaluatedRecords | Where-Object SelectorShaped | Group-Object Cmdlet, Method, Endpoint)
+foreach ($group in $selectorGroups) {
+    if (@($group.Group | Where-Object Status -ne 'DEAD KEY').Count -eq 0) {
+        $first = $group.Group | Select-Object -First 1
+        $noSurvivingSelectorRecords.Add([PSCustomObject]@{
+            Cmdlet    = $first.Cmdlet
+            Parameter = "$($first.Method) $($first.Endpoint)"
+            Method    = $first.Method
+            Endpoint  = $first.Endpoint
+        })
+    }
+}
+
+$sortedDeadKeys = @(Sort-PfbDeadKeyRecords -Records @($deadKeyRecords) |
+    ForEach-Object {
+        [ordered]@{
+            severity  = $_.Severity
+            cmdlet    = $_.Cmdlet
+            parameter = $_.Parameter
+            wireKey   = $_.WireKey
+            method    = $_.Method
+            endpoint  = $_.Endpoint
+            declared  = @($_.Declared)
+        }
+    })
+$sortedNoSurvivingSelector = @(Sort-PfbDeadKeyRecords -Records @($noSurvivingSelectorRecords) |
+    ForEach-Object {
+        [ordered]@{
+            cmdlet   = $_.Cmdlet
+            method   = $_.Method
+            endpoint = $_.Endpoint
+        }
+    })
+
+$manifest = [ordered]@{
+    specVersion = [string]$specVersion
+    counts      = [ordered]@{
+        parametersInventoried = $inventory.Count
+        keysEvaluated         = $evaluatedRecords.Count
+        ok                    = $okRecords.Count
+        deadKey               = $deadKeyRecords.Count
+        skipReasons           = $skipReasons
+    }
+    deadKeys = $sortedDeadKeys
+    noSurvivingSelector = $sortedNoSurvivingSelector
+}
+
+$outputDir = Split-Path -Parent $OutputPath
+if (-not (Test-Path -LiteralPath $outputDir)) {
+    New-Item -ItemType Directory -Path $outputDir -Force | Out-Null
+}
+$manifest | ConvertTo-Json -Depth 20 | Set-Content -Path $OutputPath -Encoding UTF8
+Write-Host "Wrote $($deadKeyRecords.Count) dead keys from $($inventory.Count) inventoried parameters to $OutputPath" -ForegroundColor Green

--- a/tools/Build-PfbDeadKeyReport.ps1
+++ b/tools/Build-PfbDeadKeyReport.ps1
@@ -177,6 +177,31 @@ foreach ($record in $inventory) {
 # A skipped selector is unevaluable, not evidence that every selector is dead. Group all
 # inventory records by operation, then emit only when the group has at least one selector,
 # no selector was skipped for any reason, and every evaluated selector is a DEAD KEY.
+#
+# Two limits on that "for any reason", stated because the guarantee is narrower than the
+# sentence above reads and both were measured rather than assumed:
+#
+#   1. The rule is OPERATION-scoped, not cmdlet-scoped. Group identity is
+#      (Cmdlet, Method, Endpoint), and a selector skipped as `endpoint/method ambiguous`
+#      carries a null Method/Endpoint -- so it forms its own null-keyed group and cannot
+#      suppress the same cmdlet's real group. 10 such records exist today (across
+#      Get-PfbNode, Remove-PfbBucket, Remove-PfbFileSystem, Remove-PfbFileSystemSnapshot,
+#      Remove-PfbRealm); for all five the ambiguity affects EVERY selector the cmdlet has,
+#      so no evaluated-and-dead selector survives to form a group anyway. The gap needs a
+#      cmdlet with some selectors resolved-and-dead and others ambiguous, which does not
+#      exist in the current inventory.
+#   2. An unresolvable wire name is invisible to the rule -- the `continue` below drops it
+#      before the shape test, because the shape of a name that could not be resolved is
+#      unknowable. So this really means "no IDENTIFIABLE selector was skipped", and the 125
+#      `wire name unresolved` records fall outside it.
+#
+# Consequence of the rule as written, deliberate rather than overlooked: the 22 body-surface
+# selector-shaped records are all Update-Pfb* PATCH parameters (NewName -> name, plus
+# ServicePrincipalNames and SubjectAlternativeNames). A request-body `name` can never act as
+# a query selector, yet its presence suppresses its operation's group -- so no Update-Pfb*
+# cmdlet carrying a -NewName can appear here regardless of how dead its query selectors are.
+# That errs toward under-reporting, which is the safe direction for a report whose entries
+# are read as destructive-verb hazards.
 $noSurvivingSelectorRecords = [System.Collections.Generic.List[object]]::new()
 $allSelectorRecords = [System.Collections.Generic.List[object]]::new()
 foreach ($record in $inventory) {

--- a/tools/README.md
+++ b/tools/README.md
@@ -435,6 +435,8 @@ Run in this order:
    for that HTTP verb. It pins analysis to the capability map's last `generatedFrom` version,
    skips body and unresolved parameters, and identifies destructive dead keys plus groups with
    no surviving selector. This is reporting only -- it does not edit any cmdlet.
+   The `noSurvivingSelector` list deliberately under-reports in three specific ways -- read
+   `Reports/README.md` before consuming it as a complete list.
 
    ```powershell
    ./tools/Build-PfbDeadKeyReport.ps1

--- a/tools/README.md
+++ b/tools/README.md
@@ -174,6 +174,16 @@ Run in this order:
    ./tools/Build-PfbApiDriftReport.ps1 -SinceVersion '2.26'
    ```
 
+   **`Build-PfbDeadKeyReport.ps1`** builds `Reports/PfbDeadKeyReport.json`, the committed
+   inventory of query keys emitted by `Public/` cmdlets that their endpoint does not declare
+   for that HTTP verb. It pins analysis to the capability map's last `generatedFrom` version,
+   skips body and unresolved parameters, and identifies destructive dead keys plus groups with
+   no surviving selector. This is reporting only -- it does not edit any cmdlet.
+
+   ```powershell
+   ./tools/Build-PfbDeadKeyReport.ps1
+   ```
+
    `parameterGaps` also never reports a small set of non-actionable fields
    (`$script:PfbNonActionableParameters` in `tools/lib/PfbApiDriftTools.ps1`:
    `X-Request-ID`, `continuation_token`, `offset`) -- these are declared on nearly every

--- a/tools/README.md
+++ b/tools/README.md
@@ -174,16 +174,6 @@ Run in this order:
    ./tools/Build-PfbApiDriftReport.ps1 -SinceVersion '2.26'
    ```
 
-   **`Build-PfbDeadKeyReport.ps1`** builds `Reports/PfbDeadKeyReport.json`, the committed
-   inventory of query keys emitted by `Public/` cmdlets that their endpoint does not declare
-   for that HTTP verb. It pins analysis to the capability map's last `generatedFrom` version,
-   skips body and unresolved parameters, and identifies destructive dead keys plus groups with
-   no surviving selector. This is reporting only -- it does not edit any cmdlet.
-
-   ```powershell
-   ./tools/Build-PfbDeadKeyReport.ps1
-   ```
-
    `parameterGaps` also never reports a small set of non-actionable fields
    (`$script:PfbNonActionableParameters` in `tools/lib/PfbApiDriftTools.ps1`:
    `X-Request-ID`, `continuation_token`, `offset`) -- these are declared on nearly every
@@ -439,6 +429,16 @@ Run in this order:
    upstream of `$ref` resolution, will misread this release as instability that never happened.
    Use resolved (endpoint, field) pairs (`Get-PfbSchemaPropertyDetails`'s own single resolving
    walker, decision 3) for any future metric here, never a raw annotation-site count.
+
+7. **`Build-PfbDeadKeyReport.ps1`** — builds `Reports/PfbDeadKeyReport.json`, the committed
+   inventory of query keys emitted by `Public/` cmdlets that their endpoint does not declare
+   for that HTTP verb. It pins analysis to the capability map's last `generatedFrom` version,
+   skips body and unresolved parameters, and identifies destructive dead keys plus groups with
+   no surviving selector. This is reporting only -- it does not edit any cmdlet.
+
+   ```powershell
+   ./tools/Build-PfbDeadKeyReport.ps1
+   ```
 
 ## Response-shape drift (`Build-PfbResponseShapeMap.ps1`)
 

--- a/tools/lib/PfbSpecTools.ps1
+++ b/tools/lib/PfbSpecTools.ps1
@@ -188,6 +188,63 @@ function Resolve-PfbRef {
     return $current
 }
 
+function Get-PfbDeclaredQueryKey {
+    <#
+    .SYNOPSIS
+        Query parameter names an operation declares, resolving $ref'd parameters.
+    .DESCRIPTION
+        Returns a string array of declared query parameter names, or $null when the path or the
+        verb is absent from the spec. $null and @() mean different things and callers depend on
+        the difference: $null is "this endpoint/verb is not in this spec version", @() is "it is
+        here and declares no query parameters". Collapsing them reclassifies an absent endpoint as
+        one where every key is dead -- 29 of 632 operations in fb2.28 declare zero query keys, so
+        this is a live case and not a hypothetical.
+
+        RETURNS WITH A UNARY COMMA on purpose. PowerShell unrolls a returned array: without it a
+        zero-element result arrives as $null (indistinguishable from "verb absent") and a
+        one-element result arrives as a bare [string] (so `-contains` still works but the caller's
+        type assumptions do not). Both were present in the first draft of this function and both
+        were caught only by executing it.
+
+        Endpoint literals in cmdlet source carry no leading slash and no /api/<version> prefix, so
+        both are added here. Getting this wrong makes every lookup miss and every key look dead.
+
+        Verb presence is tested by KEY PRESENCE, not truthiness: an operation node that exists but
+        is empty is a declared verb with no parameters, not an absent verb.
+
+        Null-tolerant by design, matching the rest of this file (see the StrictMode note at the top).
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] $Spec,
+        [Parameter(Mandatory)] [string]$Endpoint,
+        [Parameter(Mandatory)] [string]$Method,
+        [Parameter(Mandatory)] [string]$Version
+    )
+
+    $pathKey = "/api/$Version/" + $Endpoint.TrimStart('/')
+    $node = $Spec.paths.$pathKey
+    if (-not $node) { return $null }
+
+    $methodLower = $Method.ToLowerInvariant()
+    if ($node.PSObject.Properties.Name -notcontains $methodLower) { return $null }
+    $op = $node.$methodLower
+
+    $names = [System.Collections.Generic.List[string]]::new()
+    if ($op -and $op.parameters) {
+        foreach ($p in $op.parameters) {
+            $resolved = Resolve-PfbRef -Node $p -Spec $Spec
+            if ($resolved -and
+                $resolved.PSObject.Properties.Name -contains 'name' -and
+                $resolved.name -and
+                $resolved.'in' -eq 'query') {
+                $names.Add([string]$resolved.name)
+            }
+        }
+    }
+    return , $names.ToArray()
+}
+
 function Add-PfbSchemaPropertyNodes {
     <#
     .SYNOPSIS


### PR DESCRIPTION
## Summary
- add a spec-derived report of query keys sent by `Public/` cmdlets but undeclared for the endpoint and HTTP verb
- commit the current baseline of 126 dead keys and 18 operations with no surviving selector, without changing cmdlet behavior
- add monotone regression tests that reject newly introduced dead keys while allowing the inventory to shrink as fixes land
- regenerate the report in the scheduled API-capability workflow and document its deliberate coverage limits

## Design notes
- preserve the distinction between an endpoint absent from the spec (`$null`) and an endpoint declaring zero query parameters (empty array)
- run the committed-artifact gate on both PowerShell 7 and Windows PowerShell 5.1; keep regeneration and synthetic-classification tests gated to PowerShell 7
- compare committed and regenerated content after normalizing line endings, while retaining raw-byte comparison between two same-platform generator runs
- treat `noSurvivingSelector` as a deliberately conservative, operation-scoped signal rather than a complete cmdlet refusal list

## Verification
- [x] scoped Pester: PowerShell 7 — 23 passed, 0 failed, 0 skipped
- [x] scoped Pester: Windows PowerShell 5.1 — 17 passed, 0 failed, 6 expected skips
- [x] discovery-only full-tree measurement: Windows PowerShell 5.1 — 2,876 discovered, 258 discovery-time skips against ceiling 268, 0 container failures
- [x] discovery-only full-tree measurement: PowerShell 7 — 2 skips against ceiling 8
- [x] mutation checks confirm new content drift, missing/renamed severity vocabulary, destructive-key growth, coverage collapse, and broken reconciliation all fail the intended assertion
- [x] mutation checks confirm dead-key shrinkage, including the documented total-zero relaxation, remains green
- [x] report SHA-256 unchanged through review fixes: `9EAEF0C3D4EAEA21F5AE3E9B696BE551986882AC674BED83E53B9DA67911FDF9`

## Live testing
Not applicable: this branch changes reporting, tests, and scheduled regeneration only. It changes no cmdlet and issues no FlashBlade API request, so there is no runtime array behavior to exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)