### PR TITLE
Suppress the bare total_item_count wrapper and stop empty pipelines from issuing unfiltered requests (#121)

### DIFF
--- a/Private/Invoke-PfbApiRequest.ps1
+++ b/Private/Invoke-PfbApiRequest.ps1
@@ -352,6 +352,13 @@ function Invoke-PfbApiRequest {
             # Some endpoints return data directly (not wrapped in items). But a
             # total_item_count-only body is an empty list response unless the request asked for
             # total_only. Other no-items bodies are genuine direct-data responses and stay verbatim.
+            #
+            # This classifier is deliberately NOT restricted to total_item_count -eq 0, and that
+            # asymmetry with the final-return gate below -- which keeps its $allItems.Count -eq 0
+            # conjunct on purpose -- is intentional. The two do different jobs: this branch
+            # normalizes a body that carries no items at all, so there is nothing to preserve,
+            # while the gate preserves items that unexpectedly appear on a total-only read. Do not
+            # align either one with the other.
             $responseKeys = @($response.PSObject.Properties.Name)
             $isCountOnlyListResponse = ($responseKeys.Count -eq 1 -and
                 $responseKeys[0] -eq 'total_item_count')

--- a/Private/Invoke-PfbApiRequest.ps1
+++ b/Private/Invoke-PfbApiRequest.ps1
@@ -227,6 +227,10 @@ function Invoke-PfbApiRequest {
 
     $allItems = [System.Collections.Generic.List[object]]::new()
     $totalItemCount = $null
+    # Computed once, before either response-shape branch, so the no-items branch inside the
+    # pagination loop and the final wrapper return below cannot drift apart. See the block beside
+    # that final return for why the REQUEST, not the response, has to be the discriminator.
+    $totalOnlyRequested = ($null -ne $QueryParams -and $QueryParams['total_only'] -eq 'true')
     $hasMore = $true
     $isFirstRequest = $true
 
@@ -345,8 +349,16 @@ function Invoke-PfbApiRequest {
             }
         }
         elseif ($null -ne $response) {
-            # Some endpoints return data directly (not wrapped in items)
-            return $response
+            # Some endpoints return data directly (not wrapped in items). But a
+            # total_item_count-only body is an empty list response unless the request asked for
+            # total_only. Other no-items bodies are genuine direct-data responses and stay verbatim.
+            $responseKeys = @($response.PSObject.Properties.Name)
+            $isCountOnlyListResponse = ($responseKeys.Count -eq 1 -and
+                $responseKeys[0] -eq 'total_item_count')
+            if (-not $isCountOnlyListResponse -or $totalOnlyRequested) {
+                return $response
+            }
+            $totalItemCount = $response.total_item_count
         }
 
         # Track total count from first response
@@ -375,8 +387,30 @@ function Invoke-PfbApiRequest {
         $allItems = $allItems.GetRange(0, $requestedLimit)
     }
 
-    # If TotalOnly was requested and we got a count but no items, return the count
-    if ($allItems.Count -eq 0 -and $null -ne $totalItemCount) {
+    # A total-only read asked for the count and nothing else, so hand back the count on its own.
+    # Every OTHER empty result must return an empty collection -- see issue #121 for what the
+    # bare wrapper did to callers when this branch fired for all of them.
+    #
+    # The discriminator has to be the request. Measured against FB-A at REST 2.26, a total-only
+    # response and an ordinary empty result are the same four keys and differ only in the value
+    # of total_item_count:
+    #
+    #   GET /file-systems?total_only=true   -> { total, continuation_token, total_item_count: 2, items: [] }
+    #   GET /file-systems?filter=<no-match> -> { total, continuation_token, total_item_count: 0, items: [] }
+    #
+    # so no test on the RESPONSE can tell them apart, and a guard keyed on a non-zero count
+    # would hand the wrapper straight back to an ordinary caller. $QueryParams already carries
+    # the answer: Add-PfbCommonQueryParams writes total_only there when the caller passed
+    # -TotalOnly. Gate on the value rather than the key, so this stays correct if that helper's
+    # separate ContainsKey behaviour is ever changed. $totalOnlyRequested is computed once up with
+    # the pagination setup, above the loop, because the no-items branch inside the loop needs the
+    # same answer this return does.
+    #
+    # The zero-items half of the original condition is kept deliberately. A total-only response
+    # has always been observed to carry an empty items array, so this narrowing costs nothing
+    # today -- but if some endpoint ever answers a total-only read with items in it, returning
+    # those items is the older behaviour and the safer one.
+    if ($allItems.Count -eq 0 -and $totalOnlyRequested -and $null -ne $totalItemCount) {
         return [PSCustomObject]@{ total_item_count = $totalItemCount }
     }
 

--- a/Private/Test-PfbEmptyPipelineRead.ps1
+++ b/Private/Test-PfbEmptyPipelineRead.ps1
@@ -1,0 +1,23 @@
+function Test-PfbEmptyPipelineRead {
+    <#
+    .SYNOPSIS
+        Detects an empty pipeline invocation that would issue an unfiltered request.
+    .DESCRIPTION
+        Public collect-in-process cmdlets call this from end after building their final
+        query hashtable. A piped invocation with no final query key received no object to
+        select; issuing the request would turn that absence into an unfiltered read/write.
+        Direct calls are not suppressed, and any surviving query key leaves the request alone.
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory)]
+        [System.Management.Automation.PSCmdlet]$Caller,
+
+        [AllowNull()]
+        [System.Collections.IDictionary]$QueryParams
+    )
+
+    if (-not $Caller.MyInvocation.ExpectingInput) { return $false }
+    return ($null -eq $QueryParams -or $QueryParams.Count -eq 0)
+}

--- a/Public/Admin/Get-PfbAdmin.ps1
+++ b/Public/Admin/Get-PfbAdmin.ps1
@@ -54,6 +54,7 @@ function Get-PfbAdmin {
     end {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'admins' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Admin/Get-PfbAdminCache.ps1
+++ b/Public/Admin/Get-PfbAdminCache.ps1
@@ -56,6 +56,7 @@ function Get-PfbAdminCache {
     end {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'admins/cache' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Admin/Get-PfbApiClient.ps1
+++ b/Public/Admin/Get-PfbApiClient.ps1
@@ -56,6 +56,7 @@ function Get-PfbApiClient {
     end {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'api-clients' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Admin/Get-PfbApiToken.ps1
+++ b/Public/Admin/Get-PfbApiToken.ps1
@@ -102,6 +102,7 @@ function Get-PfbApiToken {
         if ($allIds)   { $queryParams['admin_ids']   = $allIds   -join ',' }
         if ($ExposeApiToken) { $queryParams['expose_api_token'] = 'true' }
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'admins/api-tokens' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Admin/Get-PfbManagementAccessPolicy.ps1
+++ b/Public/Admin/Get-PfbManagementAccessPolicy.ps1
@@ -55,6 +55,7 @@ function Get-PfbManagementAccessPolicy {
     end {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'management-access-policies' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Admin/Get-PfbOidcIdp.ps1
+++ b/Public/Admin/Get-PfbOidcIdp.ps1
@@ -55,6 +55,7 @@ function Get-PfbOidcIdp {
     end {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'sso/oidc/idps' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Admin/Get-PfbPublicKey.ps1
+++ b/Public/Admin/Get-PfbPublicKey.ps1
@@ -56,6 +56,7 @@ function Get-PfbPublicKey {
     end {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'public-keys' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Admin/Get-PfbSaml2Idp.ps1
+++ b/Public/Admin/Get-PfbSaml2Idp.ps1
@@ -55,6 +55,7 @@ function Get-PfbSaml2Idp {
     end {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'sso/saml2/idps' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Admin/Get-PfbSession.ps1
+++ b/Public/Admin/Get-PfbSession.ps1
@@ -56,6 +56,7 @@ function Get-PfbSession {
     end {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'sessions' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Admin/Test-PfbSaml2Idp.ps1
+++ b/Public/Admin/Test-PfbSaml2Idp.ps1
@@ -50,6 +50,7 @@ function Test-PfbSaml2Idp {
         if ($allNames.Count -gt 0) { $queryParams['names'] = $allNames -join ',' }
         if ($allIds.Count -gt 0)   { $queryParams['ids']   = $allIds -join ',' }
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'sso/saml2/idps/test' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Alert/Get-PfbAlert.ps1
+++ b/Public/Alert/Get-PfbAlert.ps1
@@ -52,6 +52,7 @@ function Get-PfbAlert {
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
         if ($PSBoundParameters.ContainsKey('Flagged'))    { $queryParams['flagged'] = ([bool]$Flagged).ToString().ToLower() }
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'alerts' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Alert/Get-PfbAlertWatcher.ps1
+++ b/Public/Alert/Get-PfbAlertWatcher.ps1
@@ -46,6 +46,7 @@ function Get-PfbAlertWatcher {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'alert-watchers' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Bucket/Get-PfbBucket.ps1
+++ b/Public/Bucket/Get-PfbBucket.ps1
@@ -68,6 +68,7 @@ function Get-PfbBucket {
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
         if ($Destroyed)            { $queryParams['destroyed']  = 'true' }
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'buckets' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Bucket/Get-PfbBucketAccessPolicy.ps1
+++ b/Public/Bucket/Get-PfbBucketAccessPolicy.ps1
@@ -88,6 +88,7 @@ function Get-PfbBucketAccessPolicy {
         if ($allBucketNames.Count -gt 0) { $queryParams['bucket_names'] = $allBucketNames -join ',' }
         if ($allBucketIds.Count -gt 0)   { $queryParams['bucket_ids']   = $allBucketIds -join ',' }
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         try {
             Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'buckets/bucket-access-policies' -QueryParams $queryParams -AutoPaginate
         }

--- a/Public/Bucket/Get-PfbBucketAccessPolicyRule.ps1
+++ b/Public/Bucket/Get-PfbBucketAccessPolicyRule.ps1
@@ -82,6 +82,7 @@ function Get-PfbBucketAccessPolicyRule {
         if ($allBucketNames.Count -gt 0) { $queryParams['bucket_names'] = $allBucketNames -join ',' }
         if ($PolicyName)                 { $queryParams['policy_names'] = $PolicyName -join ',' }
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         try {
             Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'buckets/bucket-access-policies/rules' -QueryParams $queryParams -AutoPaginate
         }

--- a/Public/Bucket/Get-PfbBucketAuditFilter.ps1
+++ b/Public/Bucket/Get-PfbBucketAuditFilter.ps1
@@ -80,6 +80,7 @@ function Get-PfbBucketAuditFilter {
         if ($allBucketNames.Count -gt 0) { $queryParams['bucket_names'] = $allBucketNames -join ',' }
         if ($allBucketIds.Count -gt 0)   { $queryParams['bucket_ids']   = $allBucketIds -join ',' }
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'buckets/audit-filters' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Bucket/Get-PfbBucketCorsPolicy.ps1
+++ b/Public/Bucket/Get-PfbBucketCorsPolicy.ps1
@@ -87,6 +87,7 @@ function Get-PfbBucketCorsPolicy {
         if ($allBucketNames.Count -gt 0) { $queryParams['bucket_names'] = $allBucketNames -join ',' }
         if ($allBucketIds.Count -gt 0)   { $queryParams['bucket_ids']   = $allBucketIds -join ',' }
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         try {
             Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'buckets/cross-origin-resource-sharing-policies' -QueryParams $queryParams -AutoPaginate
         }

--- a/Public/Bucket/Get-PfbBucketCorsPolicyRule.ps1
+++ b/Public/Bucket/Get-PfbBucketCorsPolicyRule.ps1
@@ -82,6 +82,7 @@ function Get-PfbBucketCorsPolicyRule {
         if ($allBucketNames.Count -gt 0) { $queryParams['bucket_names'] = $allBucketNames -join ',' }
         if ($PolicyName)                 { $queryParams['policy_names'] = $PolicyName -join ',' }
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         try {
             Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'buckets/cross-origin-resource-sharing-policies/rules' -QueryParams $queryParams -AutoPaginate
         }

--- a/Public/Bucket/Get-PfbBucketPerformance.ps1
+++ b/Public/Bucket/Get-PfbBucketPerformance.ps1
@@ -71,6 +71,7 @@ function Get-PfbBucketPerformance {
         if ($EndTime)              { $queryParams['end_time']   = $EndTime }
         if ($Resolution)           { $queryParams['resolution'] = $Resolution }
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'buckets/performance' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Bucket/Get-PfbBucketS3Performance.ps1
+++ b/Public/Bucket/Get-PfbBucketS3Performance.ps1
@@ -72,6 +72,7 @@ function Get-PfbBucketS3Performance {
         if ($EndTime)              { $queryParams['end_time']   = $EndTime }
         if ($Resolution)           { $queryParams['resolution'] = $Resolution }
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'buckets/s3-specific-performance' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Certificate/Get-PfbCertificate.ps1
+++ b/Public/Certificate/Get-PfbCertificate.ps1
@@ -52,6 +52,7 @@ function Get-PfbCertificate {
     end {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'certificates' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Certificate/Get-PfbCertificateGroup.ps1
+++ b/Public/Certificate/Get-PfbCertificateGroup.ps1
@@ -56,6 +56,7 @@ function Get-PfbCertificateGroup {
     end {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'certificate-groups' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Certificate/Get-PfbCertificateGroupCertificate.ps1
+++ b/Public/Certificate/Get-PfbCertificateGroupCertificate.ps1
@@ -82,6 +82,7 @@ function Get-PfbCertificateGroupCertificate {
         if ($allCertificateGroupIds.Count -gt 0) {
             $queryParams['certificate_group_ids'] = $allCertificateGroupIds -join ','
         }
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'certificate-groups/certificates' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Certificate/Get-PfbCertificateGroupUse.ps1
+++ b/Public/Certificate/Get-PfbCertificateGroupUse.ps1
@@ -46,6 +46,7 @@ function Get-PfbCertificateGroupUse {
     end {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'certificate-groups/uses' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Certificate/Get-PfbCertificateUse.ps1
+++ b/Public/Certificate/Get-PfbCertificateUse.ps1
@@ -46,6 +46,7 @@ function Get-PfbCertificateUse {
     end {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'certificates/uses' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/DirectoryService/Get-PfbActiveDirectory.ps1
+++ b/Public/DirectoryService/Get-PfbActiveDirectory.ps1
@@ -43,6 +43,7 @@ function Get-PfbActiveDirectory {
     end {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'active-directory' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/DirectoryService/Get-PfbDirectoryService.ps1
+++ b/Public/DirectoryService/Get-PfbDirectoryService.ps1
@@ -45,6 +45,7 @@ function Get-PfbDirectoryService {
     end {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'directory-services' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/DirectoryService/Get-PfbDirectoryServiceRole.ps1
+++ b/Public/DirectoryService/Get-PfbDirectoryServiceRole.ps1
@@ -55,6 +55,7 @@ function Get-PfbDirectoryServiceRole {
     end {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'directory-services/roles' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/DirectoryService/Get-PfbLocalDirectoryService.ps1
+++ b/Public/DirectoryService/Get-PfbLocalDirectoryService.ps1
@@ -47,6 +47,7 @@ function Get-PfbLocalDirectoryService {
     end {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'directory-services/local/directory-services' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/DirectoryService/Get-PfbLocalGroup.ps1
+++ b/Public/DirectoryService/Get-PfbLocalGroup.ps1
@@ -46,6 +46,7 @@ function Get-PfbLocalGroup {
     end {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'directory-services/local/groups' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/DirectoryService/Get-PfbLocalGroupMember.ps1
+++ b/Public/DirectoryService/Get-PfbLocalGroupMember.ps1
@@ -72,6 +72,7 @@ function Get-PfbLocalGroupMember {
         if ($allGroups.Count -gt 0) { $queryParams['group_names']  = $allGroups -join ',' }
         if ($Member)                { $queryParams['member_names'] = $Member -join ',' }
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         $response = Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'directory-services/local/groups/members' -QueryParams $queryParams -AutoPaginate
 
         # Lift the nested parent group name to a top-level property so that piping a membership into

--- a/Public/DirectoryService/Remove-PfbLocalGroup.ps1
+++ b/Public/DirectoryService/Remove-PfbLocalGroup.ps1
@@ -36,6 +36,7 @@ function Remove-PfbLocalGroup {
         $queryParams = @{}
         if ($allNames.Count -gt 0) { $queryParams['names'] = $allNames -join ',' }
         if ($allIds.Count -gt 0)   { $queryParams['ids']   = $allIds -join ',' }
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
 
         $target = if ($allNames.Count -gt 0) { $allNames -join ',' } else { $allIds -join ',' }
         if ($PSCmdlet.ShouldProcess($target, 'Delete local group')) {

--- a/Public/DirectoryService/Test-PfbActiveDirectory.ps1
+++ b/Public/DirectoryService/Test-PfbActiveDirectory.ps1
@@ -51,6 +51,7 @@ function Test-PfbActiveDirectory {
         if ($allNames.Count -gt 0) { $queryParams['names'] = $allNames -join ',' }
         if ($allIds.Count -gt 0)   { $queryParams['ids']   = $allIds -join ',' }
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'active-directory/test' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/FileSystem/Get-PfbFileLock.ps1
+++ b/Public/FileSystem/Get-PfbFileLock.ps1
@@ -67,6 +67,7 @@ function Get-PfbFileLock {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'file-systems/locks' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/FileSystem/Get-PfbFileLockClient.ps1
+++ b/Public/FileSystem/Get-PfbFileLockClient.ps1
@@ -67,6 +67,7 @@ function Get-PfbFileLockClient {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'file-systems/locks/clients' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/FileSystem/Get-PfbFileSystem.ps1
+++ b/Public/FileSystem/Get-PfbFileSystem.ps1
@@ -76,6 +76,7 @@ function Get-PfbFileSystem {
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
         if ($Destroyed)            { $queryParams['destroyed']  = 'true' }
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'file-systems' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/FileSystem/Get-PfbFileSystemExport.ps1
+++ b/Public/FileSystem/Get-PfbFileSystemExport.ps1
@@ -67,6 +67,7 @@ function Get-PfbFileSystemExport {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'file-system-exports' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/FileSystem/Get-PfbFileSystemGroupPerformance.ps1
+++ b/Public/FileSystem/Get-PfbFileSystemGroupPerformance.ps1
@@ -92,6 +92,7 @@ function Get-PfbFileSystemGroupPerformance {
         if ($EndTime -gt 0)       { $queryParams['end_time']   = $EndTime }
         if ($Resolution -gt 0)    { $queryParams['resolution'] = $Resolution }
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'file-systems/groups/performance' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/FileSystem/Get-PfbFileSystemSession.ps1
+++ b/Public/FileSystem/Get-PfbFileSystemSession.ps1
@@ -69,6 +69,7 @@ function Get-PfbFileSystemSession {
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames
         if ($Protocol)             { $queryParams['protocols']  = $Protocol -join ',' }
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'file-systems/sessions' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/FileSystem/Get-PfbFileSystemStorageClass.ps1
+++ b/Public/FileSystem/Get-PfbFileSystemStorageClass.ps1
@@ -72,6 +72,7 @@ function Get-PfbFileSystemStorageClass {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         try {
             Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'file-systems/space/storage-classes' -QueryParams $queryParams -AutoPaginate
         }

--- a/Public/FileSystem/Get-PfbFileSystemUserPerformance.ps1
+++ b/Public/FileSystem/Get-PfbFileSystemUserPerformance.ps1
@@ -92,6 +92,7 @@ function Get-PfbFileSystemUserPerformance {
         if ($EndTime -gt 0)       { $queryParams['end_time']   = $EndTime }
         if ($Resolution -gt 0)    { $queryParams['resolution'] = $Resolution }
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'file-systems/users/performance' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/FileSystem/Get-PfbOpenFile.ps1
+++ b/Public/FileSystem/Get-PfbOpenFile.ps1
@@ -58,6 +58,7 @@ function Get-PfbOpenFile {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Ids $allIds
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'file-systems/open-files' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/FileSystemSnapshot/Get-PfbFileSystemSnapshot.ps1
+++ b/Public/FileSystemSnapshot/Get-PfbFileSystemSnapshot.ps1
@@ -72,6 +72,7 @@ function Get-PfbFileSystemSnapshot {
         if ($SourceName)           { $queryParams['source_names']  = $SourceName }
         if ($Destroyed)            { $queryParams['destroyed']     = 'true' }
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'file-system-snapshots' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/FileSystemSnapshot/Get-PfbFileSystemSnapshotTransfer.ps1
+++ b/Public/FileSystemSnapshot/Get-PfbFileSystemSnapshotTransfer.ps1
@@ -68,6 +68,7 @@ function Get-PfbFileSystemSnapshotTransfer {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'file-system-snapshots/transfer' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Hardware/Get-PfbBlade.ps1
+++ b/Public/Hardware/Get-PfbBlade.ps1
@@ -38,6 +38,7 @@ function Get-PfbBlade {
     end {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'blades' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Hardware/Get-PfbDrive.ps1
+++ b/Public/Hardware/Get-PfbDrive.ps1
@@ -38,6 +38,7 @@ function Get-PfbDrive {
     end {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'drives' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Hardware/Get-PfbHardware.ps1
+++ b/Public/Hardware/Get-PfbHardware.ps1
@@ -38,6 +38,7 @@ function Get-PfbHardware {
     end {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'hardware' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Hardware/Get-PfbHardwareConnector.ps1
+++ b/Public/Hardware/Get-PfbHardwareConnector.ps1
@@ -38,6 +38,7 @@ function Get-PfbHardwareConnector {
     end {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'hardware-connectors' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Hardware/Get-PfbHardwareConnectorPerformance.ps1
+++ b/Public/Hardware/Get-PfbHardwareConnectorPerformance.ps1
@@ -59,6 +59,7 @@ function Get-PfbHardwareConnectorPerformance {
         if ($StartTime)            { $queryParams['start_time'] = $StartTime }
         if ($EndTime)              { $queryParams['end_time']   = $EndTime }
         if ($Resolution)           { $queryParams['resolution'] = $Resolution }
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'hardware-connectors/performance' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Hardware/Get-PfbHardwareTemperature.ps1
+++ b/Public/Hardware/Get-PfbHardwareTemperature.ps1
@@ -50,6 +50,7 @@ function Get-PfbHardwareTemperature {
         # client-side post-filter applied after the temperature filtering below. The helper would
         # unconditionally send limit= server-side, changing results.
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         $hardware = Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'hardware' -QueryParams $queryParams -AutoPaginate
 
         # Filter to components that have temperature data

--- a/Public/Misc/Get-PfbKeytab.ps1
+++ b/Public/Misc/Get-PfbKeytab.ps1
@@ -51,6 +51,7 @@ function Get-PfbKeytab {
     end {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'keytabs' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Misc/Get-PfbKeytabDownload.ps1
+++ b/Public/Misc/Get-PfbKeytabDownload.ps1
@@ -56,6 +56,7 @@ function Get-PfbKeytabDownload {
     end {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'keytabs/download' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Misc/Get-PfbKmip.ps1
+++ b/Public/Misc/Get-PfbKmip.ps1
@@ -56,6 +56,7 @@ function Get-PfbKmip {
     end {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'kmip' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Misc/Get-PfbLag.ps1
+++ b/Public/Misc/Get-PfbLag.ps1
@@ -51,6 +51,7 @@ function Get-PfbLag {
     end {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'link-aggregation-groups' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Misc/Get-PfbLegalHold.ps1
+++ b/Public/Misc/Get-PfbLegalHold.ps1
@@ -60,6 +60,7 @@ function Get-PfbLegalHold {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'legal-holds' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Misc/Get-PfbLifecycleRule.ps1
+++ b/Public/Misc/Get-PfbLifecycleRule.ps1
@@ -55,6 +55,7 @@ function Get-PfbLifecycleRule {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
         if ($BucketName) { $queryParams['bucket_names'] = $BucketName }
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'lifecycle-rules' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Misc/Get-PfbMaintenanceWindow.ps1
+++ b/Public/Misc/Get-PfbMaintenanceWindow.ps1
@@ -52,6 +52,7 @@ function Get-PfbMaintenanceWindow {
     end {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'maintenance-windows' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Misc/Get-PfbPublicKeyUse.ps1
+++ b/Public/Misc/Get-PfbPublicKeyUse.ps1
@@ -46,6 +46,7 @@ function Get-PfbPublicKeyUse {
     end {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'public-keys/uses' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Misc/Get-PfbResiliencyGroup.ps1
+++ b/Public/Misc/Get-PfbResiliencyGroup.ps1
@@ -51,6 +51,7 @@ function Get-PfbResiliencyGroup {
     end {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         try {
             Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'resiliency-groups' -QueryParams $queryParams -AutoPaginate
         }

--- a/Public/Misc/Get-PfbResourceAccess.ps1
+++ b/Public/Misc/Get-PfbResourceAccess.ps1
@@ -54,6 +54,7 @@ function Get-PfbResourceAccess {
     end {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Ids $allIds
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'resource-accesses' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Misc/Get-PfbRole.ps1
+++ b/Public/Misc/Get-PfbRole.ps1
@@ -46,6 +46,7 @@ function Get-PfbRole {
     end {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'roles' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Monitoring/Get-PfbAsyncLog.ps1
+++ b/Public/Monitoring/Get-PfbAsyncLog.ps1
@@ -60,6 +60,7 @@ function Get-PfbAsyncLog {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'logs-async' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Monitoring/Get-PfbAsyncLogDownload.ps1
+++ b/Public/Monitoring/Get-PfbAsyncLogDownload.ps1
@@ -51,6 +51,7 @@ function Get-PfbAsyncLogDownload {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'logs-async/download' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Monitoring/Get-PfbLogTargetFileSystem.ps1
+++ b/Public/Monitoring/Get-PfbLogTargetFileSystem.ps1
@@ -68,6 +68,7 @@ function Get-PfbLogTargetFileSystem {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         try {
             Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'log-targets/file-systems' -QueryParams $queryParams -AutoPaginate
         }

--- a/Public/Monitoring/Get-PfbLogTargetObjectStore.ps1
+++ b/Public/Monitoring/Get-PfbLogTargetObjectStore.ps1
@@ -60,6 +60,7 @@ function Get-PfbLogTargetObjectStore {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'log-targets/object-store' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Monitoring/Get-PfbSnmpManager.ps1
+++ b/Public/Monitoring/Get-PfbSnmpManager.ps1
@@ -53,6 +53,7 @@ function Get-PfbSnmpManager {
     end {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'snmp-managers' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Monitoring/Get-PfbSyslogServer.ps1
+++ b/Public/Monitoring/Get-PfbSyslogServer.ps1
@@ -52,6 +52,7 @@ function Get-PfbSyslogServer {
     end {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'syslog-servers' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Network/Get-PfbNetworkInterface.ps1
+++ b/Public/Network/Get-PfbNetworkInterface.ps1
@@ -46,6 +46,7 @@ function Get-PfbNetworkInterface {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'network-interfaces' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Network/Get-PfbNetworkInterfaceConnector.ps1
+++ b/Public/Network/Get-PfbNetworkInterfaceConnector.ps1
@@ -52,6 +52,7 @@ function Get-PfbNetworkInterfaceConnector {
     end {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'network-interfaces/connectors' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Network/Get-PfbNetworkInterfaceConnectorPerformance.ps1
+++ b/Public/Network/Get-PfbNetworkInterfaceConnectorPerformance.ps1
@@ -59,6 +59,7 @@ function Get-PfbNetworkInterfaceConnectorPerformance {
         if ($StartTime)            { $queryParams['start_time'] = $StartTime }
         if ($EndTime)              { $queryParams['end_time']   = $EndTime }
         if ($Resolution)           { $queryParams['resolution'] = $Resolution }
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'network-interfaces/connectors/performance' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Network/Get-PfbNetworkInterfaceConnectorSettings.ps1
+++ b/Public/Network/Get-PfbNetworkInterfaceConnectorSettings.ps1
@@ -47,6 +47,7 @@ function Get-PfbNetworkInterfaceConnectorSettings {
     end {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'network-interfaces/connectors/settings' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Network/Get-PfbNetworkInterfaceNeighbor.ps1
+++ b/Public/Network/Get-PfbNetworkInterfaceNeighbor.ps1
@@ -66,6 +66,7 @@ function Get-PfbNetworkInterfaceNeighbor {
         if ($allLocalPortNames.Count -gt 0) {
             $queryParams['local_port_names'] = $allLocalPortNames -join ','
         }
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'network-interfaces/neighbors' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Network/Get-PfbSubnet.ps1
+++ b/Public/Network/Get-PfbSubnet.ps1
@@ -46,6 +46,7 @@ function Get-PfbSubnet {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'subnets' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Node/Get-PfbNode.ps1
+++ b/Public/Node/Get-PfbNode.ps1
@@ -57,6 +57,7 @@ function Get-PfbNode {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         try {
             Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'nodes' -QueryParams $queryParams -AutoPaginate
         }

--- a/Public/Node/Get-PfbNodeGroup.ps1
+++ b/Public/Node/Get-PfbNodeGroup.ps1
@@ -52,6 +52,7 @@ function Get-PfbNodeGroup {
     end {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         try {
             Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'node-groups' -QueryParams $queryParams -AutoPaginate
         }

--- a/Public/Node/Get-PfbNodeGroupUse.ps1
+++ b/Public/Node/Get-PfbNodeGroupUse.ps1
@@ -47,6 +47,7 @@ function Get-PfbNodeGroupUse {
     end {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         try {
             Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'node-groups/uses' -QueryParams $queryParams -AutoPaginate
         }

--- a/Public/ObjectStore/Get-PfbObjectStoreAccessKey.ps1
+++ b/Public/ObjectStore/Get-PfbObjectStoreAccessKey.ps1
@@ -46,6 +46,7 @@ function Get-PfbObjectStoreAccessKey {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'object-store-access-keys' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/ObjectStore/Get-PfbObjectStoreAccessPolicy.ps1
+++ b/Public/ObjectStore/Get-PfbObjectStoreAccessPolicy.ps1
@@ -57,6 +57,7 @@ function Get-PfbObjectStoreAccessPolicy {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'object-store-access-policies' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/ObjectStore/Get-PfbObjectStoreAccessPolicyRole.ps1
+++ b/Public/ObjectStore/Get-PfbObjectStoreAccessPolicyRole.ps1
@@ -75,6 +75,7 @@ function Get-PfbObjectStoreAccessPolicyRole {
         if ($allMemberNames.Count -gt 0) { $queryParams['member_names'] = $allMemberNames -join ',' }
         if ($allMemberIds.Count -gt 0)   { $queryParams['member_ids']   = $allMemberIds -join ',' }
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         $response = Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'object-store-access-policies/object-store-roles' -QueryParams $queryParams -AutoPaginate
 
         # Lift the nested parent names to top-level properties so that piping an association into a

--- a/Public/ObjectStore/Get-PfbObjectStoreAccessPolicyRule.ps1
+++ b/Public/ObjectStore/Get-PfbObjectStoreAccessPolicyRule.ps1
@@ -70,6 +70,7 @@ function Get-PfbObjectStoreAccessPolicyRule {
         if ($allPolicyNames.Count -gt 0) { $queryParams['policy_names'] = $allPolicyNames -join ',' }
         if ($allPolicyIds.Count -gt 0)   { $queryParams['policy_ids']   = $allPolicyIds -join ',' }
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         $response = Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'object-store-access-policies/rules' -QueryParams $queryParams -AutoPaginate
 
         # Lift the nested parent policy name to a top-level property so that piping a rule into a

--- a/Public/ObjectStore/Get-PfbObjectStoreAccessPolicyUser.ps1
+++ b/Public/ObjectStore/Get-PfbObjectStoreAccessPolicyUser.ps1
@@ -75,6 +75,7 @@ function Get-PfbObjectStoreAccessPolicyUser {
         if ($allMemberNames.Count -gt 0) { $queryParams['member_names'] = $allMemberNames -join ',' }
         if ($allMemberIds.Count -gt 0)   { $queryParams['member_ids']   = $allMemberIds -join ',' }
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         $response = Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'object-store-access-policies/object-store-users' -QueryParams $queryParams -AutoPaginate
         foreach ($item in $response) {
             if ($null -ne $item) {

--- a/Public/ObjectStore/Get-PfbObjectStoreAccount.ps1
+++ b/Public/ObjectStore/Get-PfbObjectStoreAccount.ps1
@@ -49,6 +49,7 @@ function Get-PfbObjectStoreAccount {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'object-store-accounts' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/ObjectStore/Get-PfbObjectStoreAccountExport.ps1
+++ b/Public/ObjectStore/Get-PfbObjectStoreAccountExport.ps1
@@ -56,6 +56,7 @@ function Get-PfbObjectStoreAccountExport {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'object-store-account-exports' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/ObjectStore/Get-PfbObjectStoreRemoteCredential.ps1
+++ b/Public/ObjectStore/Get-PfbObjectStoreRemoteCredential.ps1
@@ -57,6 +57,7 @@ function Get-PfbObjectStoreRemoteCredential {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'object-store-remote-credentials' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/ObjectStore/Get-PfbObjectStoreRole.ps1
+++ b/Public/ObjectStore/Get-PfbObjectStoreRole.ps1
@@ -57,6 +57,7 @@ function Get-PfbObjectStoreRole {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'object-store-roles' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/ObjectStore/Get-PfbObjectStoreRoleAccessPolicy.ps1
+++ b/Public/ObjectStore/Get-PfbObjectStoreRoleAccessPolicy.ps1
@@ -75,6 +75,7 @@ function Get-PfbObjectStoreRoleAccessPolicy {
         if ($allMemberNames.Count -gt 0) { $queryParams['member_names'] = $allMemberNames -join ',' }
         if ($allMemberIds.Count -gt 0)   { $queryParams['member_ids']   = $allMemberIds -join ',' }
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'object-store-roles/object-store-access-policies' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/ObjectStore/Get-PfbObjectStoreTrustPolicy.ps1
+++ b/Public/ObjectStore/Get-PfbObjectStoreTrustPolicy.ps1
@@ -62,6 +62,7 @@ function Get-PfbObjectStoreTrustPolicy {
         if ($allRoleNames.Count -gt 0) { $queryParams['role_names'] = $allRoleNames -join ',' }
         if ($allRoleIds.Count -gt 0)   { $queryParams['role_ids']   = $allRoleIds -join ',' }
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         $response = Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'object-store-roles/object-store-trust-policies' -QueryParams $queryParams -AutoPaginate
 
         # Lift the nested parent role name to a top-level property so that piping a trust policy

--- a/Public/ObjectStore/Get-PfbObjectStoreTrustPolicyRule.ps1
+++ b/Public/ObjectStore/Get-PfbObjectStoreTrustPolicyRule.ps1
@@ -59,6 +59,7 @@ function Get-PfbObjectStoreTrustPolicyRule {
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames
         if ($allPolicyNames.Count -gt 0) { $queryParams['policy_names'] = $allPolicyNames -join ',' }
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         $response = Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'object-store-roles/object-store-trust-policies/rules' -QueryParams $queryParams -AutoPaginate
 
         # Lift the nested parent policy name to a top-level property so that piping a rule into a

--- a/Public/ObjectStore/Get-PfbObjectStoreUser.ps1
+++ b/Public/ObjectStore/Get-PfbObjectStoreUser.ps1
@@ -46,6 +46,7 @@ function Get-PfbObjectStoreUser {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'object-store-users' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/ObjectStore/Get-PfbObjectStoreUserAccessPolicy.ps1
+++ b/Public/ObjectStore/Get-PfbObjectStoreUserAccessPolicy.ps1
@@ -75,6 +75,7 @@ function Get-PfbObjectStoreUserAccessPolicy {
         if ($allPolicyNames.Count -gt 0) { $queryParams['policy_names'] = $allPolicyNames -join ',' }
         if ($allPolicyIds.Count -gt 0)   { $queryParams['policy_ids']   = $allPolicyIds -join ',' }
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         $response = Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'object-store-users/object-store-access-policies' -QueryParams $queryParams -AutoPaginate
         foreach ($item in $response) {
             if ($null -ne $item) {

--- a/Public/ObjectStore/Get-PfbObjectStoreVirtualHost.ps1
+++ b/Public/ObjectStore/Get-PfbObjectStoreVirtualHost.ps1
@@ -60,6 +60,7 @@ function Get-PfbObjectStoreVirtualHost {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'object-store-virtual-hosts' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Policy/Get-PfbAuditFileSystemPolicy.ps1
+++ b/Public/Policy/Get-PfbAuditFileSystemPolicy.ps1
@@ -60,6 +60,7 @@ function Get-PfbAuditFileSystemPolicy {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'audit-file-systems-policies' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Policy/Get-PfbAuditObjectStorePolicy.ps1
+++ b/Public/Policy/Get-PfbAuditObjectStorePolicy.ps1
@@ -60,6 +60,7 @@ function Get-PfbAuditObjectStorePolicy {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'audit-object-store-policies' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Policy/Get-PfbNetworkAccessPolicy.ps1
+++ b/Public/Policy/Get-PfbNetworkAccessPolicy.ps1
@@ -60,6 +60,7 @@ function Get-PfbNetworkAccessPolicy {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'network-access-policies' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Policy/Get-PfbNetworkAccessRule.ps1
+++ b/Public/Policy/Get-PfbNetworkAccessRule.ps1
@@ -70,6 +70,7 @@ function Get-PfbNetworkAccessRule {
         if ($allPolicyNames.Count -gt 0) { $queryParams['policy_names'] = $allPolicyNames -join ',' }
         if ($allPolicyIds.Count -gt 0)   { $queryParams['policy_ids']   = $allPolicyIds -join ',' }
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         $response = Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'network-access-policies/rules' -QueryParams $queryParams -AutoPaginate
 
         # Lift the nested parent policy name to a top-level property so that piping a rule into a

--- a/Public/Policy/Get-PfbNfsExportPolicy.ps1
+++ b/Public/Policy/Get-PfbNfsExportPolicy.ps1
@@ -60,6 +60,7 @@ function Get-PfbNfsExportPolicy {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'nfs-export-policies' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Policy/Get-PfbNfsExportRule.ps1
+++ b/Public/Policy/Get-PfbNfsExportRule.ps1
@@ -70,6 +70,7 @@ function Get-PfbNfsExportRule {
         if ($allPolicyNames.Count -gt 0) { $queryParams['policy_names'] = $allPolicyNames -join ',' }
         if ($allPolicyIds.Count -gt 0)   { $queryParams['policy_ids']   = $allPolicyIds -join ',' }
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         $response = Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'nfs-export-policies/rules' -QueryParams $queryParams -AutoPaginate
 
         # Lift the nested parent policy name to a top-level property so that piping a rule into a

--- a/Public/Policy/Get-PfbPolicy.ps1
+++ b/Public/Policy/Get-PfbPolicy.ps1
@@ -48,6 +48,7 @@ function Get-PfbPolicy {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'policies' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Policy/Get-PfbPolicyAll.ps1
+++ b/Public/Policy/Get-PfbPolicyAll.ps1
@@ -52,6 +52,7 @@ function Get-PfbPolicyAll {
     end {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'policies-all' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Policy/Get-PfbQosPolicy.ps1
+++ b/Public/Policy/Get-PfbQosPolicy.ps1
@@ -52,6 +52,7 @@ function Get-PfbQosPolicy {
     end {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'qos-policies' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Policy/Get-PfbS3ExportPolicy.ps1
+++ b/Public/Policy/Get-PfbS3ExportPolicy.ps1
@@ -61,6 +61,7 @@ function Get-PfbS3ExportPolicy {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 's3-export-policies' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Policy/Get-PfbS3ExportRule.ps1
+++ b/Public/Policy/Get-PfbS3ExportRule.ps1
@@ -70,6 +70,7 @@ function Get-PfbS3ExportRule {
         if ($allPolicyNames.Count -gt 0) { $queryParams['policy_names'] = $allPolicyNames -join ',' }
         if ($allPolicyIds.Count -gt 0)   { $queryParams['policy_ids']   = $allPolicyIds -join ',' }
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         $response = Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 's3-export-policies/rules' -QueryParams $queryParams -AutoPaginate
 
         # Lift the nested parent policy name to a top-level property so that piping a rule into a

--- a/Public/Policy/Get-PfbSmbClientPolicy.ps1
+++ b/Public/Policy/Get-PfbSmbClientPolicy.ps1
@@ -60,6 +60,7 @@ function Get-PfbSmbClientPolicy {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'smb-client-policies' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Policy/Get-PfbSmbClientRule.ps1
+++ b/Public/Policy/Get-PfbSmbClientRule.ps1
@@ -70,6 +70,7 @@ function Get-PfbSmbClientRule {
         if ($allPolicyNames.Count -gt 0) { $queryParams['policy_names'] = $allPolicyNames -join ',' }
         if ($allPolicyIds.Count -gt 0)   { $queryParams['policy_ids']   = $allPolicyIds -join ',' }
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         $response = Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'smb-client-policies/rules' -QueryParams $queryParams -AutoPaginate
 
         # Lift the nested parent policy name to a top-level property so that piping a rule into a

--- a/Public/Policy/Get-PfbSmbSharePolicy.ps1
+++ b/Public/Policy/Get-PfbSmbSharePolicy.ps1
@@ -60,6 +60,7 @@ function Get-PfbSmbSharePolicy {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'smb-share-policies' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Policy/Get-PfbSmbShareRule.ps1
+++ b/Public/Policy/Get-PfbSmbShareRule.ps1
@@ -70,6 +70,7 @@ function Get-PfbSmbShareRule {
         if ($allPolicyNames.Count -gt 0) { $queryParams['policy_names'] = $allPolicyNames -join ',' }
         if ($allPolicyIds.Count -gt 0)   { $queryParams['policy_ids']   = $allPolicyIds -join ',' }
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         $response = Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'smb-share-policies/rules' -QueryParams $queryParams -AutoPaginate
 
         # Lift the nested parent policy name to a top-level property so that piping a rule into a

--- a/Public/Policy/Get-PfbSshCaPolicy.ps1
+++ b/Public/Policy/Get-PfbSshCaPolicy.ps1
@@ -53,6 +53,7 @@ function Get-PfbSshCaPolicy {
     end {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'ssh-certificate-authority-policies' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Policy/Get-PfbStorageClassTieringPolicy.ps1
+++ b/Public/Policy/Get-PfbStorageClassTieringPolicy.ps1
@@ -52,6 +52,7 @@ function Get-PfbStorageClassTieringPolicy {
     end {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'storage-class-tiering-policies' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Policy/Get-PfbTlsPolicy.ps1
+++ b/Public/Policy/Get-PfbTlsPolicy.ps1
@@ -52,6 +52,7 @@ function Get-PfbTlsPolicy {
     end {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'tls-policies' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Policy/Get-PfbUserGroupQuotaPolicy.ps1
+++ b/Public/Policy/Get-PfbUserGroupQuotaPolicy.ps1
@@ -57,6 +57,7 @@ function Get-PfbUserGroupQuotaPolicy {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames.ToArray() -Ids $allIds.ToArray()
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'user-group-quota-policies' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Policy/Get-PfbUserGroupQuotaPolicyRule.ps1
+++ b/Public/Policy/Get-PfbUserGroupQuotaPolicyRule.ps1
@@ -72,6 +72,7 @@ function Get-PfbUserGroupQuotaPolicyRule {
         if ($allPolicyIds.Count -gt 0)   { $queryParams['policy_ids']   = $allPolicyIds -join ',' }
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $Name -Ids $Id
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'user-group-quota-policies/rules' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Policy/Get-PfbWormPolicy.ps1
+++ b/Public/Policy/Get-PfbWormPolicy.ps1
@@ -52,6 +52,7 @@ function Get-PfbWormPolicy {
     end {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'worm-data-policies' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Realm/Get-PfbRealm.ps1
+++ b/Public/Realm/Get-PfbRealm.ps1
@@ -82,6 +82,7 @@ function Get-PfbRealm {
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
         if ($Destroyed)            { $queryParams['destroyed']  = 'true' }
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'realms' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Realm/Get-PfbRealmDefaults.ps1
+++ b/Public/Realm/Get-PfbRealmDefaults.ps1
@@ -62,6 +62,7 @@ function Get-PfbRealmDefaults {
         if ($allRealmNames.Count -gt 0) {
             $queryParams['realm_names'] = $allRealmNames -join ','
         }
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'realms/defaults' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Realm/Get-PfbRealmSpace.ps1
+++ b/Public/Realm/Get-PfbRealmSpace.ps1
@@ -46,6 +46,7 @@ function Get-PfbRealmSpace {
     end {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'realms/space' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Realm/Get-PfbRealmStorageClass.ps1
+++ b/Public/Realm/Get-PfbRealmStorageClass.ps1
@@ -46,6 +46,7 @@ function Get-PfbRealmStorageClass {
     end {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         try {
             Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'realms/space/storage-classes' -QueryParams $queryParams -AutoPaginate
         }

--- a/Public/Replication/Get-PfbArrayConnection.ps1
+++ b/Public/Replication/Get-PfbArrayConnection.ps1
@@ -103,6 +103,7 @@ function Get-PfbArrayConnection {
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Ids $allIds
         if ($allRemoteNames.Count) { $queryParams['remote_names'] = $allRemoteNames -join ',' }
         if ($RemoteId) { $queryParams['remote_ids'] = $RemoteId -join ',' }
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'array-connections' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Replication/Get-PfbArrayConnectionKey.ps1
+++ b/Public/Replication/Get-PfbArrayConnectionKey.ps1
@@ -82,6 +82,7 @@ function Get-PfbArrayConnectionKey {
         # `names` for -Names. The key goes on the wire because the spec declares it, not because
         # it narrows anything -- see the note on -Name above.
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'array-connections/connection-key' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Replication/Get-PfbArrayConnectionPath.ps1
+++ b/Public/Replication/Get-PfbArrayConnectionPath.ps1
@@ -93,6 +93,7 @@ function Get-PfbArrayConnectionPath {
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Ids $allIds
         if ($allRemoteNames.Count) { $queryParams['remote_names'] = $allRemoteNames -join ',' }
         if ($RemoteId) { $queryParams['remote_ids'] = $RemoteId -join ',' }
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'array-connections/path' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Replication/Get-PfbArrayConnectionPerformanceReplication.ps1
+++ b/Public/Replication/Get-PfbArrayConnectionPerformanceReplication.ps1
@@ -106,6 +106,7 @@ function Get-PfbArrayConnectionPerformanceReplication {
         if ($EndTime) { $queryParams['end_time'] = $EndTime }
         if ($Resolution) { $queryParams['resolution'] = $Resolution }
         if ($Type) { $queryParams['type'] = $Type }
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'array-connections/performance/replication' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Replication/Get-PfbFileSystemReplicaLinkTransfer.ps1
+++ b/Public/Replication/Get-PfbFileSystemReplicaLinkTransfer.ps1
@@ -126,6 +126,7 @@ function Get-PfbFileSystemReplicaLinkTransfer {
         if ($RemoteName) { $queryParams['remote_names'] = $RemoteName -join ',' }
         if ($RemoteId)   { $queryParams['remote_ids']   = $RemoteId   -join ',' }
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'file-system-replica-links/transfer' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Replication/Get-PfbFleet.ps1
+++ b/Public/Replication/Get-PfbFleet.ps1
@@ -53,6 +53,7 @@ function Get-PfbFleet {
     end {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'fleets' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Replication/Get-PfbFleetMember.ps1
+++ b/Public/Replication/Get-PfbFleetMember.ps1
@@ -60,12 +60,16 @@ function Get-PfbFleetMember {
     Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'fleets/members' -QueryParams $queryParams -AutoPaginate |
         ForEach-Object {
             # Invoke-PfbApiRequest returns a bare { total_item_count = N } sentinel -- not a
-            # member -- when the API reports a count but no items (see its trailing return).
-            # A filter matching nothing takes that path. Decorating it would produce an
-            # object that LOOKS like a fleet member whose name is $null, which is the exact
-            # silent-wrong-binding failure this decoration exists to prevent: piping it into
-            # a context-scoping cmdlet would bind a $null name. Pass it through undecorated
-            # so the absence of MemberName fails loudly instead.
+            # member -- only for a request that explicitly asked for total_only=true. This
+            # cmdlet exposes no -TotalOnly parameter and so cannot set that key, which means
+            # today's response layer cannot hand this branch a sentinel at all.
+            #
+            # Kept as defence-in-depth rather than as a live path: if the response layer ever
+            # emits one again, decorating it would produce an object that LOOKS like a fleet
+            # member whose name is $null, and piping THAT into a context-scoping cmdlet would
+            # bind a $null name -- the exact silent-wrong-binding failure this decoration
+            # exists to prevent. Pass it through undecorated so the absence of MemberName
+            # fails loudly instead.
             if (($_.PSObject.Properties.Name -contains 'total_item_count') -and
                 ($_.PSObject.Properties.Name -notcontains 'member')) {
                 return $_

--- a/Public/Replication/Get-PfbRemoteArray.ps1
+++ b/Public/Replication/Get-PfbRemoteArray.ps1
@@ -53,6 +53,9 @@ function Get-PfbRemoteArray {
     end {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
+        # The current_fleet_only key below is a scope flag, not a selector, and is written on
+        # every path -- so it must not count toward "a selector reached the query".
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         if ($CurrentFleetOnly) { $queryParams['current_fleet_only'] = 'true' } else { $queryParams['current_fleet_only'] = 'false' }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'remote-arrays' -QueryParams $queryParams -AutoPaginate
     }

--- a/Public/Replication/Get-PfbTarget.ps1
+++ b/Public/Replication/Get-PfbTarget.ps1
@@ -53,6 +53,7 @@ function Get-PfbTarget {
     end {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'targets' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Replication/Get-PfbTargetPerformanceReplication.ps1
+++ b/Public/Replication/Get-PfbTargetPerformanceReplication.ps1
@@ -59,6 +59,7 @@ function Get-PfbTargetPerformanceReplication {
         if ($StartTime) { $queryParams['start_time'] = $StartTime }
         if ($EndTime) { $queryParams['end_time'] = $EndTime }
         if ($Resolution) { $queryParams['resolution'] = $Resolution }
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'targets/performance/replication' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Server/Get-PfbServer.ps1
+++ b/Public/Server/Get-PfbServer.ps1
@@ -70,6 +70,7 @@ function Get-PfbServer {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'servers' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Support/Get-PfbAudit.ps1
+++ b/Public/Support/Get-PfbAudit.ps1
@@ -40,6 +40,7 @@ function Get-PfbAudit {
     end {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'audits' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Support/Get-PfbSupport.ps1
+++ b/Public/Support/Get-PfbSupport.ps1
@@ -59,6 +59,7 @@ function Get-PfbSupport {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames
 
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'support' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Support/Get-PfbSupportDiagnostics.ps1
+++ b/Public/Support/Get-PfbSupportDiagnostics.ps1
@@ -52,6 +52,7 @@ function Get-PfbSupportDiagnostics {
     end {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'support-diagnostics' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Public/Support/Get-PfbSupportDiagnosticsDetails.ps1
+++ b/Public/Support/Get-PfbSupportDiagnosticsDetails.ps1
@@ -52,6 +52,7 @@ function Get-PfbSupportDiagnosticsDetails {
     end {
         $queryParams = @{}
         Add-PfbCommonQueryParams -Into $queryParams -BoundParameters $PSBoundParameters -Names $allNames -Ids $allIds
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'support-diagnostics/details' -QueryParams $queryParams -AutoPaginate
     }
 }

--- a/Tests/Get-PfbFleetMember.Tests.ps1
+++ b/Tests/Get-PfbFleetMember.Tests.ps1
@@ -127,13 +127,18 @@ Describe 'Get-PfbFleetMember - top-level MemberName/FleetName decoration' {
         @(Get-PfbFleetMember -Array $script:fakeConnection).Count | Should -Be 0
     }
 
-    It 'REGRESSION: does not decorate the total_item_count sentinel into a nameless member' {
+    It 'REGRESSION: a total_item_count sentinel, if the response layer ever emits one, is not decorated into a nameless member' {
         # Invoke-PfbApiRequest returns a bare { total_item_count = N } object -- NOT a member
-        # -- when the API reports a count but no items, which is what a filter matching
-        # nothing produces. Decorating it would emit something that looks like a fleet member
-        # with a $null name, and piping THAT into a context-scoping cmdlet would bind $null:
-        # the precise silent-wrong-binding failure this whole decoration exists to prevent.
-        # It must pass through WITHOUT MemberName, so the absence fails loudly instead.
+        # -- only for a request that explicitly asked for total_only=true. Get-PfbFleetMember
+        # exposes no -TotalOnly parameter, so it cannot produce one on today's response layer
+        # and the mocked input below is a deliberate synthetic rather than a live shape.
+        #
+        # The test's value is that it pins the decoration's behaviour against a future
+        # response-layer change: decorating such an object would emit something that looks
+        # like a fleet member with a $null name, and piping THAT into a context-scoping
+        # cmdlet would bind $null -- the precise silent-wrong-binding failure this whole
+        # decoration exists to prevent. It must pass through WITHOUT MemberName, so the
+        # absence fails loudly instead.
         Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest {
             [PSCustomObject]@{ total_item_count = 0 }
         }

--- a/Tests/Get-PfbRemoteArray.Tests.ps1
+++ b/Tests/Get-PfbRemoteArray.Tests.ps1
@@ -1,0 +1,65 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+<#
+.SYNOPSIS
+    Empty-pipeline regression coverage for Get-PfbRemoteArray (#121).
+.DESCRIPTION
+    Get-PfbRemoteArray is the one cmdlet in the guarded population where the generator's
+    usual guard position -- immediately above the request -- would have been INERT rather
+    than protective. Its end block writes `current_fleet_only` on BOTH branches of an
+    if/else, so $queryParams is never empty by the time the request is issued, and a guard
+    below that write could never fire.
+
+    Its guard is therefore hand-placed ABOVE that write, on the design's own terms: the
+    policy is "no SELECTOR reached the query", and current_fleet_only is a scope flag, not
+    a selector. These two tests pin both halves of that placement -- an empty pipeline
+    issues nothing, and an ordinary direct call still issues exactly one request that still
+    carries the flag.
+#>
+
+BeforeAll {
+    $moduleRoot = Split-Path -Parent $PSScriptRoot
+    Import-Module (Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1') -Force
+
+    $script:fakeConnection = [PSCustomObject]@{
+        PSTypeName   = 'PureStorage.FlashBlade.Connection'
+        HttpEndpoint = 'https://fb.test'
+        Endpoint     = 'fb.test'
+        AuthToken    = 'tok'
+        ApiVersion   = '2.26'
+    }
+}
+
+Describe 'Get-PfbRemoteArray - empty pipeline guard' {
+
+    It 'issues no request at all when piped an empty collection' {
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { @() }
+
+        @() | Get-PfbRemoteArray -Array $script:fakeConnection | Out-Null
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 0 -Exactly
+    }
+
+    It 'still issues exactly one request carrying current_fleet_only on a direct call' {
+        # The guard sits ABOVE the current_fleet_only write, so this is the assertion that
+        # proves it did not swallow the ordinary path or drop the flag with it.
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { @() }
+
+        Get-PfbRemoteArray -Array $script:fakeConnection | Out-Null
+
+        # $PSBoundParameters is EMPTY inside a -ParameterFilter; assert on the bound
+        # variable instead, or the filter passes vacuously.
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['current_fleet_only'] -eq 'true'
+        }
+    }
+
+    It 'still issues a request when a name arrives down the pipeline' {
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { @() }
+
+        'remote-dc2' | Get-PfbRemoteArray -Array $script:fakeConnection | Out-Null
+
+        Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+            $QueryParams['names'] -eq 'remote-dc2'
+        }
+    }
+}

--- a/Tests/Invoke-PfbApiRequest.EmptyResult.Tests.ps1
+++ b/Tests/Invoke-PfbApiRequest.EmptyResult.Tests.ps1
@@ -1,0 +1,298 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+# Issue #121. An empty list result used to come back as a one-element
+# [PSCustomObject]@{ total_item_count = N } wrapper: truthy, counted as 1 by Measure-Object,
+# and -- carrying neither `name` nor `id` -- coerced on the pipeline into
+# `names=@{total_item_count=0}`. At least one endpoint ignores that selector and returns its
+# entire collection, so a caller who searched, found nothing, and piped the nothing onward
+# received everything.
+#
+# The wrapper is still correct for one caller: a -TotalOnly read, whose whole purpose is the
+# count. The array cannot tell the two apart for us. Measured against FB-A at REST 2.26,
+# `GET /file-systems?total_only=true` and `GET /file-systems?filter=<no-match>` return the same
+# four keys and differ only in the value of `total_item_count`:
+#
+#   total_only=true    -> { total, continuation_token, total_item_count: 2, items: [] }
+#   filter=<no-match>  -> { total, continuation_token, total_item_count: 0, items: [] }
+#
+# So the discriminator has to be the REQUEST, and it is already in hand: `total_only` in
+# $QueryParams, put there by Add-PfbCommonQueryParams. These tests pin both halves -- the
+# wrapper survives for a total-only read, and nothing else ever sees it.
+
+BeforeAll {
+    $moduleRoot = Split-Path -Parent $PSScriptRoot
+    $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
+    Import-Module $manifest -Force
+}
+
+Describe 'Invoke-PfbApiRequest - empty results' {
+
+    BeforeEach {
+        # The shape the array actually returns for a filter that matches nothing.
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
+            [PSCustomObject]@{
+                total              = $null
+                continuation_token = $null
+                total_item_count   = 0
+                items              = @()
+            }
+        } -ParameterFilter { $Uri -like '*file-systems*' }
+    }
+
+    It 'returns nothing at all when the result is empty' {
+        $result = InModuleScope PureStorageFlashBladePowerShell {
+            $array = [PSCustomObject]@{
+                Endpoint = 'fb.test'; ApiVersion = '2.26'; AuthToken = 'tok'
+                ApiToken = $null; AuthMethod = 'ApiToken'; SkipCertificateCheck = $false
+            }
+            Invoke-PfbApiRequest -Array $array -Method GET -Endpoint 'file-systems' `
+                -QueryParams @{ filter = "name='zzz-no-such-filesystem'" }
+        }
+
+        # Measure-Object, not .Count: @($null).Count is 1, so .Count cannot tell an empty
+        # result from a one-element wrapper.
+        ($result | Measure-Object).Count | Should -Be 0
+    }
+
+    It 'returns a falsy value on an empty result, so "if (Get-PfbX ...)" does not fire' {
+        $result = InModuleScope PureStorageFlashBladePowerShell {
+            $array = [PSCustomObject]@{
+                Endpoint = 'fb.test'; ApiVersion = '2.26'; AuthToken = 'tok'
+                ApiToken = $null; AuthMethod = 'ApiToken'; SkipCertificateCheck = $false
+            }
+            Invoke-PfbApiRequest -Array $array -Method GET -Endpoint 'file-systems' `
+                -QueryParams @{ filter = "name='zzz-no-such-filesystem'" }
+        }
+
+        [bool]$result | Should -BeFalse
+    }
+
+    It 'emits no object carrying total_item_count, so nothing can coerce into a selector' {
+        $result = InModuleScope PureStorageFlashBladePowerShell {
+            $array = [PSCustomObject]@{
+                Endpoint = 'fb.test'; ApiVersion = '2.26'; AuthToken = 'tok'
+                ApiToken = $null; AuthMethod = 'ApiToken'; SkipCertificateCheck = $false
+            }
+            Invoke-PfbApiRequest -Array $array -Method GET -Endpoint 'file-systems' `
+                -QueryParams @{ filter = "name='zzz-no-such-filesystem'" }
+        }
+
+        # This is the defect's actual harm: an object whose only property is total_item_count
+        # binds ByValue to a -Name parameter as the string '@{total_item_count=0}'.
+        @($result | ForEach-Object { $_.PSObject.Properties.Name }) | Should -Not -Contain 'total_item_count'
+    }
+
+    It 'iterates zero times when piped into ForEach-Object' {
+        $seen = InModuleScope PureStorageFlashBladePowerShell {
+            $array = [PSCustomObject]@{
+                Endpoint = 'fb.test'; ApiVersion = '2.26'; AuthToken = 'tok'
+                ApiToken = $null; AuthMethod = 'ApiToken'; SkipCertificateCheck = $false
+            }
+            Invoke-PfbApiRequest -Array $array -Method GET -Endpoint 'file-systems' `
+                -QueryParams @{ filter = "name='zzz-no-such-filesystem'" }
+        } | ForEach-Object { 'iteration' }
+
+        ($seen | Measure-Object).Count | Should -Be 0
+    }
+
+    It 'suppresses the wrapper even when the array reports a non-zero total against zero items' {
+        # Gating must key off the REQUEST, never off the count. A non-zero total_item_count
+        # beside an empty items array is exactly what a total-only response looks like, so a
+        # count-based guard would leak the wrapper right back to an ordinary caller.
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
+            [PSCustomObject]@{
+                total_item_count = 7
+                items            = @()
+            }
+        } -ParameterFilter { $Uri -like '*file-systems*' }
+
+        $result = InModuleScope PureStorageFlashBladePowerShell {
+            $array = [PSCustomObject]@{
+                Endpoint = 'fb.test'; ApiVersion = '2.26'; AuthToken = 'tok'
+                ApiToken = $null; AuthMethod = 'ApiToken'; SkipCertificateCheck = $false
+            }
+            Invoke-PfbApiRequest -Array $array -Method GET -Endpoint 'file-systems'
+        }
+
+        ($result | Measure-Object).Count | Should -Be 0
+    }
+
+    It 'returns nothing when no QueryParams were supplied at all' {
+        # The guard has to survive a $null $QueryParams -- most read cmdlets pass one, but
+        # indexing a $null hashtable is a StrictMode error, not a $null.
+        $result = InModuleScope PureStorageFlashBladePowerShell {
+            $array = [PSCustomObject]@{
+                Endpoint = 'fb.test'; ApiVersion = '2.26'; AuthToken = 'tok'
+                ApiToken = $null; AuthMethod = 'ApiToken'; SkipCertificateCheck = $false
+            }
+            Invoke-PfbApiRequest -Array $array -Method GET -Endpoint 'file-systems'
+        }
+
+        ($result | Measure-Object).Count | Should -Be 0
+    }
+
+    It 'returns nothing when auto-pagination collects no items across pages' {
+        $script:emptyPageCount = 0
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
+            $script:emptyPageCount++
+            if ($script:emptyPageCount -eq 1) {
+                [PSCustomObject]@{ items = @(); total_item_count = 0; continuation_token = 'tok2' }
+            }
+            else {
+                [PSCustomObject]@{ items = @(); total_item_count = 0; continuation_token = $null }
+            }
+        } -ParameterFilter { $Uri -like '*file-systems*' }
+
+        $result = InModuleScope PureStorageFlashBladePowerShell {
+            $array = [PSCustomObject]@{
+                Endpoint = 'fb.test'; ApiVersion = '2.26'; AuthToken = 'tok'
+                ApiToken = $null; AuthMethod = 'ApiToken'; SkipCertificateCheck = $false
+            }
+            Invoke-PfbApiRequest -Array $array -Method GET -Endpoint 'file-systems' -QueryParams @{} -AutoPaginate
+        }
+
+        ($result | Measure-Object).Count | Should -Be 0
+        $script:emptyPageCount | Should -Be 2
+    }
+}
+
+Describe 'Invoke-PfbApiRequest - total_only reads keep their count' {
+
+    It 'still returns the bare total_item_count object when total_only was requested' {
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
+            [PSCustomObject]@{
+                total              = $null
+                continuation_token = $null
+                total_item_count   = 2
+                items              = @()
+            }
+        } -ParameterFilter { $Uri -like '*file-systems*' }
+
+        $result = InModuleScope PureStorageFlashBladePowerShell {
+            $array = [PSCustomObject]@{
+                Endpoint = 'fb.test'; ApiVersion = '2.26'; AuthToken = 'tok'
+                ApiToken = $null; AuthMethod = 'ApiToken'; SkipCertificateCheck = $false
+            }
+            Invoke-PfbApiRequest -Array $array -Method GET -Endpoint 'file-systems' `
+                -QueryParams @{ total_only = 'true' }
+        }
+
+        ($result | Measure-Object).Count | Should -Be 1
+        $result.total_item_count | Should -Be 2
+    }
+
+    It 'returns a zero count for a total_only read that matched nothing' {
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
+            [PSCustomObject]@{ total_item_count = 0; items = @() }
+        } -ParameterFilter { $Uri -like '*file-systems*' }
+
+        $result = InModuleScope PureStorageFlashBladePowerShell {
+            $array = [PSCustomObject]@{
+                Endpoint = 'fb.test'; ApiVersion = '2.26'; AuthToken = 'tok'
+                ApiToken = $null; AuthMethod = 'ApiToken'; SkipCertificateCheck = $false
+            }
+            Invoke-PfbApiRequest -Array $array -Method GET -Endpoint 'file-systems' `
+                -QueryParams @{ total_only = 'true'; filter = "name='zzz-no-such-filesystem'" }
+        }
+
+        ($result | Measure-Object).Count | Should -Be 1
+        $result.total_item_count | Should -Be 0
+    }
+
+    It 'does not treat a total_only value other than true as a total-only read' {
+        # Add-PfbCommonQueryParams only ever writes the string 'true', so anything else did not
+        # come from -TotalOnly. Keying off the value rather than the key also means this code
+        # will not inherit that helper's separate ContainsKey defect if it is fixed later.
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
+            [PSCustomObject]@{ total_item_count = 4; items = @() }
+        } -ParameterFilter { $Uri -like '*file-systems*' }
+
+        $result = InModuleScope PureStorageFlashBladePowerShell {
+            $array = [PSCustomObject]@{
+                Endpoint = 'fb.test'; ApiVersion = '2.26'; AuthToken = 'tok'
+                ApiToken = $null; AuthMethod = 'ApiToken'; SkipCertificateCheck = $false
+            }
+            Invoke-PfbApiRequest -Array $array -Method GET -Endpoint 'file-systems' `
+                -QueryParams @{ total_only = 'false' }
+        }
+
+        ($result | Measure-Object).Count | Should -Be 0
+    }
+}
+
+Describe 'Invoke-PfbApiRequest - unaffected return paths' {
+
+    It 'still returns the items of a non-empty result unchanged' {
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
+            [PSCustomObject]@{
+                total_item_count = 2
+                items            = @(
+                    [PSCustomObject]@{ name = 'fs1' }
+                    [PSCustomObject]@{ name = 'fs2' }
+                )
+            }
+        } -ParameterFilter { $Uri -like '*file-systems*' }
+
+        $result = InModuleScope PureStorageFlashBladePowerShell {
+            $array = [PSCustomObject]@{
+                Endpoint = 'fb.test'; ApiVersion = '2.26'; AuthToken = 'tok'
+                ApiToken = $null; AuthMethod = 'ApiToken'; SkipCertificateCheck = $false
+            }
+            Invoke-PfbApiRequest -Array $array -Method GET -Endpoint 'file-systems' -QueryParams @{}
+        }
+
+        ($result | Measure-Object).Count | Should -Be 2
+        @($result)[0].name | Should -Be 'fs1'
+    }
+
+    It 'treats a no-items total_item_count-only body as an ordinary empty list' {
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
+            [PSCustomObject]@{ total_item_count = 0 }
+        } -ParameterFilter { $Uri -like '*file-systems/open-files*' }
+
+        $result = InModuleScope PureStorageFlashBladePowerShell {
+            $array = [PSCustomObject]@{
+                Endpoint = 'fb.test'; ApiVersion = '2.26'; AuthToken = 'tok'
+                ApiToken = $null; AuthMethod = 'ApiToken'; SkipCertificateCheck = $false
+            }
+            Invoke-PfbApiRequest -Array $array -Method GET -Endpoint 'file-systems/open-files' `
+                -QueryParams @{}
+        }
+
+        ($result | Measure-Object).Count | Should -Be 0
+    }
+
+    It 'keeps a no-items total_item_count-only body when total_only was requested' {
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
+            [PSCustomObject]@{ total_item_count = 0 }
+        } -ParameterFilter { $Uri -like '*file-systems*' }
+
+        $result = InModuleScope PureStorageFlashBladePowerShell {
+            $array = [PSCustomObject]@{
+                Endpoint = 'fb.test'; ApiVersion = '2.26'; AuthToken = 'tok'
+                ApiToken = $null; AuthMethod = 'ApiToken'; SkipCertificateCheck = $false
+            }
+            Invoke-PfbApiRequest -Array $array -Method GET -Endpoint 'file-systems' `
+                -QueryParams @{ total_only = 'true' }
+        }
+
+        ($result | Measure-Object).Count | Should -Be 1
+        $result.total_item_count | Should -Be 0
+    }
+
+    It 'still returns a genuine direct-data body with no items or total_item_count key verbatim' {
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
+            [PSCustomObject]@{ version = '2.26' }
+        } -ParameterFilter { $Uri -like '*arrays*' }
+
+        $result = InModuleScope PureStorageFlashBladePowerShell {
+            $array = [PSCustomObject]@{
+                Endpoint = 'fb.test'; ApiVersion = '2.26'; AuthToken = 'tok'
+                ApiToken = $null; AuthMethod = 'ApiToken'; SkipCertificateCheck = $false
+            }
+            Invoke-PfbApiRequest -Array $array -Method GET -Endpoint 'arrays' -QueryParams @{}
+        }
+
+        $result.version | Should -Be '2.26'
+    }
+}

--- a/Tests/Invoke-PfbApiRequest.EmptyResult.Tests.ps1
+++ b/Tests/Invoke-PfbApiRequest.EmptyResult.Tests.ps1
@@ -52,6 +52,8 @@ Describe 'Invoke-PfbApiRequest - empty results' {
         # Measure-Object, not .Count: @($null).Count is 1, so .Count cannot tell an empty
         # result from a one-element wrapper.
         ($result | Measure-Object).Count | Should -Be 0
+        # A zero count is equally satisfied by a request that never happened.
+        Should -Invoke Invoke-RestMethod -Times 1 -Exactly -ModuleName PureStorageFlashBladePowerShell
     }
 
     It 'returns a falsy value on an empty result, so "if (Get-PfbX ...)" does not fire' {
@@ -65,6 +67,7 @@ Describe 'Invoke-PfbApiRequest - empty results' {
         }
 
         [bool]$result | Should -BeFalse
+        Should -Invoke Invoke-RestMethod -Times 1 -Exactly -ModuleName PureStorageFlashBladePowerShell
     }
 
     It 'emits no object carrying total_item_count, so nothing can coerce into a selector' {
@@ -80,6 +83,7 @@ Describe 'Invoke-PfbApiRequest - empty results' {
         # This is the defect's actual harm: an object whose only property is total_item_count
         # binds ByValue to a -Name parameter as the string '@{total_item_count=0}'.
         @($result | ForEach-Object { $_.PSObject.Properties.Name }) | Should -Not -Contain 'total_item_count'
+        Should -Invoke Invoke-RestMethod -Times 1 -Exactly -ModuleName PureStorageFlashBladePowerShell
     }
 
     It 'iterates zero times when piped into ForEach-Object' {
@@ -93,6 +97,7 @@ Describe 'Invoke-PfbApiRequest - empty results' {
         } | ForEach-Object { 'iteration' }
 
         ($seen | Measure-Object).Count | Should -Be 0
+        Should -Invoke Invoke-RestMethod -Times 1 -Exactly -ModuleName PureStorageFlashBladePowerShell
     }
 
     It 'suppresses the wrapper even when the array reports a non-zero total against zero items' {
@@ -115,6 +120,7 @@ Describe 'Invoke-PfbApiRequest - empty results' {
         }
 
         ($result | Measure-Object).Count | Should -Be 0
+        Should -Invoke Invoke-RestMethod -Times 1 -Exactly -ModuleName PureStorageFlashBladePowerShell
     }
 
     It 'returns nothing when no QueryParams were supplied at all' {
@@ -129,6 +135,7 @@ Describe 'Invoke-PfbApiRequest - empty results' {
         }
 
         ($result | Measure-Object).Count | Should -Be 0
+        Should -Invoke Invoke-RestMethod -Times 1 -Exactly -ModuleName PureStorageFlashBladePowerShell
     }
 
     It 'returns nothing when auto-pagination collects no items across pages' {
@@ -153,6 +160,7 @@ Describe 'Invoke-PfbApiRequest - empty results' {
 
         ($result | Measure-Object).Count | Should -Be 0
         $script:emptyPageCount | Should -Be 2
+        Should -Invoke Invoke-RestMethod -Times 2 -Exactly -ModuleName PureStorageFlashBladePowerShell
     }
 }
 
@@ -217,6 +225,7 @@ Describe 'Invoke-PfbApiRequest - total_only reads keep their count' {
         }
 
         ($result | Measure-Object).Count | Should -Be 0
+        Should -Invoke Invoke-RestMethod -Times 1 -Exactly -ModuleName PureStorageFlashBladePowerShell
     }
 }
 
@@ -246,6 +255,9 @@ Describe 'Invoke-PfbApiRequest - unaffected return paths' {
     }
 
     It 'treats a no-items total_item_count-only body as an ordinary empty list' {
+        # This is a response-SHAPE test. Leaving the capability gate live would couple it to
+        # whatever PfbCapabilityMap.json currently says about file-systems/open-files.
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbApiCapability { }
         Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
             [PSCustomObject]@{ total_item_count = 0 }
         } -ParameterFilter { $Uri -like '*file-systems/open-files*' }
@@ -260,6 +272,30 @@ Describe 'Invoke-PfbApiRequest - unaffected return paths' {
         }
 
         ($result | Measure-Object).Count | Should -Be 0
+        Should -Invoke Invoke-RestMethod -Times 1 -Exactly -ModuleName PureStorageFlashBladePowerShell
+    }
+
+    It 'returns a multi-key body carrying total_item_count as direct data' {
+        # The classifier's MIDDLE case, and the one a silent broadening would eat: a body with
+        # total_item_count PLUS another key, with no total_only requested, is direct data.
+        # Rewriting the exactly-one-key check as `$responseKeys -contains 'total_item_count'`
+        # passes every other test in this file and fails only this one.
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbApiCapability { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-RestMethod {
+            [PSCustomObject]@{ total_item_count = 0; continuation_token = $null }
+        } -ParameterFilter { $Uri -like '*buckets*' }
+
+        $result = InModuleScope PureStorageFlashBladePowerShell {
+            $array = [PSCustomObject]@{
+                Endpoint = 'fb.test'; ApiVersion = '2.26'; AuthToken = 'tok'
+                ApiToken = $null; AuthMethod = 'ApiToken'; SkipCertificateCheck = $false
+            }
+            Invoke-PfbApiRequest -Array $array -Method GET -Endpoint 'buckets' -QueryParams @{}
+        }
+
+        ($result | Measure-Object).Count | Should -Be 1
+        $result.PSObject.Properties.Name | Should -Contain 'continuation_token'
+        Should -Invoke Invoke-RestMethod -Times 1 -Exactly -ModuleName PureStorageFlashBladePowerShell
     }
 
     It 'keeps a no-items total_item_count-only body when total_only was requested' {

--- a/Tests/PfbEmptyPipelineGuardCoverage.Tests.ps1
+++ b/Tests/PfbEmptyPipelineGuardCoverage.Tests.ps1
@@ -1,0 +1,260 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+# Issue #121. The empty-pipeline guard is a 130-file generated population, and a generated
+# population decays silently: a new collect-in-process cmdlet arrives without the guard, or an
+# existing guard drifts into a scriptblock or onto the wrong hashtable and keeps passing the
+# generator's own AlreadyPresent recognizer (tools/Update-PfbEmptyPipelineGuards.ps1) because
+# that recognizer matches the command name anywhere in the end block's subtree.
+#
+# These are AST tripwires, not behaviour tests. They run in CI on every change; the generator
+# only runs when somebody invokes it, so this is the durable gate of the two.
+
+BeforeAll {
+    $script:moduleRoot = Split-Path -Parent $PSScriptRoot
+    $script:publicRoot = Join-Path $script:moduleRoot 'Public'
+
+    # Walk a node's parent chain up to (and excluding) the owning NamedBlockAst, reporting
+    # whether any ScriptBlockExpressionAst sits in between. A statement inside a scriptblock
+    # returns from the scriptblock, not from the cmdlet.
+    function Test-PfbNestedInScriptBlockExpression {
+        param(
+            [System.Management.Automation.Language.Ast]$Node,
+            [System.Management.Automation.Language.Ast]$Stop
+        )
+
+        $cursor = $Node.Parent
+        while ($null -ne $cursor -and -not [object]::ReferenceEquals($cursor, $Stop)) {
+            if ($cursor -is [System.Management.Automation.Language.ScriptBlockExpressionAst]) {
+                return $true
+            }
+            $cursor = $cursor.Parent
+        }
+        return $false
+    }
+
+    # The variable name a CommandAst passes to a named parameter, or $null when the argument is
+    # not a bare variable expression (or the parameter is absent).
+    function Get-PfbParameterVariableName {
+        param(
+            [System.Management.Automation.Language.CommandAst]$Command,
+            [string]$ParameterName
+        )
+
+        $elements = @($Command.CommandElements)
+        for ($i = 0; $i -lt $elements.Count; $i++) {
+            $element = $elements[$i]
+            if ($element -isnot [System.Management.Automation.Language.CommandParameterAst]) { continue }
+            if ($element.ParameterName -ne $ParameterName) { continue }
+
+            # -Param:$value packs the argument onto the CommandParameterAst itself.
+            $argument = $element.Argument
+            if ($null -eq $argument -and ($i + 1) -lt $elements.Count) {
+                $argument = $elements[$i + 1]
+            }
+            if ($argument -is [System.Management.Automation.Language.VariableExpressionAst]) {
+                return $argument.VariablePath.UserPath
+            }
+            return $null
+        }
+        return $null
+    }
+
+    $script:records = @(
+        foreach ($file in (Get-ChildItem -Path $script:publicRoot -Filter '*.ps1' -Recurse -File)) {
+            $relative = $file.FullName.Substring($script:moduleRoot.Length).TrimStart('\', '/').Replace('\', '/')
+
+            $tokens = $null
+            $errors = $null
+            $ast = [System.Management.Automation.Language.Parser]::ParseFile(
+                $file.FullName, [ref]$tokens, [ref]$errors)
+            if ($errors.Count -gt 0) {
+                throw "Parse errors in ${relative}: $(($errors | ForEach-Object { $_.Message }) -join '; ')"
+            }
+
+            $functions = @($ast.FindAll({
+                        param($node)
+                        $node -is [System.Management.Automation.Language.FunctionDefinitionAst]
+                    }, $true))
+
+            foreach ($function in $functions) {
+                $endBlock = $function.Body.EndBlock
+                $processBlock = $function.Body.ProcessBlock
+                $hasNamedEnd = ($null -ne $endBlock -and -not $endBlock.Unnamed)
+                $hasProcess = ($null -ne $processBlock -and -not $processBlock.Unnamed)
+
+                $invokeCalls = @()
+                $guardCalls = @()
+                if ($null -ne $endBlock) {
+                    $invokeCalls = @($endBlock.FindAll({
+                                param($node)
+                                $node -is [System.Management.Automation.Language.CommandAst] -and
+                                $node.GetCommandName() -eq 'Invoke-PfbApiRequest'
+                            }, $true))
+
+                    $guardCalls = @($endBlock.FindAll({
+                                param($node)
+                                $node -is [System.Management.Automation.Language.CommandAst] -and
+                                $node.GetCommandName() -eq 'Test-PfbEmptyPipelineRead'
+                            }, $true))
+                }
+
+                # Call-shape invariant: the request must stay a direct statement of the cmdlet
+                # block, not a statement of some nested scriptblock.
+                $allInvokes = @($function.FindAll({
+                            param($node)
+                            $node -is [System.Management.Automation.Language.CommandAst] -and
+                            $node.GetCommandName() -eq 'Invoke-PfbApiRequest'
+                        }, $true))
+                $nestedInvokes = @($allInvokes | Where-Object {
+                        Test-PfbNestedInScriptBlockExpression -Node $_ -Stop $function
+                    })
+
+                # Guard placement: a guard nested in a scriptblock returns from the scriptblock.
+                $nestedGuards = @($guardCalls | Where-Object {
+                        Test-PfbNestedInScriptBlockExpression -Node $_ -Stop $endBlock
+                    })
+
+                $guardQueryVars = @($guardCalls |
+                    ForEach-Object { Get-PfbParameterVariableName -Command $_ -ParameterName 'QueryParams' } |
+                    Where-Object { $_ })
+                $invokeQueryVars = @($invokeCalls |
+                    ForEach-Object { Get-PfbParameterVariableName -Command $_ -ParameterName 'QueryParams' } |
+                    Where-Object { $_ })
+
+                # Does the guard read the same hashtable the request is handed? A guard on some
+                # other variable is inert.
+                $queryVarMismatch = $false
+                if ($guardCalls.Count -gt 0) {
+                    if ($guardQueryVars.Count -ne $guardCalls.Count) {
+                        $queryVarMismatch = $true
+                    }
+                    else {
+                        foreach ($name in $invokeQueryVars) {
+                            if ($name -notin $guardQueryVars) { $queryVarMismatch = $true }
+                        }
+                    }
+                }
+
+                # Any unconditional index-write to the guarded hashtable AFTER the guard makes the
+                # guard unable to fire for the very key it is supposed to see missing.
+                $queryWriteAfterGuard = $false
+                if ($guardCalls.Count -gt 0 -and $guardQueryVars.Count -gt 0) {
+                    $firstGuardOffset = ($guardCalls |
+                        ForEach-Object { $_.Extent.StartOffset } |
+                        Measure-Object -Minimum).Minimum
+
+                    $indexAssignments = @($endBlock.FindAll({
+                                param($node)
+                                $node -is [System.Management.Automation.Language.AssignmentStatementAst] -and
+                                $node.Left -is [System.Management.Automation.Language.IndexExpressionAst] -and
+                                $node.Left.Target -is [System.Management.Automation.Language.VariableExpressionAst]
+                            }, $true))
+
+                    foreach ($assignment in $indexAssignments) {
+                        if ($assignment.Left.Target.VariablePath.UserPath -notin $guardQueryVars) { continue }
+                        if ($assignment.Extent.StartOffset -gt $firstGuardOffset) {
+                            $queryWriteAfterGuard = $true
+                        }
+                    }
+                }
+
+                [PSCustomObject]@{
+                    File                                = $relative
+                    Function                            = $function.Name
+                    Line                                = $function.Extent.StartLineNumber
+                    HasProcess                          = $hasProcess
+                    HasNamedEnd                         = $hasNamedEnd
+                    InvokeCallsInEnd                    = $invokeCalls.Count
+                    InvokeCallsTotal                    = $allInvokes.Count
+                    GuardCallsInEnd                     = $guardCalls.Count
+                    InvokeNestedInScriptBlockExpression = ($nestedInvokes.Count -gt 0)
+                    NestedInvokeLines                   = @($nestedInvokes | ForEach-Object { $_.Extent.StartLineNumber })
+                    GuardNestedInScriptBlockExpression  = ($nestedGuards.Count -gt 0)
+                    QueryVarMismatch                    = $queryVarMismatch
+                    QueryWriteAfterGuard                = $queryWriteAfterGuard
+                }
+            }
+        }
+    )
+
+    $script:qualifying = @($script:records | Where-Object {
+            $_.HasProcess -and $_.HasNamedEnd -and $_.InvokeCallsInEnd -gt 0
+        })
+    $script:totalInvokeCalls = (@($script:records | ForEach-Object { $_.InvokeCallsTotal }) |
+        Measure-Object -Sum).Sum
+}
+
+Describe 'Empty-pipeline guard coverage' {
+
+    It 'scans a population large enough for the other assertions to mean something' {
+        # Not a pinned census -- the shipped rail must not red on legitimate surface growth.
+        # These floors only prove the AST walk found the surface at all.
+        $script:records.Count | Should -BeGreaterThan 400
+        $script:qualifying.Count | Should -BeGreaterThan 100
+        $script:totalInvokeCalls | Should -BeGreaterThan 500
+    }
+
+    It 'guards every collect-in-process function that issues its request from end' {
+        # Explicit and empty. Get-PfbNetworkConnectionStatistics, Get-PfbFleetKey and
+        # Set-PfbContext are NOT exclusions -- they never satisfy the qualifying predicate.
+        $allowedUnguarded = @()
+
+        $offenders = @($script:records | Where-Object {
+                $_.HasProcess -and $_.HasNamedEnd -and $_.InvokeCallsInEnd -gt 0 -and
+                $_.GuardCallsInEnd -eq 0 -and $_.Function -notin $allowedUnguarded
+            })
+        $detail = @($offenders | ForEach-Object { "$($_.File): $($_.Function)" }) -join "`n"
+
+        $detail | Should -BeNullOrEmpty -Because "every collect-in-process/request-in-end function must guard an empty pipeline; offenders:`n$detail"
+    }
+
+    It 'keeps every Invoke-PfbApiRequest call directly in the cmdlet block' {
+        # A request issued from inside a scriptblock is unreachable by a `return` guard.
+        $nested = @($script:records | Where-Object InvokeNestedInScriptBlockExpression)
+        $detail = @($nested | ForEach-Object {
+                "$($_.File):$($_.NestedInvokeLines -join ',') $($_.Function)"
+            }) -join "`n"
+
+        $detail | Should -BeNullOrEmpty -Because "Invoke-PfbApiRequest must stay directly in the cmdlet block; nested sites:`n$detail"
+    }
+
+    It 'writes no query key unconditionally after the guard' {
+        # A guard is only protective if no query key is written after it. Get-PfbRemoteArray is
+        # the one legitimate exception: current_fleet_only is a scope flag, not a selector, and
+        # it is written on both branches of an if/else -- so its guard is placed ABOVE that write
+        # (see Task 4 / Step 10b of the issue #121 plan). Allowlisted by NAME, never by an
+        # occurrence count: it carries two such writes today, one per branch, and collapsing the
+        # branches must not red this rail.
+        $allowedPostGuardWrite = @('Get-PfbRemoteArray')
+
+        $postGuardWriters = @($script:records | Where-Object {
+                $_.GuardCallsInEnd -gt 0 -and $_.QueryWriteAfterGuard -and
+                $_.Function -notin $allowedPostGuardWrite
+            })
+        $detail = @($postGuardWriters | ForEach-Object { "$($_.File): $($_.Function)" }) -join "`n"
+
+        $detail | Should -BeNullOrEmpty -Because "a query key written after the guard makes the guard unable to fire; offenders:`n$detail"
+    }
+
+    It 'places every guard where it can actually return, on the hashtable the request receives' {
+        # Guard CORRECTNESS, not guard existence. The generator's AlreadyPresent recognizer
+        # matches the command name anywhere in the end block's subtree, so a guard that drifted
+        # into a ForEach-Object scriptblock, or that reads a hashtable the request never sees,
+        # still reports a clean fixed point from the tool. Both allowlists are explicit and empty.
+        $allowedNestedGuard = @()
+        $allowedQueryVarMismatch = @()
+
+        $nestedGuards = @($script:records | Where-Object {
+                $_.GuardNestedInScriptBlockExpression -and $_.Function -notin $allowedNestedGuard
+            })
+        $nestedDetail = @($nestedGuards | ForEach-Object { "$($_.File): $($_.Function)" }) -join "`n"
+        $nestedDetail | Should -BeNullOrEmpty -Because "a guard inside a scriptblock returns from the scriptblock, not the cmdlet; offenders:`n$nestedDetail"
+
+        $mismatched = @($script:records | Where-Object {
+                $_.GuardCallsInEnd -gt 0 -and $_.QueryVarMismatch -and
+                $_.Function -notin $allowedQueryVarMismatch
+            })
+        $mismatchDetail = @($mismatched | ForEach-Object { "$($_.File): $($_.Function)" }) -join "`n"
+        $mismatchDetail | Should -BeNullOrEmpty -Because "a guard must read the same hashtable the request is handed; offenders:`n$mismatchDetail"
+    }
+}

--- a/Tests/PfbEmptyPipelineGuardCoverage.Tests.ps1
+++ b/Tests/PfbEmptyPipelineGuardCoverage.Tests.ps1
@@ -135,26 +135,121 @@ BeforeAll {
                     }
                 }
 
-                # Any unconditional index-write to the guarded hashtable AFTER the guard makes the
-                # guard unable to fire for the very key it is supposed to see missing.
+                # Any write to the guarded hashtable AFTER the guard makes the guard unable to fire
+                # for the very key it is supposed to see missing.
+                #
+                # An index-assignment-only detector is NOT enough, and the mirror harm is worse than
+                # the one this rail was written for: hoisting a guard above
+                # `Add-PfbCommonQueryParams -Into $queryParams` leaves the guard reading an empty
+                # hashtable on EVERY piped invocation, so a legitimate piped read carrying names
+                # silently returns nothing. That shape passes a literal-key detector and also
+                # satisfies the generator's AlreadyPresent recognizer. (This repo has already paid
+                # once for a literal-key-only detector -- see the 269-endpoint drift blind spot.)
+                #
+                # So match every write form the language offers on a variable we already know by
+                # name: $q[...] = , $q.Foo = , $q.Add()/.Remove()/.Clear()/.set_Item(), and any
+                # command handing the variable to an -Into parameter (the repo's writer convention).
                 $queryWriteAfterGuard = $false
                 if ($guardCalls.Count -gt 0 -and $guardQueryVars.Count -gt 0) {
                     $firstGuardOffset = ($guardCalls |
                         ForEach-Object { $_.Extent.StartOffset } |
                         Measure-Object -Minimum).Minimum
 
-                    $indexAssignments = @($endBlock.FindAll({
+                    $mutatingMethods = @('add', 'remove', 'clear', 'set_item')
+
+                    $writeSites = @($endBlock.FindAll({
                                 param($node)
-                                $node -is [System.Management.Automation.Language.AssignmentStatementAst] -and
-                                $node.Left -is [System.Management.Automation.Language.IndexExpressionAst] -and
-                                $node.Left.Target -is [System.Management.Automation.Language.VariableExpressionAst]
+
+                                # $q['k'] = v   /   $q.k = v
+                                if ($node -is [System.Management.Automation.Language.AssignmentStatementAst]) {
+                                    $left = $node.Left
+                                    if ($left -is [System.Management.Automation.Language.IndexExpressionAst] -and
+                                        $left.Target -is [System.Management.Automation.Language.VariableExpressionAst]) {
+                                        return $true
+                                    }
+                                    if ($left -is [System.Management.Automation.Language.MemberExpressionAst] -and
+                                        $left.Expression -is [System.Management.Automation.Language.VariableExpressionAst]) {
+                                        return $true
+                                    }
+                                    return $false
+                                }
+
+                                # $q.Add(...) and friends
+                                if ($node -is [System.Management.Automation.Language.InvokeMemberExpressionAst]) {
+                                    return ($node.Expression -is [System.Management.Automation.Language.VariableExpressionAst])
+                                }
+
+                                # Add-PfbCommonQueryParams -Into $q
+                                if ($node -is [System.Management.Automation.Language.CommandAst]) {
+                                    return $true
+                                }
+
+                                return $false
                             }, $true))
 
-                    foreach ($assignment in $indexAssignments) {
-                        if ($assignment.Left.Target.VariablePath.UserPath -notin $guardQueryVars) { continue }
-                        if ($assignment.Extent.StartOffset -gt $firstGuardOffset) {
+                    foreach ($site in $writeSites) {
+                        if ($site.Extent.StartOffset -le $firstGuardOffset) { continue }
+
+                        $writtenVar = $null
+                        if ($site -is [System.Management.Automation.Language.AssignmentStatementAst]) {
+                            $left = $site.Left
+                            if ($left -is [System.Management.Automation.Language.IndexExpressionAst]) {
+                                $writtenVar = $left.Target.VariablePath.UserPath
+                            }
+                            else {
+                                $writtenVar = $left.Expression.VariablePath.UserPath
+                            }
+                        }
+                        elseif ($site -is [System.Management.Automation.Language.InvokeMemberExpressionAst]) {
+                            $memberName = "$($site.Member)"
+                            if ($memberName.ToLowerInvariant() -notin $mutatingMethods) { continue }
+                            $writtenVar = $site.Expression.VariablePath.UserPath
+                        }
+                        else {
+                            $writtenVar = Get-PfbParameterVariableName -Command $site -ParameterName 'Into'
+                        }
+
+                        if ($writtenVar -and $writtenVar -in $guardQueryVars) {
                             $queryWriteAfterGuard = $true
                         }
+                    }
+                }
+
+                # I-1, first half: a guard that runs AFTER the request cannot stop it. Offsets, not
+                # statement indexes, so this survives any nesting the other rails allow.
+                $guardAfterSomeInvoke = $false
+                if ($guardCalls.Count -gt 0 -and $invokeCalls.Count -gt 0) {
+                    $firstGuardOffset = ($guardCalls |
+                        ForEach-Object { $_.Extent.StartOffset } |
+                        Measure-Object -Minimum).Minimum
+                    $firstInvokeOffset = ($invokeCalls |
+                        ForEach-Object { $_.Extent.StartOffset } |
+                        Measure-Object -Minimum).Minimum
+                    $guardAfterSomeInvoke = ($firstGuardOffset -gt $firstInvokeOffset)
+                }
+
+                # I-1, second half: the predicate is only a guard if its answer is acted on. A bare
+                # `Test-PfbEmptyPipelineRead ...` statement, or `$null = Test-...`, evaluates the
+                # predicate and discards it -- and still counts as AlreadyPresent to the generator.
+                # Require the call to BE the condition of an if whose taken branch returns.
+                $guardReturns = $false
+                foreach ($guard in $guardCalls) {
+                    $pipeline = $guard.Parent
+                    if ($pipeline -isnot [System.Management.Automation.Language.PipelineAst]) { continue }
+                    $ifStatement = $pipeline.Parent
+                    if ($ifStatement -isnot [System.Management.Automation.Language.IfStatementAst]) { continue }
+
+                    foreach ($clause in $ifStatement.Clauses) {
+                        if (-not [object]::ReferenceEquals($clause.Item1, $pipeline)) { continue }
+                        $returns = @($clause.Item2.FindAll({
+                                    param($node)
+                                    $node -is [System.Management.Automation.Language.ReturnStatementAst]
+                                }, $true) | Where-Object {
+                                # A return inside a scriptblock in the branch returns from the
+                                # scriptblock, not the cmdlet.
+                                -not (Test-PfbNestedInScriptBlockExpression -Node $_ -Stop $clause.Item2)
+                            })
+                        if ($returns.Count -gt 0) { $guardReturns = $true }
                     }
                 }
 
@@ -172,6 +267,8 @@ BeforeAll {
                     GuardNestedInScriptBlockExpression  = ($nestedGuards.Count -gt 0)
                     QueryVarMismatch                    = $queryVarMismatch
                     QueryWriteAfterGuard                = $queryWriteAfterGuard
+                    GuardAfterSomeInvoke                = $guardAfterSomeInvoke
+                    GuardReturns                        = $guardReturns
                 }
             }
         }
@@ -182,6 +279,8 @@ BeforeAll {
         })
     $script:totalInvokeCalls = (@($script:records | ForEach-Object { $_.InvokeCallsTotal }) |
         Measure-Object -Sum).Sum
+    $script:endBlockInvokeCalls = (@($script:records | ForEach-Object { $_.InvokeCallsInEnd }) |
+        Measure-Object -Sum).Sum
 }
 
 Describe 'Empty-pipeline guard coverage' {
@@ -189,9 +288,16 @@ Describe 'Empty-pipeline guard coverage' {
     It 'scans a population large enough for the other assertions to mean something' {
         # Not a pinned census -- the shipped rail must not red on legitimate surface growth.
         # These floors only prove the AST walk found the surface at all.
+        #
+        # The load-bearing one is $script:qualifying (130 measured): it is computed from
+        # InvokeCallsInEnd, so an end-block detector regression drives it to zero and reds the
+        # rail rather than silently emptying the coverage It. The end-block call floor is set on
+        # that same metric for the same reason. The whole-function total is the loosest of the
+        # three and is floored with headroom, so a consolidation refactor cannot red it.
         $script:records.Count | Should -BeGreaterThan 400
         $script:qualifying.Count | Should -BeGreaterThan 100
-        $script:totalInvokeCalls | Should -BeGreaterThan 500
+        $script:endBlockInvokeCalls | Should -BeGreaterThan 250
+        $script:totalInvokeCalls | Should -BeGreaterThan 400
     }
 
     It 'guards every collect-in-process function that issues its request from end' {
@@ -204,7 +310,6 @@ Describe 'Empty-pipeline guard coverage' {
                 $_.GuardCallsInEnd -eq 0 -and $_.Function -notin $allowedUnguarded
             })
         $detail = @($offenders | ForEach-Object { "$($_.File): $($_.Function)" }) -join "`n"
-
         $detail | Should -BeNullOrEmpty -Because "every collect-in-process/request-in-end function must guard an empty pipeline; offenders:`n$detail"
     }
 
@@ -214,7 +319,6 @@ Describe 'Empty-pipeline guard coverage' {
         $detail = @($nested | ForEach-Object {
                 "$($_.File):$($_.NestedInvokeLines -join ',') $($_.Function)"
             }) -join "`n"
-
         $detail | Should -BeNullOrEmpty -Because "Invoke-PfbApiRequest must stay directly in the cmdlet block; nested sites:`n$detail"
     }
 
@@ -232,7 +336,6 @@ Describe 'Empty-pipeline guard coverage' {
                 $_.Function -notin $allowedPostGuardWrite
             })
         $detail = @($postGuardWriters | ForEach-Object { "$($_.File): $($_.Function)" }) -join "`n"
-
         $detail | Should -BeNullOrEmpty -Because "a query key written after the guard makes the guard unable to fire; offenders:`n$detail"
     }
 
@@ -256,5 +359,66 @@ Describe 'Empty-pipeline guard coverage' {
             })
         $mismatchDetail = @($mismatched | ForEach-Object { "$($_.File): $($_.Function)" }) -join "`n"
         $mismatchDetail | Should -BeNullOrEmpty -Because "a guard must read the same hashtable the request is handed; offenders:`n$mismatchDetail"
+    }
+
+    It 'runs every guard before the request, and acts on its answer' {
+        # Existence, placement and subject are not enough. Two more shapes are inert AND still
+        # satisfy the generator's AlreadyPresent recognizer, so without these the drift gate and
+        # this rail would both read green on a guard that does nothing:
+        #   - a guard sitting BELOW the Invoke-PfbApiRequest it is meant to stop;
+        #   - a bare `Test-PfbEmptyPipelineRead ...` (or `$null = Test-...`) whose boolean is
+        #     evaluated and thrown away.
+        # Both allowlists are explicit and empty.
+        $allowedGuardAfterInvoke = @()
+        $allowedGuardWithoutReturn = @()
+
+        $late = @($script:records | Where-Object {
+                $_.GuardAfterSomeInvoke -and $_.Function -notin $allowedGuardAfterInvoke
+            })
+        $lateDetail = @($late | ForEach-Object { "$($_.File): $($_.Function)" }) -join "`n"
+        $lateDetail | Should -BeNullOrEmpty -Because "a guard below the request cannot stop it; offenders:`n$lateDetail"
+
+        $inert = @($script:records | Where-Object {
+                $_.GuardCallsInEnd -gt 0 -and -not $_.GuardReturns -and
+                $_.Function -notin $allowedGuardWithoutReturn
+            })
+        $inertDetail = @($inert | ForEach-Object { "$($_.File): $($_.Function)" }) -join "`n"
+        $inertDetail | Should -BeNullOrEmpty -Because "a guard whose answer is discarded never returns; offenders:`n$inertDetail"
+    }
+
+    It 'has a working scriptblock-nesting detector' {
+        # The one one-way predicate in this file. Every other detector fails safe -- a broken
+        # Get-PfbParameterVariableName drives QueryVarMismatch true and reds, a broken guard
+        # finder reds the coverage It -- but if Test-PfbNestedInScriptBlockExpression regressed to
+        # always returning $false, the call-shape It and the nested half of the placement It would
+        # both pass vacuously and no floor would notice. So assert the predicate against a fixture
+        # with a known answer in each direction, independent of the tree.
+        $fixture = @'
+function Test-Fixture {
+    end {
+        Invoke-PfbApiRequest -Endpoint 'direct'
+        1..2 | ForEach-Object { Invoke-PfbApiRequest -Endpoint 'nested' }
+    }
+}
+'@
+        $fixtureAst = [System.Management.Automation.Language.Parser]::ParseInput(
+            $fixture, [ref]$null, [ref]$null)
+        $fixtureFunction = $fixtureAst.Find({
+                param($node)
+                $node -is [System.Management.Automation.Language.FunctionDefinitionAst]
+            }, $true)
+
+        $calls = @($fixtureFunction.FindAll({
+                    param($node)
+                    $node -is [System.Management.Automation.Language.CommandAst] -and
+                    $node.GetCommandName() -eq 'Invoke-PfbApiRequest'
+                }, $true))
+        $calls.Count | Should -Be 2
+
+        $answers = @($calls | ForEach-Object {
+                Test-PfbNestedInScriptBlockExpression -Node $_ -Stop $fixtureFunction
+            })
+        $answers[0] | Should -BeFalse -Because 'the first call is a direct statement of the end block'
+        $answers[1] | Should -BeTrue -Because 'the second call is inside a ForEach-Object scriptblock'
     }
 }

--- a/Tests/Test-PfbEmptyPipelineRead.Tests.ps1
+++ b/Tests/Test-PfbEmptyPipelineRead.Tests.ps1
@@ -49,12 +49,35 @@ Describe 'Test-PfbEmptyPipelineRead' {
 
     It 'treats a null query hashtable as empty without throwing under StrictMode' {
         InModuleScope PureStorageFlashBladePowerShell {
+            # Measured: Set-StrictMode in the It's own scope does NOT cross into the module's
+            # session state -- with it set only there, deleting the $null clause from
+            # Private/Test-PfbEmptyPipelineRead.ps1 leaves all four tests green on both editions.
+            # It has to be set HERE, inside InModuleScope, to reach the callee.
+            Set-StrictMode -Version Latest
             function Invoke-PredicateFixture {
                 [CmdletBinding()]
                 param([Parameter(ValueFromPipeline)][string]$Name)
                 end { Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $null }
             }
 
+            @() | Invoke-PredicateFixture | Should -BeTrue
+        }
+    }
+
+    It 'keys off ExpectingInput: one fixture, one empty query, opposite answers' {
+        # The ExpectingInput half rested on a single direct-invocation case. This holds the
+        # fixture and the final query identical and varies only the invocation form, so
+        # deleting the ExpectingInput short-circuit flips the direct half and reds this test.
+        InModuleScope PureStorageFlashBladePowerShell {
+            function Invoke-PredicateFixture {
+                [CmdletBinding()]
+                param([Parameter(ValueFromPipeline)][string]$Name)
+                begin { $queryParams = @{} }
+                process { if ($Name) { $queryParams['names'] = $Name } }
+                end { Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams }
+            }
+
+            Invoke-PredicateFixture | Should -BeFalse
             @() | Invoke-PredicateFixture | Should -BeTrue
         }
     }

--- a/Tests/Test-PfbEmptyPipelineRead.Tests.ps1
+++ b/Tests/Test-PfbEmptyPipelineRead.Tests.ps1
@@ -1,0 +1,61 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    Import-Module (Join-Path (Split-Path -Parent $PSScriptRoot) `
+            'PureStorageFlashBladePowerShell.psd1') -Force
+}
+
+Describe 'Test-PfbEmptyPipelineRead' {
+    It 'returns true for a piped invocation whose final query is empty' {
+        InModuleScope PureStorageFlashBladePowerShell {
+            function Invoke-PredicateFixture {
+                [CmdletBinding()]
+                param([Parameter(ValueFromPipeline)][string]$Name)
+                begin { $queryParams = @{} }
+                process { if ($Name) { $queryParams['names'] = $Name } }
+                end { Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams }
+            }
+
+            @() | Invoke-PredicateFixture | Should -BeTrue
+        }
+    }
+
+    It 'returns false for a direct invocation whose final query is empty' {
+        InModuleScope PureStorageFlashBladePowerShell {
+            function Invoke-PredicateFixture {
+                [CmdletBinding()]
+                param([Parameter(ValueFromPipeline)][string]$Name)
+                end { Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams @{} }
+            }
+
+            Invoke-PredicateFixture | Should -BeFalse
+        }
+    }
+
+    It 'returns false when a piped invocation has a surviving final query key' {
+        InModuleScope PureStorageFlashBladePowerShell {
+            function Invoke-PredicateFixture {
+                [CmdletBinding()]
+                param([Parameter(ValueFromPipeline)][string]$Name)
+                end {
+                    Test-PfbEmptyPipelineRead -Caller $PSCmdlet `
+                        -QueryParams @{ filter = "name='kept'" }
+                }
+            }
+
+            @() | Invoke-PredicateFixture | Should -BeFalse
+        }
+    }
+
+    It 'treats a null query hashtable as empty without throwing under StrictMode' {
+        InModuleScope PureStorageFlashBladePowerShell {
+            function Invoke-PredicateFixture {
+                [CmdletBinding()]
+                param([Parameter(ValueFromPipeline)][string]$Name)
+                end { Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $null }
+            }
+
+            @() | Invoke-PredicateFixture | Should -BeTrue
+        }
+    }
+}

--- a/Tests/Update-PfbEmptyPipelineGuards.Tests.ps1
+++ b/Tests/Update-PfbEmptyPipelineGuards.Tests.ps1
@@ -1,0 +1,379 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+<#
+.SYNOPSIS
+    Tests for tools/Update-PfbEmptyPipelineGuards.ps1, the generator that inserts one
+    empty-pipeline guard statement into every collect-then-request public cmdlet.
+.DESCRIPTION
+    Notes on deliberate choices here:
+
+    * Every path derives from $PSScriptRoot. The Pester runner does not run with the repo
+      root as its working directory, so a CWD-relative path silently resolves elsewhere.
+
+    * The population is re-derived from the source AST by the generator itself. This file
+      never reads the outer census CSV: a future cmdlet added to Public/ must be discovered,
+      not compared against a frozen list.
+
+    * Synthetic fixtures are parsed but never executed, so they reference $Array and
+      Invoke-PfbApiRequest without either existing.
+
+    * The "Unnamed end block" fixture is the trap this whole predicate exists for: the
+      parser SYNTHESISES an end block for a function that declared no named blocks at all,
+      so `$null -ne $Body.EndBlock` alone is true for nearly every function in the module.
+      Only a NAMED end block paired with a process block is a collect-then-request shape.
+
+    * The real-tree fixed point is asserted with -WhatIf, which reports what WOULD change
+      and writes nothing -- the same strength as write-twice-and-compare with no chance of
+      dirtying tracked Public/ files when it fails.
+#>
+
+BeforeAll {
+    $script:repoRoot = Split-Path -Parent $PSScriptRoot
+    $script:generator = Join-Path $script:repoRoot 'tools/Update-PfbEmptyPipelineGuards.ps1'
+    $script:guard = 'if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }'
+
+    function New-GuardFixture {
+        param([string]$Root, [string]$Name, [string[]]$Lines, [string]$Newline = "`n")
+        $public = Join-Path $Root 'Public'
+        New-Item -ItemType Directory -Path $public -Force | Out-Null
+        $path = Join-Path $public "$Name.ps1"
+        [System.IO.File]::WriteAllText(
+            $path,
+            ($Lines -join $Newline) + $Newline,
+            (New-Object System.Text.UTF8Encoding($false)))
+        return $path
+    }
+
+    # Byte-exact "unchanged on disk" evidence, as one comparable string. Comparing the raw
+    # byte arrays with Should -Be works but reports a several-hundred-element diff on
+    # failure; the hex signature fails in one readable line and is just as exact.
+    function Get-FixtureByteSignature {
+        param([string]$Path)
+        [System.BitConverter]::ToString([System.IO.File]::ReadAllBytes($Path))
+    }
+
+    # A plain collect-then-request shape: begin/process/end, one request in the end block.
+    function Get-NormalFixtureLines {
+        param([string]$FunctionName = 'Get-FixtureNormal')
+        @(
+            "function $FunctionName {"
+            '    [CmdletBinding()]'
+            '    param('
+            '        [Parameter(ValueFromPipeline)] [string[]]$Name,'
+            '        [Parameter()] [PSCustomObject]$Array'
+            '    )'
+            '    begin { $allNames = @() }'
+            '    process { if ($Name) { $allNames += $Name } }'
+            '    end {'
+            '        $queryParams = @{}'
+            '        if ($allNames.Count -gt 0) { $queryParams[''names''] = $allNames -join '','' }'
+            "        Invoke-PfbApiRequest -Array `$Array -Method GET -Endpoint 'fixtures' -QueryParams `$queryParams"
+            '    }'
+            '}'
+        )
+    }
+}
+
+Describe 'Update-PfbEmptyPipelineGuards - fixture shapes' {
+
+    It 'inserts exactly one guard immediately before the request in a normal function' {
+        $root = Join-Path $TestDrive ([guid]::NewGuid().ToString('N'))
+        $file = New-GuardFixture -Root $root -Name 'Get-FixtureNormal' -Lines (Get-NormalFixtureLines)
+
+        $summary = & $script:generator -PublicRoot $root -Confirm:$false
+
+        @($summary.Inserted).Count | Should -Be 1
+        @($summary.AlreadyPresent).Count | Should -Be 0
+        @($summary.SkippedNeedsHuman).Count | Should -Be 0
+
+        $text = [System.IO.File]::ReadAllText($file)
+        $text.Contains($script:guard) | Should -BeTrue
+
+        # Placement and indentation: the guard is the line directly above the request, at
+        # the request's own indent.
+        $lines = $text -split "`n"
+        $guardIndex = [array]::IndexOf($lines, '        ' + $script:guard)
+        $guardIndex | Should -BeGreaterThan 0
+        $lines[$guardIndex + 1] | Should -BeLike '        Invoke-PfbApiRequest *'
+
+        # Exactly one guard, not one per parse pass.
+        ([regex]::Matches($text, [regex]::Escape($script:guard))).Count | Should -Be 1
+    }
+
+    It 'inserts before the containing top-level statement when the request is nested in a try' {
+        $root = Join-Path $TestDrive ([guid]::NewGuid().ToString('N'))
+        $file = New-GuardFixture -Root $root -Name 'Get-FixtureTry' -Lines @(
+            'function Get-FixtureTry {'
+            '    [CmdletBinding()]'
+            '    param('
+            '        [Parameter(ValueFromPipeline)] [string[]]$Name,'
+            '        [Parameter()] [PSCustomObject]$Array'
+            '    )'
+            '    begin { $allNames = @() }'
+            '    process { if ($Name) { $allNames += $Name } }'
+            '    end {'
+            '        $queryParams = @{}'
+            '        try {'
+            "            Invoke-PfbApiRequest -Array `$Array -Method GET -Endpoint 'fixtures' -QueryParams `$queryParams"
+            '        }'
+            '        catch { throw }'
+            '    }'
+            '}'
+        )
+
+        $summary = & $script:generator -PublicRoot $root -Confirm:$false
+        @($summary.Inserted).Count | Should -Be 1
+
+        $lines = [System.IO.File]::ReadAllText($file) -split "`n"
+        $guardIndex = [array]::IndexOf($lines, '        ' + $script:guard)
+        $guardIndex | Should -BeGreaterThan 0
+        # The guard dominates the whole try statement rather than sitting inside it.
+        $lines[$guardIndex + 1] | Should -Be '        try {'
+    }
+
+    It 'leaves a function with no process block untouched' {
+        $root = Join-Path $TestDrive ([guid]::NewGuid().ToString('N'))
+        $file = New-GuardFixture -Root $root -Name 'Get-FixtureNoProcess' -Lines @(
+            'function Get-FixtureNoProcess {'
+            '    [CmdletBinding()]'
+            '    param([Parameter()] [PSCustomObject]$Array)'
+            '    begin { $queryParams = @{} }'
+            '    end {'
+            "        Invoke-PfbApiRequest -Array `$Array -Method GET -Endpoint 'fixtures' -QueryParams `$queryParams"
+            '    }'
+            '}'
+        )
+        $before = Get-FixtureByteSignature $file
+
+        $summary = & $script:generator -PublicRoot $root -Confirm:$false
+
+        @($summary.Inserted).Count | Should -Be 0
+        @($summary.SkippedNeedsHuman).Count | Should -Be 0
+        Get-FixtureByteSignature $file | Should -Be $before
+    }
+
+    It 'leaves a function whose end block is only the parser-synthesised Unnamed block untouched' {
+        $root = Join-Path $TestDrive ([guid]::NewGuid().ToString('N'))
+        $file = New-GuardFixture -Root $root -Name 'Get-FixtureUnnamedEnd' -Lines @(
+            'function Get-FixtureUnnamedEnd {'
+            '    [CmdletBinding()]'
+            '    param([Parameter()] [PSCustomObject]$Array)'
+            '    $queryParams = @{}'
+            "    Invoke-PfbApiRequest -Array `$Array -Method GET -Endpoint 'fixtures' -QueryParams `$queryParams"
+            '}'
+        )
+        $before = Get-FixtureByteSignature $file
+
+        # Pin the trap itself: this function DOES have a non-null EndBlock. Only the Unnamed
+        # flag distinguishes it, which is why the predicate cannot be a null check alone.
+        $tokens = $null; $errors = $null
+        $ast = [System.Management.Automation.Language.Parser]::ParseFile($file, [ref]$tokens, [ref]$errors)
+        $fn = @($ast.FindAll({
+                    $args[0] -is [System.Management.Automation.Language.FunctionDefinitionAst]
+                }, $true))[0]
+        $null -eq $fn.Body.EndBlock | Should -BeFalse
+        $fn.Body.EndBlock.Unnamed | Should -BeTrue
+
+        $summary = & $script:generator -PublicRoot $root -Confirm:$false
+
+        @($summary.Inserted).Count | Should -Be 0
+        @($summary.SkippedNeedsHuman).Count | Should -Be 0
+        Get-FixtureByteSignature $file | Should -Be $before
+    }
+
+    It 'routes a function with two requests in its end block to SkippedNeedsHuman, unedited' {
+        $root = Join-Path $TestDrive ([guid]::NewGuid().ToString('N'))
+        $file = New-GuardFixture -Root $root -Name 'Get-FixtureTwoCalls' -Lines @(
+            'function Get-FixtureTwoCalls {'
+            '    [CmdletBinding()]'
+            '    param('
+            '        [Parameter(ValueFromPipeline)] [string[]]$Name,'
+            '        [Parameter()] [PSCustomObject]$Array'
+            '    )'
+            '    begin { $allNames = @() }'
+            '    process { if ($Name) { $allNames += $Name } }'
+            '    end {'
+            '        $queryParams = @{}'
+            '        try {'
+            "            Invoke-PfbApiRequest -Array `$Array -Method GET -Endpoint 'primary' -QueryParams `$queryParams"
+            '        }'
+            '        catch {'
+            "            Invoke-PfbApiRequest -Array `$Array -Method GET -Endpoint 'fallback' -QueryParams `$queryParams"
+            '        }'
+            '    }'
+            '}'
+        )
+        $before = Get-FixtureByteSignature $file
+
+        $summary = & $script:generator -PublicRoot $root -Confirm:$false
+
+        @($summary.Inserted).Count | Should -Be 0
+        @($summary.SkippedNeedsHuman).Count | Should -Be 1
+        @($summary.SkippedNeedsHuman)[0] | Should -Be $file
+        Get-FixtureByteSignature $file | Should -Be $before
+    }
+
+    It 'routes a SupportsShouldProcess function to SkippedNeedsHuman, unedited' {
+        $root = Join-Path $TestDrive ([guid]::NewGuid().ToString('N'))
+        $file = New-GuardFixture -Root $root -Name 'Remove-FixtureThing' -Lines @(
+            'function Remove-FixtureThing {'
+            "    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]"
+            '    param('
+            '        [Parameter(ValueFromPipeline)] [string[]]$Name,'
+            '        [Parameter()] [PSCustomObject]$Array'
+            '    )'
+            '    begin { $allNames = @() }'
+            '    process { if ($Name) { $allNames += $Name } }'
+            '    end {'
+            '        $queryParams = @{}'
+            "        if (`$PSCmdlet.ShouldProcess('x', 'Delete')) {"
+            "            Invoke-PfbApiRequest -Array `$Array -Method DELETE -Endpoint 'fixtures' -QueryParams `$queryParams"
+            '        }'
+            '    }'
+            '}'
+        )
+        $before = Get-FixtureByteSignature $file
+
+        $summary = & $script:generator -PublicRoot $root -Confirm:$false
+
+        @($summary.Inserted).Count | Should -Be 0
+        @($summary.SkippedNeedsHuman).Count | Should -Be 1
+        Get-FixtureByteSignature $file | Should -Be $before
+    }
+
+    It 'routes a file on the explicit human-review list to SkippedNeedsHuman even when its shape is ordinary' {
+        # Get-PfbRemoteArray writes current_fleet_only on BOTH branches of an if/else, so its
+        # query hashtable is never empty at the request and a generated guard in the usual
+        # position would be inert. Its guard is placed by hand, above that write.
+        $root = Join-Path $TestDrive ([guid]::NewGuid().ToString('N'))
+        $file = New-GuardFixture -Root $root -Name 'Get-PfbRemoteArray' `
+            -Lines (Get-NormalFixtureLines -FunctionName 'Get-PfbRemoteArray')
+        $before = Get-FixtureByteSignature $file
+
+        $summary = & $script:generator -PublicRoot $root -Confirm:$false
+
+        @($summary.Inserted).Count | Should -Be 0
+        @($summary.SkippedNeedsHuman).Count | Should -Be 1
+        @($summary.SkippedNeedsHuman)[0] | Should -Be $file
+        Get-FixtureByteSignature $file | Should -Be $before
+    }
+
+    It 'reports a file that already carries the exact guard as AlreadyPresent and does not rewrite it' {
+        $root = Join-Path $TestDrive ([guid]::NewGuid().ToString('N'))
+        $lines = @(Get-NormalFixtureLines -FunctionName 'Get-FixtureGuarded')
+        # Splice the guard in above the request line, exactly where the generator puts it.
+        $requestIndex = [array]::IndexOf($lines, ($lines | Where-Object { $_ -like '*Invoke-PfbApiRequest*' } | Select-Object -First 1))
+        $withGuard = @($lines[0..($requestIndex - 1)]) + @('        ' + $script:guard) + @($lines[$requestIndex..($lines.Count - 1)])
+        $file = New-GuardFixture -Root $root -Name 'Get-FixtureGuarded' -Lines $withGuard
+        $before = Get-FixtureByteSignature $file
+
+        $summary = & $script:generator -PublicRoot $root -Confirm:$false
+
+        @($summary.Inserted).Count | Should -Be 0
+        @($summary.AlreadyPresent).Count | Should -Be 1
+        @($summary.SkippedNeedsHuman).Count | Should -Be 0
+        Get-FixtureByteSignature $file | Should -Be $before
+    }
+
+    It 'recognises an already-guarded file EVEN IF it is a human-review outlier' {
+        # Order is load-bearing: existing-guard first, human-review list second, shape third.
+        # If the list were consulted first, the hand-edited outliers would report
+        # SkippedNeedsHuman forever and the drift fixed point could never be reached.
+        $root = Join-Path $TestDrive ([guid]::NewGuid().ToString('N'))
+        $lines = @(Get-NormalFixtureLines -FunctionName 'Get-PfbRemoteArray')
+        $requestIndex = [array]::IndexOf($lines, ($lines | Where-Object { $_ -like '*Invoke-PfbApiRequest*' } | Select-Object -First 1))
+        $withGuard = @($lines[0..($requestIndex - 1)]) + @('        ' + $script:guard) + @($lines[$requestIndex..($lines.Count - 1)])
+        $file = New-GuardFixture -Root $root -Name 'Get-PfbRemoteArray' -Lines $withGuard
+
+        $summary = & $script:generator -PublicRoot $root -Confirm:$false
+
+        @($summary.AlreadyPresent).Count | Should -Be 1
+        @($summary.SkippedNeedsHuman).Count | Should -Be 0
+    }
+
+    It 'is idempotent: a second run over the same fixture root inserts nothing' {
+        $root = Join-Path $TestDrive ([guid]::NewGuid().ToString('N'))
+        $file = New-GuardFixture -Root $root -Name 'Get-FixtureIdempotent' `
+            -Lines (Get-NormalFixtureLines -FunctionName 'Get-FixtureIdempotent')
+
+        & $script:generator -PublicRoot $root -Confirm:$false | Out-Null
+        $afterFirst = Get-FixtureByteSignature $file
+
+        $second = & $script:generator -PublicRoot $root -Confirm:$false
+
+        @($second.Inserted).Count | Should -Be 0
+        @($second.AlreadyPresent).Count | Should -Be 1
+        Get-FixtureByteSignature $file | Should -Be $afterFirst
+    }
+
+    It 'writes nothing under -WhatIf but still reports what it would insert' {
+        $root = Join-Path $TestDrive ([guid]::NewGuid().ToString('N'))
+        $file = New-GuardFixture -Root $root -Name 'Get-FixtureWhatIf' `
+            -Lines (Get-NormalFixtureLines -FunctionName 'Get-FixtureWhatIf')
+        $before = Get-FixtureByteSignature $file
+
+        $summary = & $script:generator -PublicRoot $root -WhatIf
+
+        @($summary.Inserted).Count | Should -Be 1
+        Get-FixtureByteSignature $file | Should -Be $before
+    }
+}
+
+Describe 'Update-PfbEmptyPipelineGuards - encoding and line endings' {
+
+    It 'preserves LF line endings and writes no BOM' {
+        $root = Join-Path $TestDrive ([guid]::NewGuid().ToString('N'))
+        $file = New-GuardFixture -Root $root -Name 'Get-FixtureLf' `
+            -Lines (Get-NormalFixtureLines -FunctionName 'Get-FixtureLf') -Newline "`n"
+
+        & $script:generator -PublicRoot $root -Confirm:$false | Out-Null
+
+        $text = [System.IO.File]::ReadAllText($file)
+        $text.Contains("`r`n") | Should -BeFalse
+        $text.Contains($script:guard) | Should -BeTrue
+
+        $bytes = [System.IO.File]::ReadAllBytes($file)
+        # 0xEF 0xBB 0xBF is the UTF-8 BOM. No Public/*.ps1 carries one and the generator
+        # must not introduce one.
+        ($bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF) | Should -BeFalse
+    }
+
+    It 'preserves CRLF line endings and writes no BOM' {
+        $root = Join-Path $TestDrive ([guid]::NewGuid().ToString('N'))
+        $file = New-GuardFixture -Root $root -Name 'Get-FixtureCrlf' `
+            -Lines (Get-NormalFixtureLines -FunctionName 'Get-FixtureCrlf') -Newline "`r`n"
+
+        & $script:generator -PublicRoot $root -Confirm:$false | Out-Null
+
+        $text = [System.IO.File]::ReadAllText($file)
+        $text.Contains($script:guard) | Should -BeTrue
+        # Every LF in the file is part of a CRLF pair: no line was rewritten with a bare LF.
+        ([regex]::Matches($text, "`n")).Count | Should -Be ([regex]::Matches($text, "`r`n")).Count
+
+        $bytes = [System.IO.File]::ReadAllBytes($file)
+        ($bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF) | Should -BeFalse
+    }
+}
+
+Describe 'Update-PfbEmptyPipelineGuards - human-review list integrity' {
+
+    It 'throws when a human-review entry matches no file in the real tree' {
+        # The list is a [string[]] of leaf names. If a listed cmdlet is renamed or deleted,
+        # the entry must fail loudly rather than quietly protect nothing. Scoped to the real
+        # tree only, so synthetic fixture roots are not required to contain every entry.
+        { & $script:generator -WhatIf -HumanReviewFile 'Get-PfbNoSuchCmdlet.ps1' } |
+            Should -Throw -ExpectedMessage '*Get-PfbNoSuchCmdlet.ps1*'
+    }
+}
+
+Describe 'Update-PfbEmptyPipelineGuards - real tree' {
+
+    It 'is at a fixed point: a -WhatIf run over Public/ reports zero insertions and 130 guarded files' {
+        # Derived from the source AST on every run, so a newly added collect-then-request
+        # cmdlet raises this count and fails here rather than shipping unguarded.
+        $summary = & $script:generator -WhatIf
+
+        @($summary.Inserted).Count | Should -Be 0
+        @($summary.AlreadyPresent).Count | Should -Be 130
+        @($summary.SkippedNeedsHuman).Count | Should -Be 0
+    }
+}

--- a/Tests/coverage-baseline.psd1
+++ b/Tests/coverage-baseline.psd1
@@ -64,6 +64,21 @@
             'Committed dead-key report (REGRESSION guard, no spec cache required)'
             'Build-PfbDeadKeyReport regeneration (real spec cache required, PS7 only)'
             'Build-PfbDeadKeyReport classification (synthetic fixture, no spec cache, PS7 only)'
+            # Issue #121 empty-pipeline guards. Listed under BOTH editions: neither block
+            # carries a PS7 gate, neither reads the spec cache, and the generator deliberately
+            # declares `#Requires -Version 5.1` rather than 7.0 so its real-tree check runs on
+            # either leg. Both therefore contribute executed tests everywhere.
+            #
+            # These two are the reason this list matters more than MaxSkipped for #121. The
+            # coverage block re-derives the qualifying population from the AST of the tracked
+            # Public/*.ps1 files and asserts all 130 carry a guard; the real-tree block asserts
+            # the generator is at a fixed point. Both are pure gain-nothing-lose-everything
+            # rails: break a guard and they go red, but DELETE either file and a skip ceiling
+            # sees nothing, because a file that never runs contributes neither a skip nor a
+            # pass. That is the issue-#63 shape one level down, which is what this list exists
+            # to catch.
+            'Empty-pipeline guard coverage'
+            'Update-PfbEmptyPipelineGuards - real tree'
         )
     }
     winps51 = @{
@@ -118,6 +133,13 @@
             # 'Build-PfbDeadKeyReport classification (synthetic fixture, no spec cache, PS7
             # only)', are deliberately absent from this list and appear under pwsh7 only.
             'Committed dead-key report (REGRESSION guard, no spec cache required)'
+            # Issue #121 empty-pipeline guards -- see the pwsh7 block for the full rationale.
+            # Unlike the dead-key and issue-#90 generator gates above, BOTH of these belong on
+            # this leg too: the guard generator declares `#Requires -Version 5.1`, so its
+            # real-tree fixed-point check is not PS7-only and requiring it here is not a false
+            # red. Measured 7 passed / 15 passed on 5.1 for the two files.
+            'Empty-pipeline guard coverage'
+            'Update-PfbEmptyPipelineGuards - real tree'
         )
     }
 }

--- a/tools/Update-PfbEmptyPipelineGuards.ps1
+++ b/tools/Update-PfbEmptyPipelineGuards.ps1
@@ -1,0 +1,250 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Inserts the empty-pipeline guard statement into every collect-then-request cmdlet under
+    Public/, and reports the population it derived rather than one it was handed.
+.DESCRIPTION
+    A cmdlet that COLLECTS pipeline input in `process` and issues ONE request in a NAMED
+    `end` block turns an empty pipeline into an unfiltered request: nothing was collected,
+    so no selector reaches the query, so the request asks for everything. Private/
+    Test-PfbEmptyPipelineRead.ps1 decides that at runtime; this script writes the single
+    call site into each qualifying cmdlet:
+
+        if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
+
+    Everything here is decided from the ABSTRACT SYNTAX TREE, never from a regex over the
+    text. Two reasons, both measured:
+
+      * The parser SYNTHESISES an `end` block for any function that declared no named
+        blocks at all, and marks it `Unnamed`. `$null -ne $Body.EndBlock` is therefore true
+        for nearly every function in the module and selects hundreds of files that are not
+        collect-then-request at all. The qualifying predicate is process block present AND
+        end block present AND NOT Unnamed.
+
+      * This module writes attribute arguments bare -- `ValueFromPipeline`, not
+        `ValueFromPipeline = $true` -- so a text search for the assignment form silently
+        UNDER-counts the population instead of failing.
+
+    Insertion point: walk up from the `Invoke-PfbApiRequest` CommandAst to the direct child
+    statement of the end block, and insert above THAT. The request is often nested inside a
+    `try` or an assignment; inserting at the command's own line would place the guard inside
+    the try body (where it still returns, but reads as if the catch were the protected path)
+    or, worse, inside a multi-line command expression.
+
+    Routing of the shapes this script will not write, in this exact order:
+
+      1. Already carries a Test-PfbEmptyPipelineRead call in the same end block -> reported
+         AlreadyPresent. This runs FIRST so that the hand-edited outliers below become
+         AlreadyPresent once a human has placed their guard, instead of being reported as
+         skipped forever and never reaching a drift fixed point.
+      2. On the explicit human-review list (-HumanReviewFile) -> SkippedNeedsHuman. These
+         are files whose shape is ordinary but where the generator's usual position would
+         produce an INERT guard. Get-PfbRemoteArray writes `current_fleet_only` on both
+         branches of an if/else, so its query hashtable is never empty by the time the
+         request is issued; its guard belongs above that write and only a human can say so.
+      3. More than one request in the end block, or SupportsShouldProcess ->
+         SkippedNeedsHuman. Two requests need one dominating guard rather than two, and a
+         ShouldProcess cmdlet must return BEFORE it prompts, not after.
+
+    A file on the human-review list that matches nothing under the real Public/ root is a
+    hard error: a renamed or deleted cmdlet must not quietly leave the list protecting
+    nothing. That check is scoped to the real tree so synthetic fixture roots in the tests
+    are not required to contain every listed name.
+.PARAMETER PublicRoot
+    Directory holding the cmdlet files. Defaults to Public/ under the repo root. Supplying
+    it explicitly also disables the human-review list integrity check, since a fixture root
+    legitimately contains only the shapes under test.
+.PARAMETER HumanReviewFile
+    Leaf file names the generator must refuse to edit even when their shape is ordinary.
+.OUTPUTS
+    A summary object with:
+      Inserted          - files this run changed (or, under -WhatIf, would change)
+      AlreadyPresent    - qualifying files that already carry the guard
+      SkippedNeedsHuman - qualifying files a human must edit by hand
+.EXAMPLE
+    ./tools/Update-PfbEmptyPipelineGuards.ps1 -WhatIf
+    Report what would change, and act as the drift check: a non-zero Inserted count on a
+    clean tree means a new cmdlet shipped without its guard.
+.EXAMPLE
+    ./tools/Update-PfbEmptyPipelineGuards.ps1 -Confirm:$false
+    Insert the guards in place.
+#>
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [string]$PublicRoot,
+
+    [string[]]$HumanReviewFile = @('Get-PfbRemoteArray.ps1')
+)
+
+$ErrorActionPreference = 'Stop'
+
+$script:GuardStatement = 'if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }'
+$script:RequestCommand = 'Invoke-PfbApiRequest'
+$script:PredicateCommand = 'Test-PfbEmptyPipelineRead'
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$isRealTree = -not $PSBoundParameters.ContainsKey('PublicRoot')
+if (-not $PublicRoot) { $PublicRoot = Join-Path $repoRoot 'Public' }
+if (-not (Test-Path -LiteralPath $PublicRoot)) {
+    throw "Public cmdlet root not found at '$PublicRoot'."
+}
+
+function Get-PfbCommandCall {
+    <#
+        Every CommandAst under $Scope invoking $Name. GetCommandName() returns $null for a
+        dynamically invoked command, which is why it is compared rather than coerced.
+    #>
+    param(
+        [System.Management.Automation.Language.Ast]$Scope,
+        [string]$Name
+    )
+    return @($Scope.FindAll({
+                param($node)
+                $node -is [System.Management.Automation.Language.CommandAst] -and
+                $node.GetCommandName() -eq $Name
+            }, $true))
+}
+
+function Get-PfbTopLevelStatement {
+    <#
+        Walks up from $Node to the statement that is a DIRECT child of $EndBlock. That
+        statement, not the command's own line, is the insertion anchor: it is what a `try`
+        or an assignment wrapping the request resolves to.
+    #>
+    param(
+        [System.Management.Automation.Language.Ast]$Node,
+        [System.Management.Automation.Language.Ast]$EndBlock
+    )
+    $current = $Node
+    while ($null -ne $current.Parent -and $current.Parent -ne $EndBlock) {
+        $current = $current.Parent
+    }
+    if ($current.Parent -ne $EndBlock) {
+        throw 'Could not walk from the request call up to a direct child of the end block.'
+    }
+    return $current
+}
+
+$files = @(Get-ChildItem -LiteralPath $PublicRoot -Recurse -Filter '*.ps1' -File | Sort-Object FullName)
+
+if ($isRealTree) {
+    $leafNames = @($files | ForEach-Object { $_.Name })
+    foreach ($listed in $HumanReviewFile) {
+        if ($leafNames -notcontains $listed) {
+            throw ("Human-review list entry '$listed' matches no file under '$PublicRoot'. " +
+                'Remove the entry or correct it -- a stale entry protects nothing while ' +
+                'still reading as though it did.')
+        }
+    }
+}
+
+$inserted = @()
+$alreadyPresent = @()
+$skippedNeedsHuman = @()
+
+foreach ($file in $files) {
+    # Parse the SAME string that is later spliced and written back. Extent offsets index
+    # into the parsed text, so reading once and parsing that text keeps the offsets and the
+    # splice provably in step.
+    $original = [System.IO.File]::ReadAllText($file.FullName)
+
+    $tokens = $null
+    $errors = $null
+    $ast = [System.Management.Automation.Language.Parser]::ParseInput(
+        $original, $file.FullName, [ref]$tokens, [ref]$errors)
+    if ($errors.Count -gt 0) { throw "Parse errors in '$($file.FullName)'." }
+
+    $functions = $ast.FindAll({
+            param($node)
+            $node -is [System.Management.Automation.Language.FunctionDefinitionAst]
+        }, $true)
+
+    # Offsets collected per file, then applied in DESCENDING order so an earlier insertion
+    # cannot shift a later one. One qualifying function per file is the norm here, but the
+    # generator must not silently corrupt a file that ever holds two.
+    $insertOffsets = @()
+    $fileState = $null   # 'AlreadyPresent' or 'SkippedNeedsHuman', first one wins
+
+    foreach ($function in $functions) {
+        $endBlock = $function.Body.EndBlock
+        $qualifies = ($null -ne $function.Body.ProcessBlock) -and
+            ($null -ne $endBlock) -and
+            (-not $endBlock.Unnamed)
+        if (-not $qualifies) { continue }
+
+        $calls = Get-PfbCommandCall -Scope $endBlock -Name $script:RequestCommand
+        if ($calls.Count -eq 0) { continue }
+
+        # 1. Already guarded.
+        if ((Get-PfbCommandCall -Scope $endBlock -Name $script:PredicateCommand).Count -gt 0) {
+            if (-not $fileState) { $fileState = 'AlreadyPresent' }
+            continue
+        }
+
+        # 2. Explicit human-review list.
+        if ($HumanReviewFile -contains $file.Name) {
+            $fileState = 'SkippedNeedsHuman'
+            continue
+        }
+
+        # 3. Structural outliers.
+        $hasShouldProcess = $function.Extent.Text -match 'SupportsShouldProcess'
+        if ($calls.Count -ne 1 -or $hasShouldProcess) {
+            $fileState = 'SkippedNeedsHuman'
+            continue
+        }
+
+        $statement = Get-PfbTopLevelStatement -Node $calls[0] -EndBlock $endBlock
+        $insertOffsets += $statement.Extent.StartOffset
+    }
+
+    # A file needing a human edit is never partly written, even if another function in it
+    # would have qualified.
+    if ($fileState -eq 'SkippedNeedsHuman') {
+        $skippedNeedsHuman += $file.FullName
+        continue
+    }
+    if ($insertOffsets.Count -eq 0) {
+        if ($fileState -eq 'AlreadyPresent') { $alreadyPresent += $file.FullName }
+        continue
+    }
+
+    # Adopt the target file's own newline style. The repo commits LF blobs, so a checkout
+    # is CRLF on Windows and LF elsewhere; emitting a fixed style would rewrite every line
+    # of every file instead of adding one.
+    $newline = if ($original.Contains("`r`n")) { "`r`n" } else { "`n" }
+
+    $updated = $original
+    foreach ($offset in ($insertOffsets | Sort-Object -Descending)) {
+        # The statement's leading whitespace, taken from the text between the preceding
+        # newline and the statement. Tabs survive because they are copied, not assumed.
+        $lineStart = $updated.LastIndexOf("`n", $offset - 1) + 1
+        $indent = $updated.Substring($lineStart, $offset - $lineStart)
+        if ($indent -match '\S') {
+            throw ("The request statement in '$($file.FullName)' does not start its own " +
+                'line; refusing to splice a guard into shared line content.')
+        }
+        $updated = $updated.Substring(0, $lineStart) +
+            $indent + $script:GuardStatement + $newline +
+            $updated.Substring($lineStart)
+    }
+
+    $inserted += $file.FullName
+    if ($PSCmdlet.ShouldProcess($file.FullName, 'Insert empty-pipeline guard')) {
+        # WriteAllText with an explicit BOM-less UTF8 encoding: no Public/*.ps1 carries a
+        # BOM, and Set-Content -Encoding UTF8 adds one under Windows PowerShell 5.1.
+        [System.IO.File]::WriteAllText(
+            $file.FullName,
+            $updated,
+            (New-Object System.Text.UTF8Encoding($false)))
+    }
+}
+
+Write-Verbose ("Empty-pipeline guards: {0} inserted, {1} already present, {2} awaiting a human edit." -f
+    $inserted.Count, $alreadyPresent.Count, $skippedNeedsHuman.Count)
+
+[PSCustomObject]@{
+    Inserted          = @($inserted)
+    AlreadyPresent    = @($alreadyPresent)
+    SkippedNeedsHuman = @($skippedNeedsHuman)
+}


### PR DESCRIPTION
# Suppress the bare `total_item_count` wrapper and stop empty pipelines from issuing unfiltered requests (#121)

Fixes #121. The one instance of that issue's harm class this branch does **not** close is
tracked separately as #126 — see *The guard's scope limit* below.

Two further findings from this branch's own review are filed rather than folded in, so that
neither lives only in a merged PR body. Both are independent of whether this merges:

- **#128** — the coverage rails assert that a guard exists, is well-formed, precedes the
  request and has its answer used, but not that it *executes on every path*. See *Tooling and
  rails*.
- **#127** — `Remove-PfbLocalGroup` is the only write cmdlet in the module issuing its request
  from an `end` block, which is why it is the one guard here placed by hand. See *Deliberate
  behaviours and named outliers*.

## Summary

Issue #121 reported that an empty list result does not come back as an empty
collection. Instead the caller receives a single object whose only property is
`total_item_count = 0`. That object is truthy, `Measure-Object` counts it as one
item, and piping it into another cmdlet sends `names=@{total_item_count=0}` on the
wire — where the receiving endpoint ignores the malformed key and returns
everything it has. A read that matched nothing therefore turns into an unfiltered
read of the next resource.

This branch closes both halves of that behaviour:

- **The defect fix.** An empty pipeline no longer becomes an unfiltered read or
  write. A new private predicate, `Test-PfbEmptyPipelineRead`, is consulted by
  every public collect-in-`process` cmdlet that issues its request from `end`, and
  those cmdlets now return without dispatching when a piped invocation produced no
  selector at all.
- **The compatibility change.** An ordinary empty list result no longer returns the
  `total_item_count` wrapper. It returns nothing. An explicit `-TotalOnly` call
  still returns the wrapper, unchanged — that shape is preserved, not introduced.

The second point is a behaviour change for any caller that was reading
`.total_item_count` off an ordinary (non-`-TotalOnly`) empty result. That is the
compatibility risk in this PR and it is deliberate.

## The diff, with scopes attached

Both of the figures below are correct, for different scopes, and they are easy to
confuse:

| Scope | Command | Result |
|---|---|---|
| Branch-wide, `Public/` | `git diff --shortstat <base>..HEAD -- Public` | **131 files, 142 insertions, 6 deletions** |
| Generation commit alone, `Public/` | `git diff --shortstat <base>..<gen-commit> -- Public` | **130 files, 132 insertions, 0 deletions** |

The branch total is the first row. The second row is the guard-generation commit on
its own, and it is the right number for the line-ending claim: 127 of those files
were rewritten programmatically by a generator, and the commit carries **zero
deletions**, so no file had its line endings flipped. The whole of the branch's delta
over that commit — the extra file, the extra ten insertions and all six deletions — is
one comment-only change, the corrected sentinel rationale in
`Get-PfbFleetMember.ps1` (`10 6` in `--numstat`). Separately, the generation commit's
132 insertions are the 130 guard lines plus two placement-explaining comments in
`Get-PfbRemoteArray.ps1` (`3 0`), which is why 130 files carry 132 added lines.

Across the whole branch, the added `Public/` lines deduplicate to **13 distinct
lines: 12 comments and exactly one line of code** —

```powershell
if (Test-PfbEmptyPipelineRead -Caller $PSCmdlet -QueryParams $queryParams) { return }
```

That single statement is byte-identical in all 130 files that received it. The
stronger form of that claim, which does not depend on how a shell sorts: a scan of
every file under `Public/` finds **130 occurrences of `Test-PfbEmptyPipelineRead`
across 130 files, and exactly one distinct line text** among them (compared
ordinally, since `Sort-Object -Unique` compares culture-linguistically and this
project has already seen 5.1 and 7 disagree on that order). There is no other
mention of the predicate anywhere under `Public/`.

Outside `Public/`, the branch touches ten files: `Private/Invoke-PfbApiRequest.ps1`
(+45/-4, of which 7 added lines are comment), the new `Private/Test-PfbEmptyPipelineRead.ps1` (23 lines), the new
generator `tools/Update-PfbEmptyPipelineGuards.ps1` (250 lines), five new test files,
one modified test file, and `Tests/coverage-baseline.psd1`. No `Data/`, `Reports/` or `.github/` file is touched
anywhere on the branch — `git diff --stat <base>..HEAD -- Data Reports .github tools`
returns only the generator. The module manifest, the module version and
`CHANGELOG.md` are untouched; version and changelog decisions are yours.

## What suppresses the wrapper, and what does not

`Private/Invoke-PfbApiRequest.ps1` carries two changes, and it matters which one is
responsible for the measured effect.

**1. The final-return gate — this is the change that suppresses the wrapper, and it
is live-exercised.** It is one added flag plus one added conjunct, and both response
paths reach it:

```powershell
# added at line 233, above the pagination loop, so both response paths share one value
$totalOnlyRequested = ($null -ne $QueryParams -and $QueryParams['total_only'] -eq 'true')

# the final return, line 420
# before
if ($allItems.Count -eq 0 -and $null -ne $totalItemCount) {
# after
if ($allItems.Count -eq 0 -and $totalOnlyRequested -and $null -ne $totalItemCount) {
```

The gate is not specific to the `items`-present path. The no-`items` classifier
described below assigns `$totalItemCount` and falls through to this same return, so
one gate covers both shapes — which is the reason the classifier is a normalizer
rather than an independent suppression mechanism.

The discriminator has to be the *request*, not the response. Measured against FB-A
at REST 2.26, a total-only response and an ordinary empty result are the same four
keys and differ only in the value of `total_item_count`:

```
GET /file-systems?total_only=true    -> { total, continuation_token, total_item_count: 2, items: [] }
GET /file-systems?filter=<no-match>  -> { total, continuation_token, total_item_count: 0, items: [] }
```

So no test on the response can tell them apart, and a guard keyed on a non-zero
count would hand the wrapper straight back to an ordinary caller. `$QueryParams`
already carries the answer, because `Add-PfbCommonQueryParams` writes `total_only`
there when the caller passed `-TotalOnly`. The gate reads the value rather than the
key, so it stays correct if that helper's separate `ContainsKey` behaviour is ever
changed.

**2. The no-`items` classifier narrowing — defensive, and entirely unexercised
live.** A body with no `items` key used to be returned verbatim as direct data.
It now returns verbatim *unless* it has exactly one property named
`total_item_count`, in which case it is treated as an empty list response. The
classifier is deliberately not also restricted to `total_item_count -eq 0`, while the
final-return gate above deliberately keeps its `$allItems.Count -eq 0` conjunct; the
two apply opposite defaults on purpose, because a no-`items` body has no items to
preserve and a total-only read might unexpectedly carry some. A comment in the file
records that asymmetry so it does not read as an oversight to be "aligned" later.

This is defensive code and should not be credited for the measured suppression. A
scan of all 210 literal GET endpoints the module's own `Get-*` cmdlets reference,
run against FB-A at REST 2.26, found **zero** count-carrying bodies without an
`items` key (180 have `items`, 29 returned the array's own 4xx/5xx, and exactly one
is genuine direct data — `keytabs/download`, whose sole property is `Length`). A
branch-selection measurement confirms the classifier does not fire even on the two
reads whose behaviour actually changed: for `file-systems?filter=<no-match>`,
`file-systems/open-files` and `file-systems?total_only=true`, `$null -ne
$response.items` is `True` and the count-only classifier evaluates `False` on all
three. They take the `items` path and fall through to the final return.

The classifier is therefore neither confirmed nor refuted by live evidence. Its only
detector is the AST/behavioural rail added in `Tests/Invoke-PfbApiRequest.EmptyResult.Tests.ps1`,
which reds if the exactly-one-key test is ever silently broadened to
`-contains 'total_item_count'`. That rail is the reason the narrowness is safe to
ship unexercised, and it is worth knowing that it is the *only* thing holding it.

## Live verification on FB-A (REST 2.26)

Measured against the same array, in the same session, with only the module path
differing between the two runs and the git ref confirmed on each side:

| Call | `main` (branch base) | This branch |
|---|---|---|
| `Get-PfbFileSystem -Filter "name='zzz-no-such-filesystem'"` | 1 object, 1 property, `total_item_count = 0` | **0 objects** |
| `Get-PfbOpenFile` | 1 object, 1 property, `total_item_count = 0` | **0 objects** |
| `Get-PfbFileSystem -TotalOnly` | 1 object, `total_item_count = 2` | 1 object, `total_item_count = 2` (unchanged) |
| `Get-PfbFileSystem` (control) | 2 objects, 28 properties | 2 objects, 28 properties |

The unfiltered control is what makes this a before/after comparison rather than two
readings — it rules out a connection or array-state difference between the runs.

### Proving that no request was issued

A zero result count cannot distinguish "the guard fired and no request went out"
from "a request went out and came back empty". So `Invoke-PfbApiRequest` was
shadowed by a counting stub in module scope. The guard returns *before* that call,
so any capture means the guard failed to fire.

- All **130** guarded cmdlets, piped `@()`: **0 requests**.
- `Remove-PfbLocalGroup` piped `@()` with `-Confirm:$false`: **0 requests**, nothing
  transmitted.
- **Control:** `Get-PfbBucket` called **directly** with the same shim: **1 request**
  (`GET buckets`).

Without that control the zeros prove nothing, so it is included deliberately.

A full-population sweep against FB-A classified the 130 as: SUPPRESSED-ZERO 74,
UNINFORMATIVE-EMPTY 46, UNKNOWN 7, DEFERRED 3. `Get-PfbAudit` went from 759 objects
to 0, `Get-PfbSession` 237 to 0, `Get-PfbPolicyAll` 45 to 0. Please read the
UNINFORMATIVE-EMPTY and UNKNOWN rows as limits, not passes — see *Known limits*
below.

### Pre-merge re-verification: the positive path

The evidence above is almost entirely the *suppression* path. A second live run was done
before requesting merge, aimed at the opposite question — that normal usage still works.
31 harness rows, all `Pass`, array left exactly as found and no residue outstanding.

The complete three-way discrimination, on a bucket created for the purpose:

```powershell
'pslivetest-bkt-121' | Get-PfbBucket   # -> 1   guard correctly does NOT fire
@()                  | Get-PfbBucket   # -> 0   guard fires
Get-PfbBucket        (direct)          # -> 2   unfiltered read intact
```

Note the harness calls cmdlets directly, so every *pipeline* assertion here is a labelled
direct probe rather than a harness row; the rows cover the direct-call and selector
assertions. Both write lifecycles completed with each phase as its own call: bucket
create → read → shrink → destroy → eradicate → back to 1; and a fixture file system →
2 snapshots → eradicate each → destroy → eradicate → back to 2 file systems and 28
snapshots.

The fix itself, measured against its own control — same array, same session, only the
module path differing, with the `main` checkout at `a30e398`, this branch's exact base:

| Call | `main@a30e398` | `branch@f3dca14` |
|---|---|---|
| `@() \| Get-PfbFileSystemSnapshot` | **28** | **0** |
| `@() \| Get-PfbFileSystem` | 2 | 0 |

Two apparent anomalies surfaced during the run and were both **cleared as pre-existing**
by re-running against `main`. Recording them because each would read as a regression in
this branch without the control:

- `Get-PfbFileSystemSnapshot -Name` and `-SourceName` do not filter — the endpoint returns
  all 30 either way, explicit or piped, identical on `main`. This is not a new discovery:
  `Reports/PfbDeadKeyReport.json` already records both as `WRONG-RESULTS` (the endpoint
  declares `names_or_owner_names`, not `names`). The live run independently confirms the
  static report. The control that distinguishes a dead key from a broken endpoint is that
  `-Limit 5` returns 5 and `-Filter "source.name='…'"` returns exactly the 2 fixture
  snapshots, on the same endpoint in the same request shape.
- `Get-PfbArrayConnection -RemoteName 'FB-B'` returns 3 objects where 2 are correct. The
  extra object is a stray `$true`: `Private/Assert-PfbRemoteNameNotCoerced.ps1` ends with
  `return $true`, and none of its four call sites suppress it —
  `Get-PfbArrayConnection`, `Get-PfbArrayConnectionPath`,
  `Get-PfbArrayConnectionPerformanceReplication` and `Remove-PfbArrayConnection`. It
  originates in **#91** (commit `c6a0f1a`, the `remote_names` fix for #64), not here: this
  branch's only change to that file is the one guard line, and it does not touch the helper
  or the `process` block where the value leaks. Being filed separately.

  Worth flagging for its own sake, since it is a live defect on `main`: the `-RemoteName`
  path emits one stray `$true` per supplied name ahead of the real objects, so a caller's
  `| Measure-Object` overcounts and `| Select-Object -First 1` gets the boolean rather than
  a connection. The negative control confirms the query key itself is fine —
  `-RemoteName 'zzz-nonexistent'` returns HTTP 400 *"Array connection does not exist"*, and
  `-Filter "remote.name='FB-B'"` returns exactly 2.

A working selector still shrinks correctly through the changed request path on this
branch: `-Filter "source.name='pslivetest-fs-121'"` returns 2 of 30.

Not covered: `Remove-PfbLocalGroup` got no live *write* coverage in this run. Its
empty-pipeline path is shim-proven at 0 requests above; what is unverified is only that a
real delete still succeeds.

## The guard's scope limit — please read this one

The predicate is deliberately narrow, and its narrowness is not obvious from the
"130 guards" figure:

```powershell
if (-not $Caller.MyInvocation.ExpectingInput) { return $false }
return ($null -eq $QueryParams -or $QueryParams.Count -eq 0)
```

It is an **emptiness test standing in for a selector policy that the design never
defines**. Any bound non-selector key leaves the query hashtable non-empty and
defeats the guard. So:

```powershell
@() | Get-PfbFileSystem            # suppressed, no request
@() | Get-PfbFileSystem -Limit 10  # NOT suppressed, still issues an unfiltered read
```

The same applies to `-Filter`, `-Sort`, `-TotalOnly`, `-ContextNames`, `-Destroyed`
and the `-StartTime`/`-EndTime`/`-Resolution` trio. "130 guards" is coverage of the
*population* of qualifying cmdlets — it is not coverage of every empty-pipeline
invocation. Two independent reviews raised this during development, which is why it
is stated here rather than left for you to derive from the predicate.

This is now tracked as **#126**, which sets out the sharper version of the problem: the
predicate cannot distinguish a key that *addresses objects* from one that merely *scopes or
shapes* the result, so it errs toward issuing the request in every case — correct for
`-Filter`, wrong for the rest. That issue also records why the current shape makes any fix
cheap to adopt: the guard tests the built `$QueryParams` rather than the bound parameters, so
a selector policy changes one file and none of the 130 call sites.

## Deliberate behaviours and named outliers

- `@() | Get-PfbX` returns nothing and issues no request. Direct calls are never
  suppressed — `Get-PfbX` with no arguments still performs its unfiltered read, as
  before.
- `@() | Get-PfbBucket -Name 'only-this-one'` **also returns nothing.** The explicit
  `-Name` is not revived. `-Name` is the pipeline-bound parameter, so an empty
  pipeline means `process` never runs and the accumulator the query is built from
  stays empty. This is consistent with the predicate but it is a sharp edge worth
  knowing about.
- The public guard runs **before** the capability and context assertions, which live
  inside `Invoke-PfbApiRequest`. So an empty pipeline into a cmdlet that is too new
  for the connected array, or that is context-gated, now returns empty silently
  rather than raising the version error. Reordering that would mean moving the guard
  below the request-builder, which defeats it.
- **Eleven cmdlets also lose an actionable warning on the empty-pipeline path.**
  Pre-branch, `@() | Get-PfbBucketAccessPolicy` issued an unfiltered request, the
  array refused it, and the `catch` emitted guidance ("Bucket access policies require
  the -Name parameter with a fully-qualified 'bucket/policy' name…"). Post-branch the
  guard returns first and the call is silent. The same applies to
  `Get-PfbBucketAccessPolicyRule`, `Get-PfbBucketCorsPolicy`,
  `Get-PfbBucketCorsPolicyRule`, `Get-PfbFileSystemStorageClass`,
  `Get-PfbRealmStorageClass`, `Get-PfbResiliencyGroup`, `Get-PfbLogTargetFileSystem`,
  `Get-PfbNode`, `Get-PfbNodeGroup` and `Get-PfbNodeGroupUse`. All eleven warnings
  live inside `catch` blocks reachable only after a request, so nothing is being
  swallowed — but it is a real loud-to-silent conversion and is listed here rather
  than left to be discovered.
- `Get-PfbNode` has **one** guard, placed so that it dominates both its primary
  (`nodes`) and fallback (`blades`) calls, rather than one guard per call site.
- `Remove-PfbLocalGroup` — the only cmdlet in the population declaring
  `SupportsShouldProcess` — returns **before** `ShouldProcess`, so an empty pipeline
  produces no confirmation prompt and no request. The guard is on line 39,
  `ShouldProcess` on line 42 and the request on line 43; measured by AST offset as the
  tie-breaker, 1588 / 1782 / 1853 on the branch head. It is also the **only** guard in
  this branch placed by hand, because the generator routes any `SupportsShouldProcess`
  function to `SkippedNeedsHuman`. The underlying reason it lands in this population at
  all is structural and is filed as **#127**: of 112 `Remove-Pfb*` cmdlets, 82 of which
  accept pipeline input, it is the only one issuing its request from an `end` block
  rather than from `process` — so it is also the only *mutating* cmdlet among the 130
  (the rest are 127 `Get-*` and 2 `Test-*`). Nothing here depends on that being changed;
  #127 simply records that normalising the shape would remove the need for this guard.
- `Get-PfbRemoteArray`'s guard sits **above** its `current_fleet_only` write, not
  immediately before the request. That write happens on both branches of an
  `if`/`else`, so a guard in the generator's usual position would never fire and
  effective coverage would have been 129 of 130 with every count still reading
  green. Placing the guard above the write protects the empty-pipeline case and
  changes no request that is still issued — `current_fleet_only` is a scope flag, not
  a selector. This makes it the single named entry in the coverage rail's
  post-guard-write allowlist (`$allowedPostGuardWrite = @('Get-PfbRemoteArray')`),
  and emptying that allowlist on the unmutated tree names this function and nothing
  else, which is how we know the one entry is load-bearing and that no second
  function needs one.
- `Get-PfbNetworkConnectionStatistics`, `Get-PfbFleetKey` and `Set-PfbContext` are
  **not** exclusions from the coverage rail. They simply do not satisfy its
  qualifying predicate. The exclusion list is explicit and empty.

## Tooling and rails

`tools/Update-PfbEmptyPipelineGuards.ps1` is the AST generator that inserted 127 of
the guards and now serves as the drift check. It is `#Requires -Version 5.1`, which is
deliberately unlike most of its `tools/` siblings — 9 of the 11 scripts there are
`7.0` — so that the drift check can run under either edition; the shipped guard line
and predicate are 5.1-clean for the same reason.
On the finished tree it reports a fixed point:

```
Inserted=0  AlreadyPresent=130  SkippedNeedsHuman=0
```

The generator's recognizer only proves a guard **exists**, not that it is correct — a
guard moved below the request, reduced to a bare call with no `if`/`return`, hoisted
above an `Add-PfbCommonQueryParams -Into $queryParams` write, nested inside a
scriptblock, or pointed at the wrong hashtable would all still report
`AlreadyPresent`. That gap is closed in CI rather than in the generator, by
`Tests/PfbEmptyPipelineGuardCoverage.Tests.ps1`, which asserts placement, hashtable
identity, offset ordering relative to the request, that the guard is not nested inside
a scriptblock expression, and the absence of unconditional post-guard query writes.
Note the precise strength of the nesting assertion: it forbids nesting in a
`ScriptBlockExpressionAst`, which is the shape where a `return` exits the *scriptblock*
instead of the cmdlet. It does not assert that the guard is reached on every path. A
guard hand-moved inside an `if {}` or a `foreach {}` at the top of an `end` block still
returns from the cmdlet correctly, so it passes this rail and the ordering rail and the
`GuardReturns` rail — and simply does not execute when the accumulator is empty, which
is the case the guard exists for. Measured on this branch, all 130 guards share exactly
one parent-chain shape — `CommandAst -> PipelineAst -> IfStatementAst -> end block` —
and the generator can only ever insert one there (`Get-PfbTopLevelStatement` throws
rather than inserting off-anchor), so the exposure is a hand edit and is empty today.
This is filed as **#128** rather than fixed here. Worth noting for whoever takes it: the
fix is *not* a direct-child assertion, which would be too strict — a `try` or `finally`
body always executes, so a guard placed there does still dominate the request. The
property wanted is dominance, which is a control-flow predicate needing its own
non-vacuity proof over 544 functions. Each of the existing assertions was
proven to discriminate by editing the tree and confirming the matching test reds and
names the offending file; guards were then restored with the generator rather than
`git restore`.

Both rails are registered in `Tests/coverage-baseline.psd1`'s `RequiredDescribes`, on
both edition blocks. This matters more here than the skip ceiling does. `MaxSkipped`
cannot see a `Describe` that *disappears* — a file filtered out of a run, or deleted
outright, contributes neither a skip nor a pass — so before this, breaking a guard was
a red build while deleting the rail that checks the guards was a green one. That is
the issue-#63 failure shape one level down, which is precisely what that list exists
to catch. Neither rail carries a PS7 gate and neither reads the spec cache, and the
generator declares `#Requires -Version 5.1` rather than 7.0 specifically so its
real-tree fixed-point check runs on either leg — so requiring both on Windows
PowerShell 5.1 is not a false red. Verified by adding a deliberately bogus entry and
confirming `Tests/CiCoverageGate.Tests.ps1` reds on both editions and names the
offending assertion, then removing it.

## CI workflow effect on merge

`.github/workflows/update-api-capability-map.yml` triggers on `push` to `main` with
`paths: ['Public/**']` and commits with `add-paths: Data, Reports`. This branch
touches 131 `Public/` files, so **merging will fire it** and it may open its normal
bot PR.

The evidence that it will produce no artifact diff: all four regeneration gates pass,
and each artifact regenerates byte-identical to the committed copy. Regenerated to a
scratch directory outside the repo and compared by SHA-256 on raw bytes:

| Artifact | Result |
|---|---|
| `Reports/PfbFieldCmdletMap.json` | identical (`Wrote 2003 entries`) |
| `Reports/PfbApiDriftReport.json` | identical (chained to the temporary field map) |
| `Reports/PfbDeadKeyReport.json` | identical (`85 dead keys from 2164 inventoried parameters`) |
| `Reports/PfbPipelineSelectorMap.json` | identical |

The three Markdown companions are identical after newline normalisation — the
committed copies are CRLF from checkout and the generated ones are LF, proven by
full-string equality rather than by a diff with no hunks.

Note that the workflow does **not** build `Reports/PfbPipelineSelectorMap.*`; that
map is hand-run only, which is why it was regenerated manually. Its four pins all
hold, and the pair set was checked by symmetric difference rather than by equal
counts:

```
Probe pairs: 1247   Candidates: 629   Findings: 264 rows / 101 pairs   Control leakage: 0
BindError: 2
```

The mechanism for why nothing moved is what makes the null result trustworthy: the
probe harness pipes a real producer object into each candidate parameter, so a probed
pair either binds a selector — leaving the query non-empty and failing the
predicate's second condition — or fails to bind, in which case its outcome was
already `Unbindable`/`BindError`/`NoSelector` and never a request capture. The guard
cannot pre-empt the harness on any probed pair.

The committed dead-key report's floors (2000 parameters inventoried, 1600 keys
evaluated) hold unchanged, and `Update-PfbContextHelp` still reports
`Changed.Count = 0` against the guard-modified tree.

## Test evidence

Every run scoped, one file per invocation, under **both** pwsh 7.x and Windows
PowerShell 5.1 with Pester 6.0.1, `Container ok` on every run and zero failures:

| Test file | pwsh 7 | WinPS 5.1 |
|---|---|---|
| `Tests/Invoke-PfbApiRequest.EmptyResult.Tests.ps1` | 15 passed | 15 passed |
| `Tests/Test-PfbEmptyPipelineRead.Tests.ps1` | 5 passed | 5 passed |
| `Tests/PfbEmptyPipelineGuardCoverage.Tests.ps1` | 7 passed | 7 passed |
| `Tests/Update-PfbEmptyPipelineGuards.Tests.ps1` | 15 passed | 15 passed |
| `Tests/Get-PfbRemoteArray.Tests.ps1` (new) | 3 passed | 3 passed |
| `Tests/Get-PfbFleetMember.Tests.ps1` | 8 passed | 8 passed |
| `Tests/Update-PfbContextHelp.Tests.ps1` | 18 passed | 18 passed |
| `Tests/CommittedDeadKeyReport.Tests.ps1` | 7 passed | 7 passed |
| `Tests/Build-PfbPipelineSelectorMap.Tests.ps1` | 7 passed | 7 passed |
| `Tests/Build-PfbFieldCmdletMap.Tests.ps1` | 15 passed | 15 skipped |
| `Tests/Build-PfbDeadKeyReport.Tests.ps1` | 6 passed | 6 skipped |
| `Tests/Build-PfbApiDriftReport.Tests.ps1` | 65 passed | 65 skipped |
| `Tests/Build-PfbCapabilityMap.Tests.ps1` | 50 passed | 50 skipped |
| `Tests/PfbPipelineSelectorRail.Tests.ps1` | 11 passed | 11 skipped |

The 5.1 skips are the existing deliberate PS7-only gating on generator-owner test
files, not failures — every one of those runs reports `Container ok`, which is the
signal that distinguishes a healthy skip from a file that died before its tests ran.
None of the new test files add a skip on either edition.

## Known limits

Stated plainly, because a maintainer should not have to discover these from the
evidence:

- **46 sweep rows are `UNINFORMATIVE-EMPTY` and are not counted as passes.** Those
  cmdlets return nothing on this lab array whether or not the guard fires, so the
  sweep cannot distinguish the two. The request-counting shim covers all 130
  regardless; the sweep classification is the weaker of the two pieces of evidence.
- **7 rows remain `UNKNOWN`** and were preserved as unknowns rather than rounded up:
  five cmdlets with unbound mandatory parameters, one whose parameter set could not
  be resolved (`Get-PfbAsyncLogDownload`), and one that met an array-side HTTP 500
  (`Get-PfbNetworkInterfaceConnectorSettings`). Nothing was skipped by policy;
  model-limited endpoints surfaced as the array's own 400s, which is a lab ceiling
  rather than a defect.
- **The no-`items` count-only classifier is unexercised live**, as described above.
- **The aggregate CI suite was never run locally.** Ten new `Describe` blocks are
  added across the five new test files. `Tests/coverage-baseline.psd1` pins
  `MaxSkipped` ceilings and a `RequiredDescribes` presence list and carries no
  total-count pin, and the new Describes add zero skips on either edition — so
  **no ceiling needed raising**. That much is an inference from the baseline file
  plus the measured zero-skip runs, not a measurement of the aggregate suite; CI
  settles it. The `RequiredDescribes` list *was* changed, deliberately — see below.
- **`RequiredDescribes` enforcement is only observable in a full-suite run.**
  `scripts/Assert-PfbTestCoverage.ps1` resolves each entry against the result tree
  by `Path[0]`, so the entries added here are proven to *name real blocks* (by
  `Tests/CiCoverageGate.Tests.ps1`, locally, both editions) but are proven to
  *resolve to executed tests* only by CI.

## Residual: `-TotalOnly` still yields the wrapper

`-TotalOnly` returns the one-property `total_item_count` object by design, and piping
that object onward still reaches the wire. On FB-A:

```
Get-PfbFileSystem -TotalOnly | Get-PfbBucket
    FlashBlade API error (HTTP 400): Bucket does not exist.
```

This is recorded as an **observation, not an improvement claim**, and it is not a
clean before/after. On `main` the piped object carried a hand-built
`total_item_count = 0`; on this branch it carried the live value `2`. The wire string
therefore differs for a reason that has nothing to do with this branch. Whether
`-TotalOnly` should emit a plain integer, or a typed object, or should refuse to bind
onward at all, is a separate design question and is left to you.

## Files changed

- `Private/Invoke-PfbApiRequest.ps1` — final-return gate plus the no-`items`
  count-only classifier narrowing.
- `Private/Test-PfbEmptyPipelineRead.ps1` — new predicate.
- 130 files under `Public/` — one byte-identical guard line each.
- `Public/Replication/Get-PfbFleetMember.ps1` — comment-only rationale correction
  (its `total_only` sentinel passthrough is now unreachable on today's response
  layer and is retained as defence-in-depth; the old comment claimed a path that no
  longer exists).
- `tools/Update-PfbEmptyPipelineGuards.ps1` — new AST guard generator / drift check.
- Five new test files and one modified test file.
- `Tests/coverage-baseline.psd1` — registers the two guard rails in
  `RequiredDescribes` on both edition blocks. No ceiling raised.

No version bump, no `CHANGELOG.md` edit, no manifest or export change, no `Data/`,
`Reports/` or `.github/` change.

## CI

Green on `f3dca14` across all four OS/edition legs plus the spec-cache job
(`macos-latest` pwsh, `ubuntu-latest` pwsh, `windows-latest` pwsh, `windows-latest`
Windows PowerShell 5.1). That run is also what settles the two items this body lists as
locally undeterminable: the aggregate suite passes, and the two new `RequiredDescribes`
entries resolve to executed tests rather than merely naming real blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
