### PR TITLE
Reuse the loaded module in tests instead of force-importing it 165 times

### DIFF
--- a/Tests/Add-PfbCommonQueryParams.Tests.ps1
+++ b/Tests/Add-PfbCommonQueryParams.Tests.ps1
@@ -1,7 +1,8 @@
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
 
 BeforeAll {
-    Import-Module "$PSScriptRoot/../PureStorageFlashBladePowerShell.psd1" -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 }
 
 Describe 'Add-PfbCommonQueryParams' {

--- a/Tests/ArrayConnection.ShouldProcessTarget.Tests.ps1
+++ b/Tests/ArrayConnection.ShouldProcessTarget.Tests.ps1
@@ -162,7 +162,8 @@ Describe 'Array connection ShouldProcess target truthfulness' {
 
         $moduleRoot = Split-Path -Parent $PSScriptRoot
         $manifest = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-        Import-Module $manifest -Force
+        . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+        $null = Import-PfbTestModule
 
         # The recording runspace runs the real Assert-PfbConnection, which is satisfied by any
         # object carrying an AuthToken -- no mock and no network access is involved, and -WhatIf

--- a/Tests/Assert-PfbAdminNameNotCoerced.Tests.ps1
+++ b/Tests/Assert-PfbAdminNameNotCoerced.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 }
 
 Describe 'Assert-PfbAdminNameNotCoerced (#99)' {

--- a/Tests/Assert-PfbApiCapability.Tests.ps1
+++ b/Tests/Assert-PfbApiCapability.Tests.ps1
@@ -11,7 +11,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:originalModuleRoot = InModuleScope PureStorageFlashBladePowerShell { $script:PfbModuleRoot }
 

--- a/Tests/Assert-PfbContextSupported.Tests.ps1
+++ b/Tests/Assert-PfbContextSupported.Tests.ps1
@@ -5,7 +5,8 @@
 #>
 
 BeforeAll {
-    Import-Module "$PSScriptRoot/../PureStorageFlashBladePowerShell.psd1" -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 }
 
 # InModuleScope inside each It (Describe-level fails at discovery here -- see Global

--- a/Tests/Assert-PfbSelectorNotCoerced.Tests.ps1
+++ b/Tests/Assert-PfbSelectorNotCoerced.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
     $script:fakeArray = [PSCustomObject]@{
         Endpoint   = 'fb.example.test'
         ApiVersion = '2.0'

--- a/Tests/CLAUDE.md
+++ b/Tests/CLAUDE.md
@@ -1,5 +1,27 @@
 # Writing Pester tests in this repo
 
+## Loading the module
+
+Every test file loads the module through the shared helper, not with
+`Import-Module -Force`. Two lines, both **inside `BeforeAll`**:
+
+```powershell
+BeforeAll {
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
+}
+```
+
+The dot-source has to be inside `BeforeAll` too. File-scope code runs during
+Pester's discovery phase, so a function dot-sourced at file scope is not in
+scope by the time an `It` runs.
+
+`Import-PfbTestModule` reuses the already-loaded module and resets the volatile
+module-scope state instead of paying a fresh import per container; see
+`Tests/PfbTestModule.ps1` for the reasoning. `Tests/TestModuleImportGuard.Tests.ps1`
+enforces the pattern, and `tools/Update-PfbTestModuleImport.ps1` applies it
+mechanically (`-WhatIf` first).
+
 ## Calling a private function
 
 Anything under `Private/` that is **not** listed in `FunctionsToExport` in

--- a/Tests/Clear-PfbContext.Tests.ps1
+++ b/Tests/Clear-PfbContext.Tests.ps1
@@ -1,7 +1,8 @@
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
 
 BeforeAll {
-    Import-Module "$PSScriptRoot/../PureStorageFlashBladePowerShell.psd1" -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 }
 
 Describe 'Clear-PfbContext' {

--- a/Tests/Connect-PfbArray.CapabilityMapStaleness.Tests.ps1
+++ b/Tests/Connect-PfbArray.CapabilityMapStaleness.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 }
 
 Describe 'Connect-PfbArray - capability-map staleness warning' {

--- a/Tests/Connect-PfbArray.Context.Tests.ps1
+++ b/Tests/Connect-PfbArray.Context.Tests.ps1
@@ -1,7 +1,8 @@
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
 
 BeforeAll {
-    Import-Module "$PSScriptRoot/../PureStorageFlashBladePowerShell.psd1" -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 }
 
 Describe 'connection context state' {

--- a/Tests/Connect-PfbArray.NativeLoginVersionGate.Tests.ps1
+++ b/Tests/Connect-PfbArray.NativeLoginVersionGate.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:testPassword = ConvertTo-SecureString 'hunter2' -AsPlainText -Force
 }

--- a/Tests/Connect-PfbArray.OAuth2TokenRefresh.Tests.ps1
+++ b/Tests/Connect-PfbArray.OAuth2TokenRefresh.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     function New-MockHttpError {
         param([int]$StatusCode, [string]$Message = 'mock http error')

--- a/Tests/ConvertTo-PfbApiError.Tests.ps1
+++ b/Tests/ConvertTo-PfbApiError.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     function New-ErrorRecordWithBody {
         param(

--- a/Tests/ConvertTo-PfbQueryString.Tests.ps1
+++ b/Tests/ConvertTo-PfbQueryString.Tests.ps1
@@ -1,7 +1,8 @@
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
 
 BeforeAll {
-    Import-Module "$PSScriptRoot/../PureStorageFlashBladePowerShell.psd1" -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 }
 
 Describe 'ConvertTo-PfbQueryString' {

--- a/Tests/ConvertTo-PfbVersionObject.Tests.ps1
+++ b/Tests/ConvertTo-PfbVersionObject.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 }
 
 Describe 'ConvertTo-PfbVersionObject' {

--- a/Tests/FileSystemExportAndLocalDirectoryServices.Tests.ps1
+++ b/Tests/FileSystemExportAndLocalDirectoryServices.Tests.ps1
@@ -2,7 +2,8 @@
 
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
-    Import-Module (Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1') -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.26'; AuthToken = 'x' }
 }
 

--- a/Tests/FileSystemSnapshotPolicy.Tests.ps1
+++ b/Tests/FileSystemSnapshotPolicy.Tests.ps1
@@ -1,7 +1,8 @@
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
 
 BeforeAll {
-    Import-Module "$PSScriptRoot/../PureStorageFlashBladePowerShell.psd1" -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
     # A throwaway connection object; Assert-PfbConnection is mocked so its contents don't matter.
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Get-PfbApiToken.Tests.ps1
+++ b/Tests/Get-PfbApiToken.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Get-PfbApiTokenViaSsh.Tests.ps1
+++ b/Tests/Get-PfbApiTokenViaSsh.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:testPassword = ConvertTo-SecureString 'hunter2' -AsPlainText -Force
 }

--- a/Tests/Get-PfbArrayConnection.Tests.ps1
+++ b/Tests/Get-PfbArrayConnection.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Get-PfbArrayConnectionKey.Tests.ps1
+++ b/Tests/Get-PfbArrayConnectionKey.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Get-PfbArrayConnectionPath.Tests.ps1
+++ b/Tests/Get-PfbArrayConnectionPath.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Get-PfbArrayConnectionPerformanceReplication.Tests.ps1
+++ b/Tests/Get-PfbArrayConnectionPerformanceReplication.Tests.ps1
@@ -1,7 +1,8 @@
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
 
 BeforeAll {
-    Import-Module "$PSScriptRoot/../PureStorageFlashBladePowerShell.psd1" -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }
 

--- a/Tests/Get-PfbArrayPerformance.Tests.ps1
+++ b/Tests/Get-PfbArrayPerformance.Tests.ps1
@@ -1,7 +1,8 @@
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
 
 BeforeAll {
-    Import-Module "$PSScriptRoot/../PureStorageFlashBladePowerShell.psd1" -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
     # A throwaway connection object; Assert-PfbConnection is mocked so its contents don't matter.
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Get-PfbArrayPerformanceReplication.Tests.ps1
+++ b/Tests/Get-PfbArrayPerformanceReplication.Tests.ps1
@@ -1,7 +1,8 @@
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
 
 BeforeAll {
-    Import-Module "$PSScriptRoot/../PureStorageFlashBladePowerShell.psd1" -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }
 

--- a/Tests/Get-PfbArraySpace.Tests.ps1
+++ b/Tests/Get-PfbArraySpace.Tests.ps1
@@ -1,7 +1,8 @@
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
 
 BeforeAll {
-    Import-Module "$PSScriptRoot/../PureStorageFlashBladePowerShell.psd1" -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }
 

--- a/Tests/Get-PfbBucketReplicaLink.Tests.ps1
+++ b/Tests/Get-PfbBucketReplicaLink.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Get-PfbCapabilityMap.Tests.ps1
+++ b/Tests/Get-PfbCapabilityMap.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:originalModuleRoot = InModuleScope PureStorageFlashBladePowerShell { $script:PfbModuleRoot }
 }

--- a/Tests/Get-PfbFileSystemGroup.Tests.ps1
+++ b/Tests/Get-PfbFileSystemGroup.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.25'; AuthToken = 'x' }
 }

--- a/Tests/Get-PfbFileSystemGroupQuota.Tests.ps1
+++ b/Tests/Get-PfbFileSystemGroupQuota.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.25'; AuthToken = 'x' }
 }

--- a/Tests/Get-PfbFileSystemReplicaLink.Tests.ps1
+++ b/Tests/Get-PfbFileSystemReplicaLink.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Get-PfbFileSystemReplicaLinkPolicy.Tests.ps1
+++ b/Tests/Get-PfbFileSystemReplicaLinkPolicy.Tests.ps1
@@ -2,7 +2,8 @@
 
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
-    Import-Module (Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1') -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray  = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
     $script:sourceFile = [System.IO.Path]::Combine($moduleRoot, 'Public', 'Replication', 'Get-PfbFileSystemReplicaLinkPolicy.ps1')

--- a/Tests/Get-PfbFileSystemReplicaLinkTransfer.Tests.ps1
+++ b/Tests/Get-PfbFileSystemReplicaLinkTransfer.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Get-PfbFileSystemSession.Tests.ps1
+++ b/Tests/Get-PfbFileSystemSession.Tests.ps1
@@ -1,7 +1,8 @@
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
 
 BeforeAll {
-    Import-Module "$PSScriptRoot/../PureStorageFlashBladePowerShell.psd1" -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }
 

--- a/Tests/Get-PfbFileSystemUser.Tests.ps1
+++ b/Tests/Get-PfbFileSystemUser.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.25'; AuthToken = 'x' }
 }

--- a/Tests/Get-PfbFileSystemUserGroupQuotaPolicy.Tests.ps1
+++ b/Tests/Get-PfbFileSystemUserGroupQuotaPolicy.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.25'; AuthToken = 'x' }
 }

--- a/Tests/Get-PfbFileSystemUserQuota.Tests.ps1
+++ b/Tests/Get-PfbFileSystemUserQuota.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.25'; AuthToken = 'x' }
 }

--- a/Tests/Get-PfbFleetMember.Tests.ps1
+++ b/Tests/Get-PfbFleetMember.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeConnection = [PSCustomObject]@{
         PSTypeName   = 'PureStorage.FlashBlade.Connection'

--- a/Tests/Get-PfbPolicyAllMember.Tests.ps1
+++ b/Tests/Get-PfbPolicyAllMember.Tests.ps1
@@ -1,7 +1,8 @@
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
 
 BeforeAll {
-    Import-Module "$PSScriptRoot/../PureStorageFlashBladePowerShell.psd1" -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 
     $script:sourceFile = [System.IO.Path]::Combine(

--- a/Tests/Get-PfbPolicyFileSystemReplicaLink.Tests.ps1
+++ b/Tests/Get-PfbPolicyFileSystemReplicaLink.Tests.ps1
@@ -2,7 +2,8 @@
 
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
-    Import-Module (Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1') -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray  = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
     $script:sourceFile = [System.IO.Path]::Combine($moduleRoot, 'Public', 'Policy', 'Get-PfbPolicyFileSystemReplicaLink.ps1')

--- a/Tests/Get-PfbRemoteArray.Tests.ps1
+++ b/Tests/Get-PfbRemoteArray.Tests.ps1
@@ -18,7 +18,8 @@
 
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
-    Import-Module (Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1') -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeConnection = [PSCustomObject]@{
         PSTypeName   = 'PureStorage.FlashBlade.Connection'

--- a/Tests/Get-PfbSmtpServer.Tests.ps1
+++ b/Tests/Get-PfbSmtpServer.Tests.ps1
@@ -8,7 +8,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{
         Endpoint             = 'fb.example.test'

--- a/Tests/Get-PfbUserGroupQuotaPolicy.Tests.ps1
+++ b/Tests/Get-PfbUserGroupQuotaPolicy.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.25'; AuthToken = 'x' }
 }

--- a/Tests/Get-PfbUserGroupQuotaPolicyFileSystem.Tests.ps1
+++ b/Tests/Get-PfbUserGroupQuotaPolicyFileSystem.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.25'; AuthToken = 'x' }
 }

--- a/Tests/Get-PfbUserGroupQuotaPolicyMember.Tests.ps1
+++ b/Tests/Get-PfbUserGroupQuotaPolicyMember.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.25'; AuthToken = 'x' }
 }

--- a/Tests/Get-PfbUserGroupQuotaPolicyRule.Tests.ps1
+++ b/Tests/Get-PfbUserGroupQuotaPolicyRule.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.25'; AuthToken = 'x' }
 }

--- a/Tests/Get-PfbVersionMap.Tests.ps1
+++ b/Tests/Get-PfbVersionMap.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:originalModuleRoot = InModuleScope PureStorageFlashBladePowerShell { $script:PfbModuleRoot }
 }

--- a/Tests/Invoke-PfbApiRequest.CapabilityCheck.Tests.ps1
+++ b/Tests/Invoke-PfbApiRequest.CapabilityCheck.Tests.ps1
@@ -10,7 +10,8 @@
 #>
 
 BeforeAll {
-    Import-Module "$PSScriptRoot/../PureStorageFlashBladePowerShell.psd1" -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:originalModuleRoot = InModuleScope PureStorageFlashBladePowerShell { $script:PfbModuleRoot }
 

--- a/Tests/Invoke-PfbApiRequest.ContextInjection.Tests.ps1
+++ b/Tests/Invoke-PfbApiRequest.ContextInjection.Tests.ps1
@@ -7,7 +7,8 @@
 #>
 
 BeforeAll {
-    Import-Module "$PSScriptRoot/../PureStorageFlashBladePowerShell.psd1" -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 }
 
 # Two scaffolding rules, both load-bearing:

--- a/Tests/Invoke-PfbApiRequest.EmptyResult.Tests.ps1
+++ b/Tests/Invoke-PfbApiRequest.EmptyResult.Tests.ps1
@@ -22,7 +22,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 }
 
 Describe 'Invoke-PfbApiRequest - empty results' {

--- a/Tests/Invoke-PfbApiRequest.Reconnect.Tests.ps1
+++ b/Tests/Invoke-PfbApiRequest.Reconnect.Tests.ps1
@@ -1,7 +1,8 @@
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
 
 BeforeAll {
-    Import-Module "$PSScriptRoot/../PureStorageFlashBladePowerShell.psd1" -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     function New-MockHttpError {
         param([int]$StatusCode, [string]$Message = 'mock http error')

--- a/Tests/Invoke-PfbApiRequest.Tests.ps1
+++ b/Tests/Invoke-PfbApiRequest.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 }
 
 Describe 'Invoke-PfbApiRequest - HttpTimeoutMs is applied' {

--- a/Tests/Invoke-PfbApiTokenLogin.Tests.ps1
+++ b/Tests/Invoke-PfbApiTokenLogin.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 }
 
 Describe 'Invoke-PfbApiTokenLogin' {

--- a/Tests/Invoke-PfbInContext.Tests.ps1
+++ b/Tests/Invoke-PfbInContext.Tests.ps1
@@ -1,7 +1,8 @@
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
 
 BeforeAll {
-    Import-Module "$PSScriptRoot/../PureStorageFlashBladePowerShell.psd1" -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 }
 
 Describe 'Invoke-PfbInContext' {

--- a/Tests/Invoke-PfbNetworkTrace.Tests.ps1
+++ b/Tests/Invoke-PfbNetworkTrace.Tests.ps1
@@ -1,7 +1,8 @@
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
 
 BeforeAll {
-    Import-Module "$PSScriptRoot/../PureStorageFlashBladePowerShell.psd1" -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }
 

--- a/Tests/Issue88.SelectorReachability.Tests.ps1
+++ b/Tests/Issue88.SelectorReachability.Tests.ps1
@@ -189,7 +189,8 @@ $tableCoverageCase = @(
 
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
-    Import-Module (Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1') -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/New-PfbApiToken.Tests.ps1
+++ b/Tests/New-PfbApiToken.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/New-PfbArrayConnection.Tests.ps1
+++ b/Tests/New-PfbArrayConnection.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/New-PfbCertificateCertificateGroup.Tests.ps1
+++ b/Tests/New-PfbCertificateCertificateGroup.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/New-PfbFileSystem.Tests.ps1
+++ b/Tests/New-PfbFileSystem.Tests.ps1
@@ -2,7 +2,8 @@
 
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
-    Import-Module (Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1') -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.26'; AuthToken = 'x' }
 }
 

--- a/Tests/New-PfbFileSystemReplicaLink.Tests.ps1
+++ b/Tests/New-PfbFileSystemReplicaLink.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/New-PfbFileSystemReplicaLinkPolicy.Tests.ps1
+++ b/Tests/New-PfbFileSystemReplicaLinkPolicy.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/New-PfbFileSystemSnapshot.Tests.ps1
+++ b/Tests/New-PfbFileSystemSnapshot.Tests.ps1
@@ -1,7 +1,8 @@
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
 
 BeforeAll {
-    Import-Module "$PSScriptRoot/../PureStorageFlashBladePowerShell.psd1" -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
     # A throwaway connection object; Assert-PfbConnection is mocked so its contents don't matter.
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/New-PfbFileSystemUserGroupQuotaPolicy.Tests.ps1
+++ b/Tests/New-PfbFileSystemUserGroupQuotaPolicy.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.25'; AuthToken = 'x' }
 }

--- a/Tests/New-PfbFleetMember.Tests.ps1
+++ b/Tests/New-PfbFleetMember.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/New-PfbJwtToken.Tests.ps1
+++ b/Tests/New-PfbJwtToken.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 }
 
 Describe 'New-PfbJwtToken' {

--- a/Tests/New-PfbLegalHoldEntity.Tests.ps1
+++ b/Tests/New-PfbLegalHoldEntity.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/New-PfbNetworkAccessRule.Tests.ps1
+++ b/Tests/New-PfbNetworkAccessRule.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/New-PfbNetworkInterfaceTlsPolicy.Tests.ps1
+++ b/Tests/New-PfbNetworkInterfaceTlsPolicy.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/New-PfbNfsExportRule.Tests.ps1
+++ b/Tests/New-PfbNfsExportRule.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/New-PfbNodeGroupNode.Tests.ps1
+++ b/Tests/New-PfbNodeGroupNode.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/New-PfbObjectStoreAccountExport.Tests.ps1
+++ b/Tests/New-PfbObjectStoreAccountExport.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/New-PfbPolicyFileSystem.Tests.ps1
+++ b/Tests/New-PfbPolicyFileSystem.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/New-PfbPolicyFileSystemReplicaLink.Tests.ps1
+++ b/Tests/New-PfbPolicyFileSystemReplicaLink.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/New-PfbQosPolicyMember.Tests.ps1
+++ b/Tests/New-PfbQosPolicyMember.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/New-PfbQuotaGroup.Tests.ps1
+++ b/Tests/New-PfbQuotaGroup.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/New-PfbQuotaUser.Tests.ps1
+++ b/Tests/New-PfbQuotaUser.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/New-PfbS3ExportRule.Tests.ps1
+++ b/Tests/New-PfbS3ExportRule.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/New-PfbSmbClientRule.Tests.ps1
+++ b/Tests/New-PfbSmbClientRule.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/New-PfbSmbShareRule.Tests.ps1
+++ b/Tests/New-PfbSmbShareRule.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/New-PfbUserGroupQuotaPolicy.Tests.ps1
+++ b/Tests/New-PfbUserGroupQuotaPolicy.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.25'; AuthToken = 'x' }
 }

--- a/Tests/New-PfbUserGroupQuotaPolicyFileSystem.Tests.ps1
+++ b/Tests/New-PfbUserGroupQuotaPolicyFileSystem.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.25'; AuthToken = 'x' }
 }

--- a/Tests/New-PfbUserGroupQuotaPolicyRule.Tests.ps1
+++ b/Tests/New-PfbUserGroupQuotaPolicyRule.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.25'; AuthToken = 'x' }
 }

--- a/Tests/ObjectStoreAccessPolicyAssociations.Tests.ps1
+++ b/Tests/ObjectStoreAccessPolicyAssociations.Tests.ps1
@@ -1,7 +1,8 @@
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
 
 BeforeAll {
-    Import-Module "$PSScriptRoot/../PureStorageFlashBladePowerShell.psd1" -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
     # A throwaway connection object; Assert-PfbConnection is mocked so its contents don't matter.
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/ObjectStoreAccountExport.Tests.ps1
+++ b/Tests/ObjectStoreAccountExport.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/PfbBucketPolicySelectors.Tests.ps1
+++ b/Tests/PfbBucketPolicySelectors.Tests.ps1
@@ -108,7 +108,8 @@ $script:bucketOnlyPostCases = @(
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{
         Endpoint   = 'fb.example.test'

--- a/Tests/PfbCapabilityMapEndpointCoverage.Tests.ps1
+++ b/Tests/PfbCapabilityMapEndpointCoverage.Tests.ps1
@@ -18,7 +18,8 @@
 # without anyone editing it.
 
 BeforeAll {
-    Import-Module "$PSScriptRoot/../PureStorageFlashBladePowerShell.psd1" -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:PublicRoot = (Resolve-Path "$PSScriptRoot/../Public").Path
 

--- a/Tests/PfbContext.Tests.ps1
+++ b/Tests/PfbContext.Tests.ps1
@@ -1,7 +1,8 @@
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
 
 BeforeAll {
-    Import-Module "$PSScriptRoot/../PureStorageFlashBladePowerShell.psd1" -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 }
 
 Describe 'PfbContext object' {

--- a/Tests/PfbDeadSelectorRemoval.Tests.ps1
+++ b/Tests/PfbDeadSelectorRemoval.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{
         Endpoint   = 'fb.example.test'

--- a/Tests/PfbPipelineSelectorTools.Tests.ps1
+++ b/Tests/PfbPipelineSelectorTools.Tests.ps1
@@ -22,7 +22,8 @@ BeforeAll {
         . (Join-Path $script:repoRoot 'tools/lib/PfbPipelineSelectorTools.ps1')
         . (Join-Path $script:repoRoot 'tools/lib/PfbCmdletParamTools.ps1')
 
-        $script:module = Import-Module (Join-Path $script:repoRoot 'PureStorageFlashBladePowerShell.psd1') -Force -PassThru
+        . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+        $script:module = Import-PfbTestModule
         $script:bound = Get-PfbPipelineBoundParameter -Module $script:module
 
         $script:shapeMap = Get-Content (Join-Path $script:repoRoot 'Data/PfbResponseShapeMap.json') -Raw |

--- a/Tests/PfbSelectorLift.Tests.ps1
+++ b/Tests/PfbSelectorLift.Tests.ps1
@@ -1,7 +1,8 @@
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
 
 BeforeAll {
-    Import-Module "$PSScriptRoot/../PureStorageFlashBladePowerShell.psd1" -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
     $script:fakeArray = [PSCustomObject]@{
         Endpoint  = 'fb.example.test'
         ApiVersion = '2.0'

--- a/Tests/PfbSpecializedSelectorKeys.Tests.ps1
+++ b/Tests/PfbSpecializedSelectorKeys.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{
         Endpoint  = 'fb.example.test'

--- a/Tests/PfbTestImportTools.Tests.ps1
+++ b/Tests/PfbTestImportTools.Tests.ps1
@@ -41,6 +41,21 @@ BeforeAll {
         $found = @(Get-PfbTestManifestImport -Path $path)
         $found.Count | Should -Be 1
         $found[0].Form | Should -Be 'NestedJoinPath'
+
+        # The offset contract Task 3 splices on, pinned against the fixture's own text.
+        # These are CHARACTER offsets into the decoded file with an exclusive EndOffset,
+        # so ReadAllText + Substring must round-trip the returned Text exactly. Asserted
+        # on the multi-line case specifically: a first-line-only extent (stopping at the
+        # backtick) or an off-by-one would corrupt the file byte-wise when spliced.
+        $raw = [System.IO.File]::ReadAllText($path)
+        $slice = $raw.Substring($found[0].StartOffset, $found[0].EndOffset - $found[0].StartOffset)
+        $slice | Should -BeExactly $found[0].Text
+
+        # Begins with the command and ends with the trailing parameter: proves the extent
+        # spans the whole two-line command rather than truncating at the continuation.
+        $found[0].Text | Should -BeLike 'Import-Module*'
+        $found[0].Text | Should -Match '-Force\s*$'
+        $found[0].Text.Split("`n").Count | Should -BeGreaterThan 1
     }
 
     It 'does not match the separate-runspace AddCommand call' {
@@ -96,6 +111,18 @@ Describe 'Test-PfbTestModuleUsage detects the module-use obligation structurally
         $path = Join-Path $script:usageDir ((New-Guid).Guid + '.Tests.ps1')
         Set-Content -LiteralPath $path -Value "BeforeAll {`n$Body`n}" -Encoding UTF8
         (Test-PfbTestModuleUsage -Path $path -ExportedFunction $script:exported).Uses | Should -Be $Uses
+    }
+
+    It 'names the reason it fired, not just that it fired' {
+        # Reasons is what a Task 4/5 guard failure quotes back to a maintainer, so pin
+        # that it identifies the actual trigger -- the cmdlet and its line -- rather than
+        # only agreeing with the Uses boolean.
+        $path = Join-Path $script:usageDir 'reasons.Tests.ps1'
+        Set-Content -LiteralPath $path -Value "BeforeAll {`n    `$null = Get-PfbArray -Array `$a`n}" -Encoding UTF8
+        $result = Test-PfbTestModuleUsage -Path $path -ExportedFunction $script:exported
+        $result.Uses | Should -BeTrue
+        @($result.Reasons).Count | Should -Be 1
+        $result.Reasons[0] | Should -BeExactly 'calls exported cmdlet Get-PfbArray (line 2)'
     }
 
     It 'reports CallsHelper when the file loads via Import-PfbTestModule' {

--- a/Tests/PfbTestImportTools.Tests.ps1
+++ b/Tests/PfbTestImportTools.Tests.ps1
@@ -1,0 +1,108 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    $script:repoRoot = Split-Path -Parent $PSScriptRoot
+    . (Join-Path $script:repoRoot 'tools/lib/PfbTestImportTools.ps1')
+    $script:manifestPath = Join-Path $script:repoRoot 'PureStorageFlashBladePowerShell.psd1'
+}
+
+Describe 'Get-PfbTestManifestImport classifies every call-site form' {
+    BeforeAll {
+        $script:fixtureDir = Join-Path $TestDrive 'fixtures'
+        $null = New-Item -ItemType Directory -Path $script:fixtureDir -Force
+    }
+
+    It 'classifies the <Expected> form' -ForEach @(
+        @{ Expected = 'Manifest';       Body = '    Import-Module $manifest -Force' }
+        @{ Expected = 'PSScriptRoot';   Body = '    Import-Module "$PSScriptRoot/../PureStorageFlashBladePowerShell.psd1" -Force' }
+        @{ Expected = 'JoinPath';       Body = "    Import-Module (Join-Path `$moduleRoot 'PureStorageFlashBladePowerShell.psd1') -Force" }
+        @{ Expected = 'ScriptManifest'; Body = '    Import-Module $script:manifest -Force' }
+        @{ Expected = 'PassThru';       Body = "    `$script:module = Import-Module (Join-Path `$script:repoRoot 'PureStorageFlashBladePowerShell.psd1') -Force -PassThru" }
+    ) {
+        $path = Join-Path $script:fixtureDir "$Expected.Tests.ps1"
+        Set-Content -LiteralPath $path -Value "BeforeAll {`n$Body`n}" -Encoding UTF8
+        $found = @(Get-PfbTestManifestImport -Path $path)
+        $found.Count | Should -Be 1
+        $found[0].Form | Should -Be $Expected
+    }
+
+    It 'classifies a nested Join-Path spelling that spans two lines with a backtick continuation' {
+        # Tests/Test-PfbEmptyPipelineRead.Tests.ps1:4, added by PR #125. The extent spans two
+        # lines, so the classifier must not assume a single-line argument and the rewriter
+        # must splice over both lines. A here-string keeps the backtick literal.
+        $path = Join-Path $script:fixtureDir 'NestedJoinPathContinuation.Tests.ps1'
+        $body = @'
+BeforeAll {
+    Import-Module (Join-Path (Split-Path -Parent $PSScriptRoot) `
+            'PureStorageFlashBladePowerShell.psd1') -Force
+}
+'@
+        Set-Content -LiteralPath $path -Value $body -Encoding UTF8
+        $found = @(Get-PfbTestManifestImport -Path $path)
+        $found.Count | Should -Be 1
+        $found[0].Form | Should -Be 'NestedJoinPath'
+    }
+
+    It 'does not match the separate-runspace AddCommand call' {
+        $path = Join-Path $script:fixtureDir 'AddCommand.Tests.ps1'
+        $body = "BeforeAll {`n" +
+            "    `$null = `$ps.AddCommand('Import-Module').AddParameter('Name', `$Manifest).AddParameter('Force', `$true)`n}"
+        Set-Content -LiteralPath $path -Value $body -Encoding UTF8
+        @(Get-PfbTestManifestImport -Path $path).Count | Should -Be 0
+    }
+
+    It 'does not match Import-Module as an argument to Mock' {
+        $path = Join-Path $script:fixtureDir 'Mock.Tests.ps1'
+        $body = "BeforeAll {`n" +
+            "    Mock -ModuleName PureStorageFlashBladePowerShell Import-Module { } -ParameterFilter { `$Name -eq 'Posh-SSH' }`n}"
+        Set-Content -LiteralPath $path -Value $body -Encoding UTF8
+        @(Get-PfbTestManifestImport -Path $path).Count | Should -Be 0
+    }
+
+    It 'buckets an unknown manifest -Force spelling as Unrecognised rather than dropping it' {
+        $path = Join-Path $script:fixtureDir 'Odd.Tests.ps1'
+        $body = "BeforeAll {`n    Import-Module `$someOtherVariable -Force`n" +
+            "    Import-Module (Resolve-Path './PureStorageFlashBladePowerShell.psd1') -Force`n}"
+        Set-Content -LiteralPath $path -Value $body -Encoding UTF8
+        $found = @(Get-PfbTestManifestImport -Path $path)
+        $found.Count | Should -Be 1
+        $found[0].Form | Should -Be 'Unrecognised'
+    }
+}
+
+Describe 'Get-PfbExportedFunctionName reads the manifest statically' {
+    It 'returns an explicit list, not a wildcard' {
+        $names = @(Get-PfbExportedFunctionName -ManifestPath $script:manifestPath)
+        $names.Count | Should -BeGreaterThan 500
+        $names | Should -Not -Contain '*'
+        $names | Should -Contain 'Connect-PfbArray'
+    }
+}
+
+Describe 'Test-PfbTestModuleUsage detects the module-use obligation structurally' {
+    BeforeAll {
+        $script:exported = @(Get-PfbExportedFunctionName -ManifestPath $script:manifestPath)
+        $script:usageDir = Join-Path $TestDrive 'usage'
+        $null = New-Item -ItemType Directory -Path $script:usageDir -Force
+    }
+
+    It 'flags <Case>' -ForEach @(
+        @{ Case = 'a call to an exported cmdlet'; Body = '    $null = Get-PfbArray -Array $a'; Uses = $true }
+        @{ Case = 'InModuleScope naming the module'; Body = '    InModuleScope PureStorageFlashBladePowerShell { $script:PfbModuleRoot }'; Uses = $true }
+        @{ Case = 'Mock -ModuleName naming the module'; Body = '    Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }'; Uses = $true }
+        @{ Case = 'a tooling-only file'; Body = "    `$null = Get-PfbApiDriftReport -Path 'x'"; Uses = $false }
+        @{ Case = 'a cmdlet name that only appears inside a string'; Body = "    'Connect-PfbArray' | Should -Be 'Connect-PfbArray'"; Uses = $false }
+    ) {
+        $path = Join-Path $script:usageDir ((New-Guid).Guid + '.Tests.ps1')
+        Set-Content -LiteralPath $path -Value "BeforeAll {`n$Body`n}" -Encoding UTF8
+        (Test-PfbTestModuleUsage -Path $path -ExportedFunction $script:exported).Uses | Should -Be $Uses
+    }
+
+    It 'reports CallsHelper when the file loads via Import-PfbTestModule' {
+        $path = Join-Path $script:usageDir 'helper.Tests.ps1'
+        $body = "BeforeAll {`n    . (Join-Path `$PSScriptRoot 'PfbTestModule.ps1')`n" +
+            "    `$null = Import-PfbTestModule`n}"
+        Set-Content -LiteralPath $path -Value $body -Encoding UTF8
+        (Test-PfbTestModuleUsage -Path $path -ExportedFunction $script:exported).CallsHelper | Should -BeTrue
+    }
+}

--- a/Tests/PfbTestModule.Tests.ps1
+++ b/Tests/PfbTestModule.Tests.ps1
@@ -35,24 +35,82 @@ Describe 'Import-PfbTestModule' {
 
     It 'resets the connection state, the credential cache and the module root on every call' {
         $module = Import-PfbTestModule
-        & $module {
-            $script:PfbDefaultArray = 'dirty'
-            $script:PfbArrays = @{ leaked = $true }
-            $script:PfbCachedCredential = 'leaked-credential'
-            $script:PfbModuleRoot = 'TestDrive:\nonexistent'
+        # Save and restore the two lazy caches: redirecting $script:PfbModuleRoot below
+        # deliberately trips the helper's synthetic-cache invalidation, and this test must
+        # not decide what state a LATER container inherits.
+        $savedCapability = & $module { $script:PfbCapabilityMap }
+        $savedVersion = & $module { $script:PfbVersionMap }
+        try {
+            & $module {
+                $script:PfbDefaultArray = 'dirty'
+                $script:PfbArrays = @{ leaked = $true }
+                $script:PfbCachedCredential = 'leaked-credential'
+                $script:PfbModuleRoot = 'TestDrive:\nonexistent'
+            }
+            $module = Import-PfbTestModule
+            (& $module { $script:PfbDefaultArray }) | Should -BeNullOrEmpty
+            (& $module { $script:PfbArrays.Count }) | Should -Be 0
+            (& $module { $script:PfbCachedCredential }) | Should -BeNullOrEmpty
+            (& $module { $script:PfbModuleRoot }) | Should -Be $module.ModuleBase
         }
-        $module = Import-PfbTestModule
-        (& $module { $script:PfbDefaultArray }) | Should -BeNullOrEmpty
-        (& $module { $script:PfbArrays.Count }) | Should -Be 0
-        (& $module { $script:PfbCachedCredential }) | Should -BeNullOrEmpty
-        (& $module { $script:PfbModuleRoot }) | Should -Be $module.ModuleBase
+        finally {
+            # param()-passing, NOT .GetNewClosure(): a closure fails under StrictMode and
+            # silently leaks the planted state instead.
+            & $module {
+                param($capability, $version)
+                $script:PfbCapabilityMap = $capability
+                $script:PfbVersionMap = $version
+            } $savedCapability $savedVersion
+        }
     }
 
-    It 'leaves the read-only JSON caches warm' {
+    It 'leaves both read-only JSON caches warm across an ordinary reuse' {
+        # This is the guard on the helper's conditional cache invalidation: on a plain
+        # reuse the invalidation branch must NOT be taken. A mis-typed comparison there
+        # would clear the caches on every single call and quietly give back part of the
+        # speedup while every test stayed green.
         $module = Import-PfbTestModule
-        & $module { $script:PfbCapabilityMap = 'warm-marker' }
+        $savedCapability = & $module { $script:PfbCapabilityMap }
+        $savedVersion = & $module { $script:PfbVersionMap }
+        try {
+            & $module {
+                $script:PfbCapabilityMap = 'warm-marker'
+                $script:PfbVersionMap = 'warm-version-marker'
+            }
+            $module = Import-PfbTestModule
+            (& $module { $script:PfbCapabilityMap }) | Should -Be 'warm-marker'
+            (& $module { $script:PfbVersionMap }) | Should -Be 'warm-version-marker'
+        }
+        finally {
+            & $module {
+                param($capability, $version)
+                $script:PfbCapabilityMap = $capability
+                $script:PfbVersionMap = $version
+            } $savedCapability $savedVersion
+        }
+    }
+
+    It 'invalidates both caches when the incoming module root is not the real module base' {
         $module = Import-PfbTestModule
-        (& $module { $script:PfbCapabilityMap }) | Should -Be 'warm-marker'
+        $savedCapability = & $module { $script:PfbCapabilityMap }
+        $savedVersion = & $module { $script:PfbVersionMap }
+        try {
+            & $module {
+                $script:PfbCapabilityMap = 'synthetic-map'
+                $script:PfbVersionMap = 'synthetic-version'
+                $script:PfbModuleRoot = 'TestDrive:\redirected'
+            }
+            $module = Import-PfbTestModule
+            (& $module { $script:PfbCapabilityMap }) | Should -BeNullOrEmpty
+            (& $module { $script:PfbVersionMap }) | Should -BeNullOrEmpty
+        }
+        finally {
+            & $module {
+                param($capability, $version)
+                $script:PfbCapabilityMap = $capability
+                $script:PfbVersionMap = $version
+            } $savedCapability $savedVersion
+        }
     }
 
     It '-Fresh rebuilds and deliberately does NOT mark the instance prepared' {
@@ -84,5 +142,18 @@ Describe 'Import-PfbTestModule' {
         [int]$global:PfbTestModuleForceCount | Should -Be ($before + 1)
         (& $module { (Get-Command Invoke-PfbApiRequest).Definition }) |
             Should -Not -Match 'PfbSelectorProbeCapture'
+    }
+
+    It 'accepts an explicit -ManifestPath and resolves the same already-prepared instance' {
+        $null = Import-PfbTestModule
+        $before = [int]$global:PfbTestModuleForceCount
+        $module = Import-PfbTestModule -ManifestPath $script:manifest
+        # Same manifest spelled explicitly must reach the SAME instance, i.e. cost no
+        # rebuild -- otherwise a call site that passes -ManifestPath silently pays a
+        # full import on every container.
+        [int]$global:PfbTestModuleForceCount | Should -Be $before
+        $module.Name | Should -Be 'PureStorageFlashBladePowerShell'
+        (ConvertTo-PfbTestPathKey $module.ModuleBase) |
+            Should -Be (ConvertTo-PfbTestPathKey $script:repoRoot)
     }
 }

--- a/Tests/PfbTestModule.Tests.ps1
+++ b/Tests/PfbTestModule.Tests.ps1
@@ -35,9 +35,9 @@ Describe 'Import-PfbTestModule' {
 
     It 'resets the connection state, the credential cache and the module root on every call' {
         $module = Import-PfbTestModule
-        # Save and restore the two lazy caches: redirecting $script:PfbModuleRoot below
-        # deliberately trips the helper's synthetic-cache invalidation, and this test must
-        # not decide what state a LATER container inherits.
+        # Save and restore the two lazy caches: the helper nulls both on every call, so
+        # merely running this test would otherwise leave them cold, and this test must not
+        # decide what state a LATER container inherits.
         $savedCapability = & $module { $script:PfbCapabilityMap }
         $savedVersion = & $module { $script:PfbVersionMap }
         try {
@@ -64,11 +64,14 @@ Describe 'Import-PfbTestModule' {
         }
     }
 
-    It 'leaves both read-only JSON caches warm across an ordinary reuse' {
-        # This is the guard on the helper's conditional cache invalidation: on a plain
-        # reuse the invalidation branch must NOT be taken. A mis-typed comparison there
-        # would clear the caches on every single call and quietly give back part of the
-        # speedup while every test stayed green.
+    It 'clears both read-only JSON caches even on an ordinary reuse' {
+        # The ordinary-reuse case is the one that matters here: nothing about the incoming
+        # state hints that these caches need clearing, and they get cleared anyway. This
+        # test exists to stop anyone reintroducing CONDITIONAL invalidation as a speed
+        # optimisation. A conditional keyed on the incoming $script:PfbModuleRoot was tried
+        # and was wrong: a container that is about to redirect the root needs the cache
+        # empty, and no inspection of incoming state can predict that. See the long comment
+        # in PfbTestModule.ps1 for the exact failure it caused.
         $module = Import-PfbTestModule
         $savedCapability = & $module { $script:PfbCapabilityMap }
         $savedVersion = & $module { $script:PfbVersionMap }
@@ -78,8 +81,8 @@ Describe 'Import-PfbTestModule' {
                 $script:PfbVersionMap = 'warm-version-marker'
             }
             $module = Import-PfbTestModule
-            (& $module { $script:PfbCapabilityMap }) | Should -Be 'warm-marker'
-            (& $module { $script:PfbVersionMap }) | Should -Be 'warm-version-marker'
+            (& $module { $script:PfbCapabilityMap }) | Should -BeNullOrEmpty
+            (& $module { $script:PfbVersionMap }) | Should -BeNullOrEmpty
         }
         finally {
             & $module {
@@ -90,7 +93,12 @@ Describe 'Import-PfbTestModule' {
         }
     }
 
-    It 'invalidates both caches when the incoming module root is not the real module base' {
+    It 'clears both caches when a synthetic module root was left behind too' {
+        # A special case of the unconditional rule above, kept because it documents the
+        # ORIGINAL hazard: a previous container leaves a TestDrive:\ root behind and the
+        # caches it warmed are synthetic. The invalidation is not conditional on this --
+        # the caches are cleared whatever the incoming root says -- but this combination is
+        # the one that would corrupt real data if it ever stopped being covered.
         $module = Import-PfbTestModule
         $savedCapability = & $module { $script:PfbCapabilityMap }
         $savedVersion = & $module { $script:PfbVersionMap }

--- a/Tests/PfbTestModule.Tests.ps1
+++ b/Tests/PfbTestModule.Tests.ps1
@@ -1,0 +1,88 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+<#
+    These tests drive the helper directly, including the paths no call site uses
+    (-Fresh, shim detection). They are the only coverage -Fresh has.
+#>
+
+BeforeAll {
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $script:repoRoot = Split-Path -Parent $PSScriptRoot
+    $script:manifest = Join-Path $script:repoRoot 'PureStorageFlashBladePowerShell.psd1'
+}
+
+Describe 'Import-PfbTestModule' {
+    It 'returns the live module and marks it prepared' {
+        $module = Import-PfbTestModule
+        $module | Should -Not -BeNullOrEmpty
+        $module.Name | Should -Be 'PureStorageFlashBladePowerShell'
+        (& $module { $script:PfbTestModulePrepared }) | Should -BeTrue
+    }
+
+    It 'does not rebuild an already prepared instance' {
+        $first = Import-PfbTestModule
+        & $first { $script:PfbTestModuleWitness = 'kept' }
+        $before = [int]$global:PfbTestModuleForceCount
+        $second = Import-PfbTestModule
+        [int]$global:PfbTestModuleForceCount | Should -Be $before
+        (& $second { $script:PfbTestModuleWitness }) | Should -Be 'kept'
+    }
+
+    It 'increments the call counter on every call' {
+        $before = [int]$global:PfbTestModuleCallCount
+        $null = Import-PfbTestModule
+        [int]$global:PfbTestModuleCallCount | Should -Be ($before + 1)
+    }
+
+    It 'resets the connection state, the credential cache and the module root on every call' {
+        $module = Import-PfbTestModule
+        & $module {
+            $script:PfbDefaultArray = 'dirty'
+            $script:PfbArrays = @{ leaked = $true }
+            $script:PfbCachedCredential = 'leaked-credential'
+            $script:PfbModuleRoot = 'TestDrive:\nonexistent'
+        }
+        $module = Import-PfbTestModule
+        (& $module { $script:PfbDefaultArray }) | Should -BeNullOrEmpty
+        (& $module { $script:PfbArrays.Count }) | Should -Be 0
+        (& $module { $script:PfbCachedCredential }) | Should -BeNullOrEmpty
+        (& $module { $script:PfbModuleRoot }) | Should -Be $module.ModuleBase
+    }
+
+    It 'leaves the read-only JSON caches warm' {
+        $module = Import-PfbTestModule
+        & $module { $script:PfbCapabilityMap = 'warm-marker' }
+        $module = Import-PfbTestModule
+        (& $module { $script:PfbCapabilityMap }) | Should -Be 'warm-marker'
+    }
+
+    It '-Fresh rebuilds and deliberately does NOT mark the instance prepared' {
+        $null = Import-PfbTestModule
+        $before = [int]$global:PfbTestModuleForceCount
+        $fresh = Import-PfbTestModule -Fresh
+        [int]$global:PfbTestModuleForceCount | Should -Be ($before + 1)
+        (& $fresh { $script:PfbTestModulePrepared }) | Should -BeNullOrEmpty
+    }
+
+    It 'force-reimports after an unmarked instance is installed by something else' {
+        $null = Import-PfbTestModule
+        $null = Import-Module -Name $script:manifest -Force -PassThru
+        $before = [int]$global:PfbTestModuleForceCount
+        $module = Import-PfbTestModule
+        [int]$global:PfbTestModuleForceCount | Should -Be ($before + 1)
+        (& $module { $script:PfbTestModulePrepared }) | Should -BeTrue
+    }
+
+    It 'force-reimports when a selector-probe shim is present in module scope' {
+        $module = Import-PfbTestModule
+        & $module {
+            Set-Item -Path 'function:script:Invoke-PfbApiRequest' -Value {
+                $null = 'PfbSelectorProbeCapture'
+            }
+        }
+        $before = [int]$global:PfbTestModuleForceCount
+        $module = Import-PfbTestModule
+        [int]$global:PfbTestModuleForceCount | Should -Be ($before + 1)
+        (& $module { (Get-Command Invoke-PfbApiRequest).Definition }) |
+            Should -Not -Match 'PfbSelectorProbeCapture'
+    }
+}

--- a/Tests/PfbTestModule.ps1
+++ b/Tests/PfbTestModule.ps1
@@ -7,10 +7,15 @@
     dot-source at file scope: file-scope code runs during Pester's DISCOVERY phase,
     and a function left there is not in scope when the run phase executes an It.
 
-    Why this exists: 162 of 187 containers used to call `Import-Module <manifest> -Force`
-    in their BeforeAll, inside ONE host process. -Force discards and rebuilds the module,
-    re-dot-sourcing 544 .ps1 files, so 161 of those rebuilds were of an already loaded,
-    byte-identical module -- ~420-450 s of the Windows pwsh leg.
+    Why this exists: 165 containers used to call `Import-Module <manifest> -Force` in their
+    BeforeAll, inside ONE host process. -Force discards and rebuilds the module,
+    re-dot-sourcing the 574 .ps1 files under Public/ and Private/, so 164 of those rebuilds
+    were of an already loaded, byte-identical module -- ~420-450 s of the Windows pwsh leg.
+
+    Those are the re-measured figures for the tree this landed against, which had 194
+    containers. The originating spec says "162 of 187" and "544 .ps1 files"; that census
+    predates the merge of PR #125 and is low by three importers, seven containers and
+    thirty .ps1 files. Do not "correct" these back to the spec's numbers.
 
     Why -Force cannot simply be deleted: it was doing two pieces of real isolation work.
     (1) Module-scoped connection state and the redirectable $script:PfbModuleRoot must not

--- a/Tests/PfbTestModule.ps1
+++ b/Tests/PfbTestModule.ps1
@@ -1,0 +1,155 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Shared, idempotent module loader for the test suite.
+.DESCRIPTION
+    Dot-source this INSIDE a BeforeAll, then call Import-PfbTestModule. Do not
+    dot-source at file scope: file-scope code runs during Pester's DISCOVERY phase,
+    and a function left there is not in scope when the run phase executes an It.
+
+    Why this exists: 162 of 187 containers used to call `Import-Module <manifest> -Force`
+    in their BeforeAll, inside ONE host process. -Force discards and rebuilds the module,
+    re-dot-sourcing 544 .ps1 files, so 161 of those rebuilds were of an already loaded,
+    byte-identical module -- ~420-450 s of the Windows pwsh leg.
+
+    Why -Force cannot simply be deleted: it was doing two pieces of real isolation work.
+    (1) Module-scoped connection state and the redirectable $script:PfbModuleRoot must not
+    leak between files -- so this helper resets them on every call. (2) The selector probe
+    harness (tools/lib/PfbSelectorProbeHarness.ps1) shims Invoke-PfbApiRequest and
+    Assert-PfbConnection inside module scope and NEVER restores them; it relies entirely on
+    the next caller discarding the module. If a shimmed instance survived into later files,
+    every later file would exercise a capture shim and still pass green.
+
+    Containment for (2) is detection-based, not call-site-based, because the harness does
+    its own `Import-Module -Force -PassThru` and thereby INSTALLS the instance later files
+    inherit. A -Force import produces a NEW instance with no $script:PfbTestModulePrepared,
+    so the next plain call here pays one rebuild and gets a clean module. That is
+    order-independent and fail-closed.
+
+    NOT Pester-dependent, on purpose: no InModuleScope, which exists only inside a Pester
+    run and does not close over caller locals. Module scope is reached with
+    `& $module { param($x) ... } $value`, passing values as arguments.
+
+    5.1 CONSTRAINT: dot-sourced by files that run on the winps51 leg. No ternaries, no ??,
+    no pipeline chain operators.
+#>
+
+function ConvertTo-PfbTestPathKey {
+    <#
+        A comparison key for two paths that should name the same directory. Both sides are
+        always built by this same function, so consistency is all that is required of it --
+        it does not need to be a canonical filesystem identity.
+    #>
+    [CmdletBinding()]
+    param([string]$Path)
+
+    if ([string]::IsNullOrWhiteSpace($Path)) { return '' }
+    $full = $Path
+    try { $full = [System.IO.Path]::GetFullPath($Path) } catch { $full = $Path }
+    return $full.TrimEnd([char]'\', [char]'/')
+}
+
+function Test-PfbTestModulePristine {
+    <#
+        $true when neither shimmable function carries the harness's capture markers.
+
+        A POSITIVE match on the harness's own markers, mirroring the harness's reasoning at
+        tools/lib/PfbSelectorProbeHarness.ps1:72 -- a reworded message in the REAL function
+        cannot make this pass vacuously.
+    #>
+    [CmdletBinding()]
+    param([Parameter(Mandatory = $true)]$Module)
+
+    $definitions = & $Module {
+        $request = Get-Command -Name 'Invoke-PfbApiRequest' -ErrorAction SilentlyContinue
+        $assert = Get-Command -Name 'Assert-PfbConnection' -ErrorAction SilentlyContinue
+        $requestText = ''
+        $assertText = ''
+        if ($null -ne $request) { $requestText = [string]$request.Definition }
+        if ($null -ne $assert) { $assertText = [string]$assert.Definition }
+        return [PSCustomObject]@{ Request = $requestText; Assert = $assertText }
+    }
+
+    if ($definitions.Request -match 'PfbSelectorProbeCapture') { return $false }
+    if ($definitions.Assert -match 'PfbSelectorProbeCaptureAssert') { return $false }
+    return $true
+}
+
+function Import-PfbTestModule {
+    [CmdletBinding()]
+    param(
+        [switch]$Fresh,
+        [string]$ManifestPath
+    )
+
+    if ([string]::IsNullOrWhiteSpace($ManifestPath)) {
+        $ManifestPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'PureStorageFlashBladePowerShell.psd1'
+    }
+    $expectedBase = ConvertTo-PfbTestPathKey (Split-Path -Parent $ManifestPath)
+
+    # Get-Module returns a COLLECTION, and returns more than one element whenever a
+    # same-named module is also reachable from PSModulePath. `& $module { }` against a
+    # two-element array fails, so filter then index -- never assign Get-Module bare.
+    $candidates = @(Get-Module -Name 'PureStorageFlashBladePowerShell' |
+        Where-Object { (ConvertTo-PfbTestPathKey $_.ModuleBase) -ieq $expectedBase })
+    $module = $null
+    if ($candidates.Count -gt 0) { $module = $candidates[0] }
+
+    $reason = $null
+    if ($Fresh) {
+        $reason = '-Fresh requested'
+    }
+    elseif ($null -eq $module) {
+        $reason = 'no loaded instance at the expected base'
+    }
+    elseif (-not (& $module { $script:PfbTestModulePrepared })) {
+        $reason = 'instance was force-imported by something other than this helper'
+    }
+    elseif (-not (Test-PfbTestModulePristine -Module $module)) {
+        $reason = 'selector-probe shim detected in module scope'
+    }
+
+    if ($null -ne $reason) {
+        $module = Import-Module -Name $ManifestPath -Force -PassThru -ErrorAction Stop
+        # -Fresh deliberately withholds the marker: "I want a virgin module and I do not
+        # promise to leave it clean", so the NEXT caller rebuilds. That is what makes
+        # -Fresh safe downstream, not just for its own caller.
+        if (-not $Fresh) { & $module { $script:PfbTestModulePrepared = $true } }
+
+        # GLOBAL, not module scope: a counter kept in module scope is wiped by the very
+        # -Force import it is counting, so it would read 1 forever and always look
+        # perfect -- a broken instrument that reports success.
+        $global:PfbTestModuleForceCount = 1 + [int]$global:PfbTestModuleForceCount
+
+        # Write-Host, not Write-Verbose: this must appear in the CI job log. On a healthy
+        # run it is 1-3 lines. If it appears 162 times the win is gone, and the reason
+        # plus the two path spellings name the cause. No assertion over test OUTCOMES can
+        # detect that failure, because it fails closed and everything stays green.
+        Write-Host ("PfbTestModule: full import #{0} ({1}); expected base '{2}'" -f
+            $global:PfbTestModuleForceCount, $reason, $expectedBase)
+    }
+
+    $global:PfbTestModuleCallCount = 1 + [int]$global:PfbTestModuleCallCount
+
+    # Reset on EVERY call, including straight after a fresh import, so there is exactly
+    # one code path. $script:PfbModuleRoot is NOT a constant: 12 lines across 4 test files
+    # redirect it at TestDrive:\ so the cache getters load synthetic JSON, and a dead
+    # TestDrive: path left here silently nulls both caches for every later file.
+    # The two JSON caches are deliberately NOT reset -- keeping them warm is part of the
+    # speedup, and they are lazy read-only reads of committed data.
+    # $script:PfbCachedCredential is NOT declared in the .psm1 preamble -- it is created on
+    # first write by Set-PfbCredential / Get-PfbCredential and cleared by
+    # Clear-PfbCredential. No test exercises those three cmdlets today, so the leak is
+    # latent rather than active; reset it anyway. Without this, the first test that calls
+    # Set-PfbCredential leaves a credential cached for every later file, and
+    # Get-PfbCredential silently returns it instead of prompting.
+    & $module {
+        param($root)
+        $script:PfbDefaultArray = $null
+        $script:PfbArrays = @{}
+        $script:PfbCachedCredential = $null
+        $script:PfbModuleRoot = $root
+    } $module.ModuleBase
+
+    return $module
+}

--- a/Tests/PfbTestModule.ps1
+++ b/Tests/PfbTestModule.ps1
@@ -32,6 +32,11 @@
 
     5.1 CONSTRAINT: dot-sourced by files that run on the winps51 leg. No ternaries, no ??,
     no pipeline chain operators.
+
+    -ManifestPath is almost never needed. $PSScriptRoot inside Import-PfbTestModule resolves
+    to the DEFINING file's directory (Tests/), not the caller's -- measured by dot-sourcing
+    this file from a script in %TEMP% on both editions, where the default manifest path still
+    resolved and the import succeeded. So a call site in a Tests/ subdirectory can omit it.
 #>
 
 function ConvertTo-PfbTestPathKey {
@@ -82,6 +87,15 @@ function Import-PfbTestModule {
         [string]$ManifestPath
     )
 
+    # StrictMode is inherited dynamically into a callee, so the first call in a process
+    # would throw on `[int]$global:PfbTestModuleForceCount` if a caller has
+    # `Set-StrictMode -Version Latest` in force. Initialise here rather than at
+    # dot-source time: a bare assignment at dot-source time would ZERO the counters in
+    # every one of the ~165 BeforeAll blocks that dot-sources this file, destroying the
+    # instrument below.
+    if (-not (Test-Path variable:global:PfbTestModuleForceCount)) { $global:PfbTestModuleForceCount = 0 }
+    if (-not (Test-Path variable:global:PfbTestModuleCallCount)) { $global:PfbTestModuleCallCount = 0 }
+
     if ([string]::IsNullOrWhiteSpace($ManifestPath)) {
         $ManifestPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'PureStorageFlashBladePowerShell.psd1'
     }
@@ -90,17 +104,40 @@ function Import-PfbTestModule {
     # Get-Module returns a COLLECTION, and returns more than one element whenever a
     # same-named module is also reachable from PSModulePath. `& $module { }` against a
     # two-element array fails, so filter then index -- never assign Get-Module bare.
-    $candidates = @(Get-Module -Name 'PureStorageFlashBladePowerShell' |
+    # $loaded is kept unfiltered so the log line below can report the base(s) that ARE
+    # loaded, which is the one fact needed to diagnose a path-spelling mismatch.
+    $loaded = @(Get-Module -Name 'PureStorageFlashBladePowerShell')
+    $candidates = @($loaded |
         Where-Object { (ConvertTo-PfbTestPathKey $_.ModuleBase) -ieq $expectedBase })
     $module = $null
     if ($candidates.Count -gt 0) { $module = $candidates[0] }
+
+    $loadedBases = 'none'
+    if ($loaded.Count -gt 0) {
+        $loadedBases = (@($loaded | ForEach-Object { "'" + $_.ModuleBase + "'" }) -join ', ')
+    }
 
     $reason = $null
     if ($Fresh) {
         $reason = '-Fresh requested'
     }
     elseif ($null -eq $module) {
-        $reason = 'no loaded instance at the expected base'
+        # Two very different situations, and they MUST NOT share a reason string. The
+        # first is healthy and happens exactly once per process. The second is the
+        # fail-closed catastrophe this whole instrument exists to detect: the module IS
+        # loaded, but at a spelling the key comparison rejects, so all ~165 containers
+        # take the force path, every test stays green, and the entire saving is gone.
+        # No path normalisation can rescue that case -- measured on this box, neither
+        # [System.IO.Path]::GetFullPath nor (Get-Item ...).FullName resolves the
+        # C:\Users\Justin junction to its real C:\Users\Justin Emerson spelling. Do NOT
+        # "harden" the comparison with a resolution call and assume the risk is handled;
+        # this log line is the only detector there is.
+        if ($loaded.Count -gt 0) {
+            $reason = 'loaded instance(s) exist but NONE at the expected base -- path spelling mismatch'
+        }
+        else {
+            $reason = 'no loaded instance of that name'
+        }
     }
     elseif (-not (& $module { $script:PfbTestModulePrepared })) {
         $reason = 'instance was force-imported by something other than this helper'
@@ -121,12 +158,33 @@ function Import-PfbTestModule {
         # perfect -- a broken instrument that reports success.
         $global:PfbTestModuleForceCount = 1 + [int]$global:PfbTestModuleForceCount
 
-        # Write-Host, not Write-Verbose: this must appear in the CI job log. On a healthy
-        # run it is 1-3 lines. If it appears 162 times the win is gone, and the reason
-        # plus the two path spellings name the cause. No assertion over test OUTCOMES can
-        # detect that failure, because it fails closed and everything stays green.
-        Write-Host ("PfbTestModule: full import #{0} ({1}); expected base '{2}'" -f
-            $global:PfbTestModuleForceCount, $reason, $expectedBase)
+        # Write-Host, not Write-Verbose: this must appear in the CI job log. No assertion
+        # over test OUTCOMES can detect the failure this instrument exists for, because
+        # that failure fails closed and everything stays green.
+        #
+        # What a HEALTHY run looks like -- an enumeration of contributors, not a small
+        # absolute number:
+        #   1  the first container in the process to call the helper (the cold import);
+        #   4  Tests/PfbTestModule.Tests.ps1 itself, which force-imports deliberately
+        #      because it is the subject under test (-Fresh, the unmarked instance -Fresh
+        #      leaves behind, the explicit external Import-Module -Force case, and the
+        #      shim case);
+        #   1  one recovery rebuild after each container that calls
+        #      Initialize-PfbSelectorHarness -- today Tests/PfbSelectorProbeHarness.Tests.ps1
+        #      and Tests/PfbPipelineSelectorRail.Tests.ps1, so 2 on pwsh7 and 0 on
+        #      Windows PowerShell 5.1 where both are edition-gated;
+        #   +1 per container the rewrite cannot convert.
+        # That is roughly 7 on pwsh7 and 5 on 5.1 today.
+        #
+        # Every -Fresh call site costs TWO force imports, not one: its own, plus the next
+        # plain caller's, because -Fresh deliberately withholds the prepared marker.
+        # There are ZERO -Fresh call sites today (only this file's own test uses it).
+        #
+        # The GATE is therefore `FORCE < CALLS / 10`, not any small absolute number. The
+        # exact healthy figure gets measured and pinned as a literal once the tree-wide
+        # rewrite has landed; until then, a ratio is the only honest assertion.
+        Write-Host ("PfbTestModule: full import #{0} ({1}); expected base '{2}'; loaded base(s) {3}" -f
+            $global:PfbTestModuleForceCount, $reason, $expectedBase, $loadedBases)
     }
 
     $global:PfbTestModuleCallCount = 1 + [int]$global:PfbTestModuleCallCount
@@ -143,6 +201,26 @@ function Import-PfbTestModule {
     # latent rather than active; reset it anyway. Without this, the first test that calls
     # Set-PfbCredential leaves a credential cached for every later file, and
     # Get-PfbCredential silently returns it instead of prompting.
+    #
+    # ...with ONE fail-safe exception. Dropping -Force means a synthetic JSON cache loaded
+    # under a redirected $script:PfbModuleRoot now outlives its container. Four test files
+    # redirect that root and all four restore it in an AfterEach today, but none of those
+    # restores is asserted anywhere, so "the caches are real" would rest entirely on other
+    # files' teardown remaining correct forever. Instead: invalidate the two caches only
+    # when the INCOMING root proves they may be synthetic. On any happy path -- a plain
+    # reuse, or the instant after a fresh import -- the incoming root already equals
+    # $module.ModuleBase, this branch is not taken, and the caches stay warm exactly as
+    # the design requires. If this comparison is ever mis-typed into always-true it would
+    # silently clear the caches on every call and give back part of the speedup, so there
+    # is a test asserting the branch is NOT taken on a plain reuse.
+    $incomingRoot = & $module { $script:PfbModuleRoot }
+    if ((ConvertTo-PfbTestPathKey $incomingRoot) -ine (ConvertTo-PfbTestPathKey $module.ModuleBase)) {
+        & $module {
+            $script:PfbCapabilityMap = $null
+            $script:PfbVersionMap = $null
+        }
+    }
+
     & $module {
         param($root)
         $script:PfbDefaultArray = $null

--- a/Tests/PfbTestModule.ps1
+++ b/Tests/PfbTestModule.ps1
@@ -193,8 +193,6 @@ function Import-PfbTestModule {
     # one code path. $script:PfbModuleRoot is NOT a constant: 12 lines across 4 test files
     # redirect it at TestDrive:\ so the cache getters load synthetic JSON, and a dead
     # TestDrive: path left here silently nulls both caches for every later file.
-    # The two JSON caches are deliberately NOT reset -- keeping them warm is part of the
-    # speedup, and they are lazy read-only reads of committed data.
     # $script:PfbCachedCredential is NOT declared in the .psm1 preamble -- it is created on
     # first write by Set-PfbCredential / Get-PfbCredential and cleared by
     # Clear-PfbCredential. No test exercises those three cmdlets today, so the leak is
@@ -202,30 +200,46 @@ function Import-PfbTestModule {
     # Set-PfbCredential leaves a credential cached for every later file, and
     # Get-PfbCredential silently returns it instead of prompting.
     #
-    # ...with ONE fail-safe exception. Dropping -Force means a synthetic JSON cache loaded
-    # under a redirected $script:PfbModuleRoot now outlives its container. Four test files
-    # redirect that root and all four restore it in an AfterEach today, but none of those
-    # restores is asserted anywhere, so "the caches are real" would rest entirely on other
-    # files' teardown remaining correct forever. Instead: invalidate the two caches only
-    # when the INCOMING root proves they may be synthetic. On any happy path -- a plain
-    # reuse, or the instant after a fresh import -- the incoming root already equals
-    # $module.ModuleBase, this branch is not taken, and the caches stay warm exactly as
-    # the design requires. If this comparison is ever mis-typed into always-true it would
-    # silently clear the caches on every call and give back part of the speedup, so there
-    # is a test asserting the branch is NOT taken on a plain reuse.
-    $incomingRoot = & $module { $script:PfbModuleRoot }
-    if ((ConvertTo-PfbTestPathKey $incomingRoot) -ine (ConvertTo-PfbTestPathKey $module.ModuleBase)) {
-        & $module {
-            $script:PfbCapabilityMap = $null
-            $script:PfbVersionMap = $null
-        }
-    }
-
+    # The two lazy JSON caches -- $script:PfbCapabilityMap and $script:PfbVersionMap -- are
+    # nulled UNCONDITIONALLY, and that must not be turned back into a conditional.
+    #
+    # An earlier version nulled them only when the INCOMING $script:PfbModuleRoot differed
+    # from $module.ModuleBase, on the theory that a matching root proves the caches are
+    # real and can stay warm. That is directionally half a test. It catches "a previous
+    # file left a synthetic root behind, so the cache may be synthetic". It cannot catch
+    # the opposite and far more common case: the cache holds REAL data, and the file about
+    # to run is going to redirect the root to TestDrive:\ and needs the cache EMPTY. The
+    # measured failure was
+    #   Get-PfbCapabilityMap.Tests.ps1 -- 'loads and returns the manifest from
+    #   Data/PfbCapabilityMap.json under the module root'
+    # which passes alone and fails when Tests/Connect-PfbArray.Context.Tests.ps1 runs
+    # first. That file populates the real capability map and correctly restores the root,
+    # so incoming == ModuleBase, the conditional declined to invalidate, and the real map
+    # survived into a container whose FIRST It redirects the root and expects synthetic
+    # JSON. (Its AfterEach nulls the cache, so only test 1 was exposed -- which is exactly
+    # why this went unnoticed.) All four root-redirecting files have the same hole:
+    # Assert-PfbApiCapability.Tests.ps1, Get-PfbCapabilityMap.Tests.ps1,
+    # Get-PfbVersionMap.Tests.ps1, Invoke-PfbApiRequest.CapabilityCheck.Tests.ps1.
+    #
+    # No inspection of incoming state can close this: whether the cache needs to be empty
+    # depends on what the container is about to do, and the helper cannot know the future.
+    # Snapshot-and-restore does not close it either -- these tests need the cache EMPTY at
+    # file start, which is what the old `Import-Module -Force` gave them incidentally; a
+    # faithfully restored REAL map fails the same assertion.
+    #
+    # The cost of doing it unconditionally is one re-parse per container that actually
+    # reads a map (Data/PfbCapabilityMap.json is ~351 KB, ~60 ms on pwsh 7 and ~80-160 ms
+    # on 5.1); most containers never touch either map. What it buys is exact -Force
+    # equivalence for these two variables, and that equivalence is the property that makes
+    # ~165 mechanically-rewritten containers trustworthy. Do not trade it back for a few
+    # seconds.
     & $module {
         param($root)
         $script:PfbDefaultArray = $null
         $script:PfbArrays = @{}
         $script:PfbCachedCredential = $null
+        $script:PfbCapabilityMap = $null
+        $script:PfbVersionMap = $null
         $script:PfbModuleRoot = $root
     } $module.ModuleBase
 

--- a/Tests/QuotaGroup.Tests.ps1
+++ b/Tests/QuotaGroup.Tests.ps1
@@ -1,7 +1,8 @@
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
 
 BeforeAll {
-    Import-Module "$PSScriptRoot/../PureStorageFlashBladePowerShell.psd1" -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }
 

--- a/Tests/QuotaUser.Tests.ps1
+++ b/Tests/QuotaUser.Tests.ps1
@@ -1,7 +1,8 @@
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
 
 BeforeAll {
-    Import-Module "$PSScriptRoot/../PureStorageFlashBladePowerShell.psd1" -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
     # A throwaway connection object; Assert-PfbConnection is mocked so its contents don't matter.
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Remove-PfbApiToken.Tests.ps1
+++ b/Tests/Remove-PfbApiToken.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Remove-PfbArrayConnection.Tests.ps1
+++ b/Tests/Remove-PfbArrayConnection.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Remove-PfbFileSystemReplicaLink.Tests.ps1
+++ b/Tests/Remove-PfbFileSystemReplicaLink.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Remove-PfbFileSystemReplicaLinkPolicy.Tests.ps1
+++ b/Tests/Remove-PfbFileSystemReplicaLinkPolicy.Tests.ps1
@@ -2,7 +2,8 @@
 
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
-    Import-Module (Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1') -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray  = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
     $script:sourceFile = [System.IO.Path]::Combine($moduleRoot, 'Public', 'Replication', 'Remove-PfbFileSystemReplicaLinkPolicy.ps1')

--- a/Tests/Remove-PfbFileSystemSession.Tests.ps1
+++ b/Tests/Remove-PfbFileSystemSession.Tests.ps1
@@ -1,7 +1,8 @@
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
 
 BeforeAll {
-    Import-Module "$PSScriptRoot/../PureStorageFlashBladePowerShell.psd1" -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }
 

--- a/Tests/Remove-PfbFileSystemSnapshotTransfer.Tests.ps1
+++ b/Tests/Remove-PfbFileSystemSnapshotTransfer.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Remove-PfbFileSystemUserGroupQuotaPolicy.Tests.ps1
+++ b/Tests/Remove-PfbFileSystemUserGroupQuotaPolicy.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.25'; AuthToken = 'x' }
 }

--- a/Tests/Remove-PfbPolicyFileSystem.Tests.ps1
+++ b/Tests/Remove-PfbPolicyFileSystem.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Remove-PfbPolicyFileSystemReplicaLink.Tests.ps1
+++ b/Tests/Remove-PfbPolicyFileSystemReplicaLink.Tests.ps1
@@ -2,7 +2,8 @@
 
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
-    Import-Module (Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1') -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray  = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
     $script:sourceFile = [System.IO.Path]::Combine($moduleRoot, 'Public', 'Policy', 'Remove-PfbPolicyFileSystemReplicaLink.ps1')

--- a/Tests/Remove-PfbUserGroupQuotaPolicy.Tests.ps1
+++ b/Tests/Remove-PfbUserGroupQuotaPolicy.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.25'; AuthToken = 'x' }
 }

--- a/Tests/Remove-PfbUserGroupQuotaPolicyFileSystem.Tests.ps1
+++ b/Tests/Remove-PfbUserGroupQuotaPolicyFileSystem.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.25'; AuthToken = 'x' }
 }

--- a/Tests/Remove-PfbUserGroupQuotaPolicyRule.Tests.ps1
+++ b/Tests/Remove-PfbUserGroupQuotaPolicyRule.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.25'; AuthToken = 'x' }
 }

--- a/Tests/RemovedCmdlets.Tests.ps1
+++ b/Tests/RemovedCmdlets.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:moduleRootPath = $moduleRoot
     $script:manifestPath   = $manifest

--- a/Tests/Resolve-PfbParameterComponent.Tests.ps1
+++ b/Tests/Resolve-PfbParameterComponent.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 }
 
 Describe 'Resolve-PfbParameterComponent' {

--- a/Tests/Resolve-PfbRequestContext.Tests.ps1
+++ b/Tests/Resolve-PfbRequestContext.Tests.ps1
@@ -1,7 +1,8 @@
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
 
 BeforeAll {
-    Import-Module "$PSScriptRoot/../PureStorageFlashBladePowerShell.psd1" -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 }
 
 # InModuleScope goes INSIDE each It, never around the Describe body: Describe-level

--- a/Tests/Set-PfbContext.Tests.ps1
+++ b/Tests/Set-PfbContext.Tests.ps1
@@ -1,7 +1,8 @@
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
 
 BeforeAll {
-    Import-Module "$PSScriptRoot/../PureStorageFlashBladePowerShell.psd1" -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 }
 
 Describe 'Set-PfbContext' {

--- a/Tests/Set-PfbPresetWorkload.Tests.ps1
+++ b/Tests/Set-PfbPresetWorkload.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.26'; AuthToken = 'x' }
 }

--- a/Tests/Set-PfbTlsProtocol.Tests.ps1
+++ b/Tests/Set-PfbTlsProtocol.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 }
 
 Describe 'Set-PfbTlsProtocol' {

--- a/Tests/Set-PfbWorkloadTag.Tests.ps1
+++ b/Tests/Set-PfbWorkloadTag.Tests.ps1
@@ -11,7 +11,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{
         Endpoint             = 'fb.example.test'

--- a/Tests/Test-PfbActiveDirectory.Tests.ps1
+++ b/Tests/Test-PfbActiveDirectory.Tests.ps1
@@ -1,7 +1,8 @@
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
 
 BeforeAll {
-    Import-Module "$PSScriptRoot/../PureStorageFlashBladePowerShell.psd1" -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
     # A throwaway connection object; Assert-PfbConnection is mocked so its contents don't matter.
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Test-PfbContextMultiValueCapable.Tests.ps1
+++ b/Tests/Test-PfbContextMultiValueCapable.Tests.ps1
@@ -9,7 +9,8 @@
 #>
 
 BeforeAll {
-    Import-Module "$PSScriptRoot/../PureStorageFlashBladePowerShell.psd1" -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 }
 
 # InModuleScope inside each It, never around the Describe body (Describe-level fails at

--- a/Tests/Test-PfbEmptyPipelineRead.Tests.ps1
+++ b/Tests/Test-PfbEmptyPipelineRead.Tests.ps1
@@ -1,8 +1,8 @@
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
 
 BeforeAll {
-    Import-Module (Join-Path (Split-Path -Parent $PSScriptRoot) `
-            'PureStorageFlashBladePowerShell.psd1') -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 }
 
 Describe 'Test-PfbEmptyPipelineRead' {

--- a/Tests/Test-PfbSaml2Idp.Tests.ps1
+++ b/Tests/Test-PfbSaml2Idp.Tests.ps1
@@ -1,7 +1,8 @@
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
 
 BeforeAll {
-    Import-Module "$PSScriptRoot/../PureStorageFlashBladePowerShell.psd1" -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
     # A throwaway connection object; Assert-PfbConnection is mocked so its contents don't matter.
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Test-PfbSupport.Tests.ps1
+++ b/Tests/Test-PfbSupport.Tests.ps1
@@ -1,7 +1,8 @@
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
 
 BeforeAll {
-    Import-Module "$PSScriptRoot/../PureStorageFlashBladePowerShell.psd1" -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }
 

--- a/Tests/Test-PfbSyslogServer.Tests.ps1
+++ b/Tests/Test-PfbSyslogServer.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
     $script:expectedResponse = [PSCustomObject]@{

--- a/Tests/TestModuleImportGuard.Tests.ps1
+++ b/Tests/TestModuleImportGuard.Tests.ps1
@@ -15,7 +15,13 @@ BeforeAll {
     . (Join-Path $script:repoRoot 'tools/lib/PfbTestImportTools.ps1')
     $script:exported = @(Get-PfbExportedFunctionName -ManifestPath (
         Join-Path $script:repoRoot 'PureStorageFlashBladePowerShell.psd1'))
-    $script:testFiles = @(Get-ChildItem -Path (Join-Path $script:repoRoot 'Tests') -Filter '*.Tests.ps1' -File)
+    # -Recurse so all three enumerations of Tests/ agree: the rewriter recurses, and the CI
+    # runner's Run.Path = 'Tests' is recursive too. There are no test files in subdirectories
+    # today, so this changes nothing observable -- it closes a future hole. The asymmetry that
+    # makes it worth closing: the second It below catches a file that uses the module without
+    # loading it through the helper, a failure invisible in a full-suite run and visible only
+    # in a standalone single-file run. A subdirectory file would escape that check silently.
+    $script:testFiles = @(Get-ChildItem -Path (Join-Path $script:repoRoot 'Tests') -Filter '*.Tests.ps1' -File -Recurse)
 
     # Files that legitimately force-import in their OWN process or runspace, or need a
     # genuinely virgin module and cannot use -Fresh. Kept as short as it can possibly be:
@@ -42,7 +48,22 @@ Describe 'Test-module import guard (AST, no spec cache required, every edition)'
                 $offenders += ("{0}:{1} -- {2}" -f $file.Name, $import.Line, $import.Text)
             }
         }
-        $offenders -join "`n" | Should -BeNullOrEmpty
+        # A bare list of offending lines says what is wrong and not what to do, so the
+        # correct shape ships with the failure. These are the exact two lines
+        # tools/Update-PfbTestModuleImport.ps1 emits.
+        $message = ''
+        if ($offenders.Count -gt 0) {
+            $message = ($offenders -join "`n") + "`n`n" + (@(
+                'Load the module through the shared helper instead. Inside BeforeAll:'
+                ''
+                "    . (Join-Path `$PSScriptRoot 'PfbTestModule.ps1')"
+                '    $null = Import-PfbTestModule'
+                ''
+                'Both lines must be INSIDE BeforeAll. ./tools/Update-PfbTestModuleImport.ps1'
+                'performs this rewrite automatically; run it with -WhatIf first.'
+            ) -join "`n")
+        }
+        $message | Should -BeNullOrEmpty
     }
 
     It 'finds no test file that uses the module without loading it through the helper' {
@@ -74,10 +95,14 @@ Describe 'Test-module import guard (AST, no spec cache required, every edition)'
         # That correctly excludes $script:PfbAllArraysSuffix (Private/PfbContext.ps1) and the
         # three constants in Private/PfbContextConstants.ps1.
         #
-        # This is a CHANGE DETECTOR, not a correctness assertion: the helper makes a
-        # documented decision per variable (reset the connection pair and the credential
-        # cache; leave the two JSON caches warm on purpose). If this list changes, decide
-        # which bucket the newcomer belongs in and update Tests/PfbTestModule.ps1 to match.
+        # This is a CHANGE DETECTOR, not a correctness assertion: the helper resets EVERY
+        # variable on this list unconditionally -- the connection pair, the credential cache,
+        # and both JSON caches. An earlier revision left the two JSON caches warm on the
+        # grounds that they were safe to reuse; commit d649d6d reversed exactly that, and
+        # Tests/PfbTestModule.ps1 argues at length that the reset must never become
+        # conditional again. If this list changes, decide whether the newcomer is volatile
+        # (per the assignment-position rule above) and update Tests/PfbTestModule.ps1 to
+        # reset it too.
         $sources = @()
         $sources += Get-Item (Join-Path $script:repoRoot 'PureStorageFlashBladePowerShell.psm1')
         $sources += Get-ChildItem (Join-Path $script:repoRoot 'Private') -Filter '*.ps1' -Recurse -File
@@ -136,5 +161,54 @@ Describe 'Test-module import guard (AST, no spec cache required, every edition)'
             '$script:PfbDefaultArray'
             '$script:PfbVersionMap'
         )
+    }
+
+    It 'keeps the guard allowlist and the rewriter exclusion set in lockstep' {
+        # Both lists name files that legitimately keep a raw -Force import, and the comment on
+        # $script:allowlist says they must stay in lockstep. This asserts it instead. The
+        # dangerous direction is an entry added to the allowlist but NOT to the rewriter's
+        # exclusion set: the rewriter would then convert a file this guard has stopped
+        # watching, or a real offender would sit permanently unexamined. Both are literal
+        # string arrays in tracked files, so the assertion is cheap and exact.
+        #
+        # Parsed with the AST rather than dot-sourced on purpose: the rewriter declares
+        # `#Requires -Version 7.0` and this file is deliberately ungated on edition, so
+        # dot-sourcing it would kill the whole container under Windows PowerShell 5.1.
+        $rewriterPath = Join-Path $script:repoRoot 'tools/Update-PfbTestModuleImport.ps1'
+        $tokens = $null
+        $errors = $null
+        $ast = [System.Management.Automation.Language.Parser]::ParseFile(
+            $rewriterPath, [ref]$tokens, [ref]$errors)
+        if ($null -ne $errors -and $errors.Count -gt 0) {
+            throw ("Update-PfbTestModuleImport.ps1 failed to parse: {0}" -f $errors[0].Message)
+        }
+
+        $assignments = @($ast.FindAll({
+            param($node)
+            if (-not ($node -is [System.Management.Automation.Language.AssignmentStatementAst])) {
+                return $false
+            }
+            $left = $node.Left
+            if (-not ($left -is [System.Management.Automation.Language.VariableExpressionAst])) {
+                return $false
+            }
+            return ($left.VariablePath.UserPath -eq 'script:ExcludedFileName')
+        }, $true))
+
+        # Asserted as exactly one, not "at least one": if the variable is renamed or split,
+        # this must fail loudly rather than compare the allowlist against an empty set and
+        # report a false lockstep.
+        $assignments.Count | Should -Be 1 -Because 'ExcludedFileName must remain a single literal assignment in tools/Update-PfbTestModuleImport.ps1'
+
+        $exclusions = [string[]]@($assignments[0].Right.FindAll({
+            param($node)
+            return ($node -is [System.Management.Automation.Language.StringConstantExpressionAst])
+        }, $true) | ForEach-Object { $_.Value })
+        [Array]::Sort($exclusions, [System.StringComparer]::Ordinal)
+
+        $allowed = [string[]]@($script:allowlist)
+        [Array]::Sort($allowed, [System.StringComparer]::Ordinal)
+
+        ($exclusions -join ', ') | Should -Be ($allowed -join ', ')
     }
 }

--- a/Tests/TestModuleImportGuard.Tests.ps1
+++ b/Tests/TestModuleImportGuard.Tests.ps1
@@ -1,0 +1,140 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+<#
+    UNGATED on edition, on purpose: pure AST plus file IO, 5.1-safe, no spec cache, and
+    no graceful-skip path. It must contribute executed tests on both legs, which is why it
+    is listed in RequiredDescribes in BOTH blocks of coverage-baseline.psd1 -- MaxSkipped
+    cannot see a Describe that vanishes without skipping.
+
+    Deliberately does NOT try to detect a leaked shim. A test asserting "the module I can
+    see right now is pristine" would pass or fail depending on container order and would be
+    a flaky red. Shim detection belongs in Tests/PfbTestModule.ps1, at runtime, per call.
+#>
+
+BeforeAll {
+    $script:repoRoot = Split-Path -Parent $PSScriptRoot
+    . (Join-Path $script:repoRoot 'tools/lib/PfbTestImportTools.ps1')
+    $script:exported = @(Get-PfbExportedFunctionName -ManifestPath (
+        Join-Path $script:repoRoot 'PureStorageFlashBladePowerShell.psd1'))
+    $script:testFiles = @(Get-ChildItem -Path (Join-Path $script:repoRoot 'Tests') -Filter '*.Tests.ps1' -File)
+
+    # Files that legitimately force-import in their OWN process or runspace, or need a
+    # genuinely virgin module and cannot use -Fresh. Kept as short as it can possibly be:
+    # the separate-runspace call and the Mock argument are excluded STRUCTURALLY by the AST
+    # predicate, not by being listed here.
+    #
+    # PfbTestModule.Tests.ps1 is the helper's own test file. It installs an UNMARKED module
+    # instance with a raw -Force import on purpose -- that import is the fixture proving the
+    # helper rebuilds when something outside it loads the module, which is the single most
+    # important behaviour the helper has. Converting it would mean testing the detector
+    # without ever triggering the condition it detects. This entry must stay in lockstep
+    # with the rewriter's own exclusion set in tools/Update-PfbTestModuleImport.ps1: a file
+    # the rewriter refuses to convert still contains a raw import, so if the two lists ever
+    # diverge, one of them is wrong.
+    $script:allowlist = @('PfbTestModule.Tests.ps1')
+}
+
+Describe 'Test-module import guard (AST, no spec cache required, every edition)' {
+    It 'finds no raw -Force manifest import in any test file' {
+        $offenders = @()
+        foreach ($file in $script:testFiles) {
+            if ($script:allowlist -contains $file.Name) { continue }
+            foreach ($import in @(Get-PfbTestManifestImport -Path $file.FullName)) {
+                $offenders += ("{0}:{1} -- {2}" -f $file.Name, $import.Line, $import.Text)
+            }
+        }
+        $offenders -join "`n" | Should -BeNullOrEmpty
+    }
+
+    It 'finds no test file that uses the module without loading it through the helper' {
+        # A file that DELETES its import and then rides whatever a previous container left
+        # loaded is a WORSE failure than the one this change fixes, and it is invisible in a
+        # full-suite run because the module is always loaded by the time it matters. This
+        # half of the guard is what protects the standalone single-file run.
+        $offenders = @()
+        foreach ($file in $script:testFiles) {
+            if ($script:allowlist -contains $file.Name) { continue }
+            $usage = Test-PfbTestModuleUsage -Path $file.FullName -ExportedFunction $script:exported
+            if ($usage.Uses -and -not $usage.CallsHelper) {
+                $offenders += ("{0} -- {1}" -f $file.Name, ($usage.Reasons -join '; '))
+            }
+        }
+        $offenders -join "`n" | Should -BeNullOrEmpty
+    }
+
+    It 'pins the set of VOLATILE module-scope variables so a new one cannot appear unnoticed' {
+        # Risk 2 from the spec, in its real form. Scanning only the .psm1 preamble is NOT
+        # enough and would be close to vacuous: $script:PfbCachedCredential is never
+        # declared there -- it springs into existence on first write inside
+        # Set-PfbCredential / Get-PfbCredential -- and the spec's original five-variable
+        # enumeration missed it for exactly that reason.
+        #
+        # The distinction that matters is WHERE the assignment lives, not which file:
+        #   - inside a function body  => runs whenever that function is called => VOLATILE
+        #   - at dot-source scope     => runs once per import => a constant, safe to leave
+        # That correctly excludes $script:PfbAllArraysSuffix (Private/PfbContext.ps1) and the
+        # three constants in Private/PfbContextConstants.ps1.
+        #
+        # This is a CHANGE DETECTOR, not a correctness assertion: the helper makes a
+        # documented decision per variable (reset the connection pair and the credential
+        # cache; leave the two JSON caches warm on purpose). If this list changes, decide
+        # which bucket the newcomer belongs in and update Tests/PfbTestModule.ps1 to match.
+        $sources = @()
+        $sources += Get-Item (Join-Path $script:repoRoot 'PureStorageFlashBladePowerShell.psm1')
+        $sources += Get-ChildItem (Join-Path $script:repoRoot 'Private') -Filter '*.ps1' -Recurse -File
+        $sources += Get-ChildItem (Join-Path $script:repoRoot 'Public') -Filter '*.ps1' -Recurse -File
+
+        $volatile = @()
+        foreach ($source in $sources) {
+            $tokens = $null
+            $errors = $null
+            $ast = [System.Management.Automation.Language.Parser]::ParseFile(
+                $source.FullName, [ref]$tokens, [ref]$errors)
+            if ($null -ne $errors -and $errors.Count -gt 0) {
+                throw ("{0} failed to parse: {1}" -f $source.Name, $errors[0].Message)
+            }
+            $assignments = @($ast.FindAll({
+                param($node)
+                return ($node -is [System.Management.Automation.Language.AssignmentStatementAst])
+            }, $true))
+            foreach ($assignment in $assignments) {
+                # Key on the target's ROOT VARIABLE PATH, not on the raw extent text.
+                # $script:PfbArrays is only ever assigned through an indexer
+                # ($script:PfbArrays[$Array.Endpoint] = ..., $script:PfbArrays[$Endpoint] = ...),
+                # so the raw extent yields '$script:PfbArrays[$Endpoint]' and a pin written
+                # against plain variable names could never match. This pin is a change detector
+                # over which VARIABLES are volatile, so the variable is the right key -- and
+                # keying on the expression would also red spuriously the first time someone
+                # rewrites an index expression.
+                $left = $assignment.Left
+                $variable = $left
+                if (-not ($variable -is [System.Management.Automation.Language.VariableExpressionAst])) {
+                    $variable = @($left.FindAll({
+                        param($node)
+                        return ($node -is [System.Management.Automation.Language.VariableExpressionAst])
+                    }, $true))[0]
+                }
+                if ($null -eq $variable) { continue }
+                $target = '$' + $variable.VariablePath.UserPath
+                if ($target -notlike '$script:Pfb*') { continue }
+                $node = $assignment.Parent
+                $inFunction = $false
+                while ($null -ne $node) {
+                    if ($node -is [System.Management.Automation.Language.FunctionDefinitionAst]) {
+                        $inFunction = $true
+                        break
+                    }
+                    $node = $node.Parent
+                }
+                if ($inFunction) { $volatile += $target }
+            }
+        }
+
+        @($volatile | Sort-Object -Unique) | Should -Be @(
+            '$script:PfbArrays'
+            '$script:PfbCachedCredential'
+            '$script:PfbCapabilityMap'
+            '$script:PfbDefaultArray'
+            '$script:PfbVersionMap'
+        )
+    }
+}

--- a/Tests/TotalOnlyCapability.Tests.ps1
+++ b/Tests/TotalOnlyCapability.Tests.ps1
@@ -43,7 +43,8 @@ $supportedTotalOnlyCmdlets = @(
 BeforeAll {
     $repoRoot = Split-Path -Parent $PSScriptRoot
     $manifest = Join-Path $repoRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.25'; AuthToken = 'x' }
 

--- a/Tests/Update-PfbActiveDirectory.Tests.ps1
+++ b/Tests/Update-PfbActiveDirectory.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Update-PfbAdmin.Tests.ps1
+++ b/Tests/Update-PfbAdmin.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Update-PfbApiClient.Tests.ps1
+++ b/Tests/Update-PfbApiClient.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Update-PfbArrayConnection.Tests.ps1
+++ b/Tests/Update-PfbArrayConnection.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Update-PfbAsyncLog.Tests.ps1
+++ b/Tests/Update-PfbAsyncLog.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Update-PfbBucketAuditFilter.Tests.ps1
+++ b/Tests/Update-PfbBucketAuditFilter.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Update-PfbCertificate.Tests.ps1
+++ b/Tests/Update-PfbCertificate.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Update-PfbContextHelp.Tests.ps1
+++ b/Tests/Update-PfbContextHelp.Tests.ps1
@@ -32,7 +32,8 @@ BeforeAll {
     $script:generator = Join-Path $script:repoRoot 'tools/Update-PfbContextHelp.ps1'
     $script:presetFile = Join-Path $script:repoRoot 'Public/Presets/New-PfbPresetWorkload.ps1'
     $script:manifest = Join-Path $script:repoRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $script:manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 }
 
 Describe 'Update-PfbContextHelp' {

--- a/Tests/Update-PfbDirectoryServiceRole.Tests.ps1
+++ b/Tests/Update-PfbDirectoryServiceRole.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Update-PfbDns.Tests.ps1
+++ b/Tests/Update-PfbDns.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Update-PfbFileSystem.Demote.Tests.ps1
+++ b/Tests/Update-PfbFileSystem.Demote.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     # A throwaway connection object; Assert-PfbConnection is mocked so its contents don't matter.
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }

--- a/Tests/Update-PfbFileSystemExport.Tests.ps1
+++ b/Tests/Update-PfbFileSystemExport.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Update-PfbFleet.Tests.ps1
+++ b/Tests/Update-PfbFleet.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Update-PfbHardware.Tests.ps1
+++ b/Tests/Update-PfbHardware.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Update-PfbHardwareConnector.Tests.ps1
+++ b/Tests/Update-PfbHardwareConnector.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Update-PfbKmip.Tests.ps1
+++ b/Tests/Update-PfbKmip.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Update-PfbLag.Tests.ps1
+++ b/Tests/Update-PfbLag.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Update-PfbLegalHold.Tests.ps1
+++ b/Tests/Update-PfbLegalHold.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Update-PfbLegalHoldEntity.Tests.ps1
+++ b/Tests/Update-PfbLegalHoldEntity.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Update-PfbLifecycleRule.Tests.ps1
+++ b/Tests/Update-PfbLifecycleRule.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Update-PfbLogTargetFileSystem.Tests.ps1
+++ b/Tests/Update-PfbLogTargetFileSystem.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Update-PfbLogTargetObjectStore.Tests.ps1
+++ b/Tests/Update-PfbLogTargetObjectStore.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Update-PfbManagementAccessPolicy.Tests.ps1
+++ b/Tests/Update-PfbManagementAccessPolicy.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Update-PfbNetworkInterface.Tests.ps1
+++ b/Tests/Update-PfbNetworkInterface.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Update-PfbNetworkInterfaceConnector.Tests.ps1
+++ b/Tests/Update-PfbNetworkInterfaceConnector.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Update-PfbNode.Tests.ps1
+++ b/Tests/Update-PfbNode.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Update-PfbNodeGroup.Tests.ps1
+++ b/Tests/Update-PfbNodeGroup.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Update-PfbObjectStoreAccountExport.Tests.ps1
+++ b/Tests/Update-PfbObjectStoreAccountExport.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Update-PfbObjectStoreRemoteCredential.Tests.ps1
+++ b/Tests/Update-PfbObjectStoreRemoteCredential.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Update-PfbObjectStoreRole.Tests.ps1
+++ b/Tests/Update-PfbObjectStoreRole.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Update-PfbObjectStoreVirtualHost.Tests.ps1
+++ b/Tests/Update-PfbObjectStoreVirtualHost.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Update-PfbOidcIdp.Tests.ps1
+++ b/Tests/Update-PfbOidcIdp.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Update-PfbQosPolicy.Tests.ps1
+++ b/Tests/Update-PfbQosPolicy.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Update-PfbRealmDefaults.Tests.ps1
+++ b/Tests/Update-PfbRealmDefaults.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Update-PfbSaml2Idp.Tests.ps1
+++ b/Tests/Update-PfbSaml2Idp.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Update-PfbSmtpServer.Tests.ps1
+++ b/Tests/Update-PfbSmtpServer.Tests.ps1
@@ -8,7 +8,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{
         Endpoint             = 'fb.example.test'

--- a/Tests/Update-PfbSnmpManager.Tests.ps1
+++ b/Tests/Update-PfbSnmpManager.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Update-PfbSshCaPolicy.Tests.ps1
+++ b/Tests/Update-PfbSshCaPolicy.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Update-PfbStorageClassTieringPolicy.Tests.ps1
+++ b/Tests/Update-PfbStorageClassTieringPolicy.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Update-PfbSubnet.Tests.ps1
+++ b/Tests/Update-PfbSubnet.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Update-PfbSyslogServer.Tests.ps1
+++ b/Tests/Update-PfbSyslogServer.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Update-PfbTarget.Tests.ps1
+++ b/Tests/Update-PfbTarget.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Update-PfbTestModuleImport.Tests.ps1
+++ b/Tests/Update-PfbTestModuleImport.Tests.ps1
@@ -85,6 +85,9 @@ Describe 'Update-PfbTestModuleImport rewrites each known form' -Skip:($PSVersion
         $summary = & $script:rewriter -TestRoot $script:sandbox -WarningAction SilentlyContinue
         $summary.Unrecognised.Count | Should -Be 1
         $summary.Changed.Count | Should -Be 0
+        # An Unrecognised-only file is still a file: it must land in a summary bucket, or the
+        # census cannot be reconciled against the file count.
+        $summary.Unchanged | Should -Be 1
         [System.IO.File]::ReadAllText($path) | Should -Be $original
     }
 
@@ -121,5 +124,179 @@ Describe 'Update-PfbTestModuleImport rewrites each known form' -Skip:($PSVersion
             $updated | Should -Not -Match "(?<!`r)`n"
         }
         (& $script:rewriter -TestRoot $script:sandbox).Changed | Should -BeNullOrEmpty
+    }
+
+    It 'rewrites the <Name> call-site form to exactly the expected two lines' -ForEach @(
+        @{ Name = 'Manifest'; Target = '$null'
+            Statement = '    Import-Module $manifest -Force' }
+        @{ Name = 'ScriptManifest'; Target = '$null'
+            Statement = '    Import-Module $script:manifest -Force' }
+        @{ Name = 'PSScriptRoot'; Target = '$null'
+            Statement = '    Import-Module "$PSScriptRoot/../PureStorageFlashBladePowerShell.psd1" -Force' }
+        @{ Name = 'JoinPath'; Target = '$null'
+            Statement = "    Import-Module (Join-Path `$moduleRoot 'PureStorageFlashBladePowerShell.psd1') -Force" }
+        @{ Name = 'PassThru'; Target = '$script:module'
+            Statement = "    `$script:module = Import-Module `$manifest -Force -PassThru" }
+        # The only form whose extent spans two physical lines (a backtick continuation), so
+        # the only one where the head/tail arithmetic is non-trivial. Two lines in, two out.
+        @{ Name = 'NestedJoinPath'; Target = '$null'
+            Statement = "    Import-Module (Join-Path (Split-Path -Parent `$PSScriptRoot) ``" + "`n" +
+                "            'PureStorageFlashBladePowerShell.psd1') -Force" }
+    ) {
+        $path = Join-Path $script:sandbox "$Name.Tests.ps1"
+        [System.IO.File]::WriteAllText($path, "BeforeAll {`n$Statement`n}`n")
+
+        $summary = & $script:rewriter -TestRoot $script:sandbox
+        $summary.Changed.Count | Should -Be 1
+        [System.IO.File]::ReadAllText($path) | Should -Be (
+            "BeforeAll {`n" +
+            "    . (Join-Path `$PSScriptRoot 'PfbTestModule.ps1')`n" +
+            "    $Target = Import-PfbTestModule`n" +
+            "}`n")
+    }
+
+    It 'never examines a file on the exclusion list, and reports it in Excluded' {
+        # Tests/PfbTestModule.Tests.ps1:126 force-imports the manifest ON PURPOSE, to install
+        # an unmarked module instance for the helper to notice. Rewriting it deletes the
+        # condition under test, so the rewriter must not even look at the file.
+        $path = Join-Path $script:sandbox 'PfbTestModule.Tests.ps1'
+        $original = "BeforeAll {`n        `$null = Import-Module -Name `$script:manifest -Force -PassThru`n}`n"
+        [System.IO.File]::WriteAllText($path, $original)
+
+        $summary = & $script:rewriter -TestRoot $script:sandbox
+        $summary.Changed.Count | Should -Be 0
+        $summary.Excluded.Count | Should -Be 1
+        $summary.Excluded[0] | Should -BeLike '*PfbTestModule.Tests.ps1'
+        [System.IO.File]::ReadAllText($path) | Should -Be $original
+    }
+
+    It 'Changed + Unchanged + Excluded accounts for every test file examined' {
+        [System.IO.File]::WriteAllText((Join-Path $script:sandbox 'J1.Tests.ps1'),
+            "BeforeAll {`n    Import-Module `$manifest -Force`n}`n")
+        [System.IO.File]::WriteAllText((Join-Path $script:sandbox 'J2.Tests.ps1'),
+            "BeforeAll {`n    . (Join-Path `$PSScriptRoot 'PfbTestModule.ps1')`n    `$null = Import-PfbTestModule`n}`n")
+        [System.IO.File]::WriteAllText((Join-Path $script:sandbox 'PfbTestModule.Tests.ps1'),
+            "BeforeAll {`n    Import-Module `$manifest -Force`n}`n")
+
+        $summary = & $script:rewriter -TestRoot $script:sandbox
+        $summary.Changed.Count | Should -Be 1
+        $summary.Unchanged | Should -Be 1
+        $summary.Excluded.Count | Should -Be 1
+        ($summary.Changed.Count + $summary.Unchanged + $summary.Excluded.Count) |
+            Should -Be @(Get-ChildItem -Path $script:sandbox -Filter '*.Tests.ps1' -File -Recurse).Count
+    }
+
+    It 'keeps the real assignment target and any statement earlier on the same line' {
+        # Hardcoding $script:module silently RENAMES the target (a throw under StrictMode);
+        # moving the splice left edge back to the indentation silently DELETES the sentinel.
+        $path = Join-Path $script:sandbox 'K.Tests.ps1'
+        [System.IO.File]::WriteAllText($path,
+            "BeforeAll {`n    `$script:sentinel = 42; `$myOwnName = Import-Module `$manifest -Force -PassThru`n}`n")
+
+        $null = & $script:rewriter -TestRoot $script:sandbox
+        [System.IO.File]::ReadAllText($path) | Should -Be (
+            "BeforeAll {`n" +
+            "    `$script:sentinel = 42; . (Join-Path `$PSScriptRoot 'PfbTestModule.ps1')`n" +
+            "    `$myOwnName = Import-PfbTestModule`n" +
+            "}`n")
+    }
+
+    It 'does not emit a dot-source as the right-hand side of an existing assignment' {
+        # `$null = . (Join-Path ...)` parses, so no parse check catches it -- assert the shape.
+        $path = Join-Path $script:sandbox 'L.Tests.ps1'
+        [System.IO.File]::WriteAllText($path, "BeforeAll {`n    `$null = Import-Module `$manifest -Force`n}`n")
+
+        $null = & $script:rewriter -TestRoot $script:sandbox
+        [System.IO.File]::ReadAllText($path) | Should -Be (
+            "BeforeAll {`n" +
+            "    . (Join-Path `$PSScriptRoot 'PfbTestModule.ps1')`n" +
+            "    `$null = Import-PfbTestModule`n" +
+            "}`n")
+    }
+
+    It 'preserves a trailing comment and a tab indent' {
+        $path = Join-Path $script:sandbox 'M.Tests.ps1'
+        [System.IO.File]::WriteAllText($path,
+            "BeforeAll {`n`t`tImport-Module `$manifest -Force  # keep me: issue #999`n}`n")
+
+        $null = & $script:rewriter -TestRoot $script:sandbox
+        [System.IO.File]::ReadAllText($path) | Should -Be (
+            "BeforeAll {`n" +
+            "`t`t. (Join-Path `$PSScriptRoot 'PfbTestModule.ps1')`n" +
+            "`t`t`$null = Import-PfbTestModule  # keep me: issue #999`n" +
+            "}`n")
+    }
+
+    It 'recovers the indent and the newline from the local line in a mixed-ending file' {
+        # LastIndexOf($nl, ...) skips lines ended with the other convention and recovers the
+        # indent of the wrong line -- an 8-space indent collapses to 4.
+        $path = Join-Path $script:sandbox 'N.Tests.ps1'
+        [System.IO.File]::WriteAllText($path,
+            "BeforeAll {`r`n    if (`$true) {`n        Import-Module `$manifest -Force`n    }`r`n}`r`n")
+
+        $null = & $script:rewriter -TestRoot $script:sandbox
+        [System.IO.File]::ReadAllText($path) | Should -Be (
+            "BeforeAll {`r`n" +
+            "    if (`$true) {`n" +
+            "        . (Join-Path `$PSScriptRoot 'PfbTestModule.ps1')`n" +
+            "        `$null = Import-PfbTestModule`n" +
+            "    }`r`n}`r`n")
+    }
+
+    It 'rewrites every import in a file that carries more than one' {
+        $path = Join-Path $script:sandbox 'O.Tests.ps1'
+        [System.IO.File]::WriteAllText($path,
+            "BeforeAll {`n    Import-Module `$manifest -Force`n}`nDescribe 'x' {`n    BeforeAll {`n        Import-Module `$script:manifest -Force`n    }`n}`n")
+
+        $null = & $script:rewriter -TestRoot $script:sandbox
+        $updated = [System.IO.File]::ReadAllText($path)
+        ([regex]::Matches($updated, [regex]::Escape('Import-PfbTestModule'))).Count | Should -Be 2
+        $updated | Should -Not -Match 'Import-Module'
+        $updated | Should -Match "    \. \(Join-Path \`$PSScriptRoot 'PfbTestModule\.ps1'\)"
+        $updated | Should -Match "        \. \(Join-Path \`$PSScriptRoot 'PfbTestModule\.ps1'\)"
+    }
+
+    It 'reports an import in an unmodelled syntactic position as Unrecognised' {
+        $path = Join-Path $script:sandbox 'P.Tests.ps1'
+        $original = "BeforeAll {`n    Import-Module `$manifest -Force | Out-Null`n}`n"
+        [System.IO.File]::WriteAllText($path, $original)
+
+        $summary = & $script:rewriter -TestRoot $script:sandbox -WarningAction SilentlyContinue
+        $summary.Changed.Count | Should -Be 0
+        $summary.Unrecognised.Count | Should -Be 1
+        [System.IO.File]::ReadAllText($path) | Should -Be $original
+    }
+
+    It 'finds a test file in a subfolder, because Pester Run.Path is recursive' {
+        $nested = Join-Path $script:sandbox 'Nested'
+        $null = New-Item -ItemType Directory -Path $nested -Force
+        [System.IO.File]::WriteAllText((Join-Path $nested 'Q.Tests.ps1'),
+            "BeforeAll {`n    Import-Module `$manifest -Force`n}`n")
+
+        (& $script:rewriter -TestRoot $script:sandbox).Changed.Count | Should -Be 1
+    }
+
+    It 'splices character offsets, not byte offsets, with multi-byte text ahead of the import' {
+        # 14 bytes of char/byte divergence BEFORE the import: an em dash, an e-acute, a CJK
+        # ideograph and an astral emoji (surrogate pair). Byte-indexing corrupts both sides.
+        $path = Join-Path $script:sandbox 'R.Tests.ps1'
+        $prose = "# tests $([char]0x2014) caf$([char]0xE9) $([char]0x4E2D) $([char]::ConvertFromUtf32(0x1F600))"
+        [System.IO.File]::WriteAllText($path,
+            "$prose`nBeforeAll {`n    Import-Module `$manifest -Force`n}`n",
+            (New-Object System.Text.UTF8Encoding($false)))
+
+        $null = & $script:rewriter -TestRoot $script:sandbox
+        [System.IO.File]::ReadAllText($path) | Should -Be (
+            "$prose`n" +
+            "BeforeAll {`n" +
+            "    . (Join-Path `$PSScriptRoot 'PfbTestModule.ps1')`n" +
+            "    `$null = Import-PfbTestModule`n" +
+            "}`n")
+    }
+
+    It 'never emits -Fresh or a PfbTestModulePrepared assignment' {
+        $source = [System.IO.File]::ReadAllText($script:rewriter)
+        $source.Contains('PfbTestModulePrepared') | Should -BeFalse
+        $source.Contains('-Fresh') | Should -BeFalse
     }
 }

--- a/Tests/Update-PfbTestModuleImport.Tests.ps1
+++ b/Tests/Update-PfbTestModuleImport.Tests.ps1
@@ -1,0 +1,125 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+<#
+    Gated to PS7 for consistency with every other tooling test in this suite. The
+    file-level BeforeAll guards its OWN body as well: a skipped Describe does not stop a
+    file-level BeforeAll, and dot-sourcing a 7-only script under 5.1 kills the whole
+    container rather than one test. That mistake has cost this repo 65 tests before --
+    see the header of Tests/CommittedDriftReport.Tests.ps1.
+#>
+
+BeforeAll {
+    $script:isPwsh7 = $PSVersionTable.PSVersion.Major -ge 7
+    if ($script:isPwsh7) {
+        $script:repoRoot = Split-Path -Parent $PSScriptRoot
+        $script:rewriter = Join-Path $script:repoRoot 'tools/Update-PfbTestModuleImport.ps1'
+    }
+}
+
+Describe 'Update-PfbTestModuleImport rewrites each known form' -Skip:($PSVersionTable.PSVersion.Major -lt 7) {
+    BeforeEach {
+        $script:sandbox = Join-Path $TestDrive ((New-Guid).Guid)
+        $null = New-Item -ItemType Directory -Path $script:sandbox -Force
+    }
+
+    It 'replaces only the import statement and keeps the surrounding assignments' {
+        $path = Join-Path $script:sandbox 'A.Tests.ps1'
+        $original = "BeforeAll {`n" +
+            "    `$moduleRoot = Split-Path -Parent `$PSScriptRoot`n" +
+            "    `$manifest   = Join-Path `$moduleRoot 'PureStorageFlashBladePowerShell.psd1'`n" +
+            "    Import-Module `$manifest -Force`n" +
+            "}`n"
+        [System.IO.File]::WriteAllText($path, $original)
+
+        $summary = & $script:rewriter -TestRoot $script:sandbox
+        $summary.Changed.Count | Should -Be 1
+
+        $updated = [System.IO.File]::ReadAllText($path)
+        $updated | Should -Match '\$moduleRoot = Split-Path'
+        $updated | Should -Match "\`$manifest   = Join-Path"
+        $updated | Should -Not -Match 'Import-Module \$manifest -Force'
+        $updated | Should -Match "    \. \(Join-Path \`$PSScriptRoot 'PfbTestModule\.ps1'\)"
+        $updated | Should -Match '    \$null = Import-PfbTestModule'
+    }
+
+    It 'preserves the -PassThru assignment target and its indentation' {
+        $path = Join-Path $script:sandbox 'B.Tests.ps1'
+        $original = "BeforeAll {`n    if (`$script:isPwsh7) {`n" +
+            "        `$script:module = Import-Module (Join-Path `$script:repoRoot 'PureStorageFlashBladePowerShell.psd1') -Force -PassThru`n" +
+            "    }`n}`n"
+        [System.IO.File]::WriteAllText($path, $original)
+
+        $null = & $script:rewriter -TestRoot $script:sandbox
+        $updated = [System.IO.File]::ReadAllText($path)
+        $updated | Should -Match "        \. \(Join-Path \`$PSScriptRoot 'PfbTestModule\.ps1'\)"
+        $updated | Should -Match '        \$script:module = Import-PfbTestModule'
+    }
+
+    It 'does not touch the separate-runspace AddCommand call' {
+        $path = Join-Path $script:sandbox 'C.Tests.ps1'
+        $original = "BeforeAll {`n" +
+            "    `$null = `$ps.AddCommand('Import-Module').AddParameter('Name', `$Manifest).AddParameter('Force', `$true)`n}`n"
+        [System.IO.File]::WriteAllText($path, $original)
+
+        $summary = & $script:rewriter -TestRoot $script:sandbox
+        $summary.Changed.Count | Should -Be 0
+        [System.IO.File]::ReadAllText($path) | Should -Be $original
+    }
+
+    It 'does not touch Import-Module passed as an argument to Mock' {
+        $path = Join-Path $script:sandbox 'D.Tests.ps1'
+        $original = "BeforeAll {`n" +
+            "    Mock -ModuleName PureStorageFlashBladePowerShell Import-Module { } -ParameterFilter { `$Name -eq 'Posh-SSH' }`n}`n"
+        [System.IO.File]::WriteAllText($path, $original)
+
+        $summary = & $script:rewriter -TestRoot $script:sandbox
+        $summary.Changed.Count | Should -Be 0
+        [System.IO.File]::ReadAllText($path) | Should -Be $original
+    }
+
+    It 'reports an unknown spelling in Unrecognised and warns, rather than skipping it silently' {
+        $path = Join-Path $script:sandbox 'E.Tests.ps1'
+        $original = "BeforeAll {`n" +
+            "    Import-Module (Resolve-Path './PureStorageFlashBladePowerShell.psd1') -Force`n}`n"
+        [System.IO.File]::WriteAllText($path, $original)
+
+        $summary = & $script:rewriter -TestRoot $script:sandbox -WarningAction SilentlyContinue
+        $summary.Unrecognised.Count | Should -Be 1
+        $summary.Changed.Count | Should -Be 0
+        [System.IO.File]::ReadAllText($path) | Should -Be $original
+    }
+
+    It 'is idempotent: a second run reports zero changes' {
+        $path = Join-Path $script:sandbox 'F.Tests.ps1'
+        [System.IO.File]::WriteAllText($path, "BeforeAll {`n    Import-Module `$manifest -Force`n}`n")
+        $null = & $script:rewriter -TestRoot $script:sandbox
+        (& $script:rewriter -TestRoot $script:sandbox).Changed | Should -BeNullOrEmpty
+    }
+
+    It '-WhatIf reports the change without writing' {
+        $path = Join-Path $script:sandbox 'G.Tests.ps1'
+        $original = "BeforeAll {`n    Import-Module `$manifest -Force`n}`n"
+        [System.IO.File]::WriteAllText($path, $original)
+        (& $script:rewriter -TestRoot $script:sandbox -WhatIf).Changed.Count | Should -Be 1
+        [System.IO.File]::ReadAllText($path) | Should -Be $original
+    }
+
+    It 'preserves <Name> line endings and stays idempotent under them' -ForEach @(
+        @{ Name = 'LF';   Newline = "`n" }
+        @{ Name = 'CRLF'; Newline = "`r`n" }
+    ) {
+        $path = Join-Path $script:sandbox "H-$Name.Tests.ps1"
+        $lines = @('BeforeAll {', '    Import-Module $manifest -Force', '}')
+        [System.IO.File]::WriteAllText($path, ($lines -join $Newline) + $Newline)
+
+        $null = & $script:rewriter -TestRoot $script:sandbox
+        $updated = [System.IO.File]::ReadAllText($path)
+        if ($Newline -eq "`n") {
+            $updated | Should -Not -Match "`r"
+        }
+        else {
+            ([regex]::Matches($updated, "`r`n")).Count | Should -Be 4
+            $updated | Should -Not -Match "(?<!`r)`n"
+        }
+        (& $script:rewriter -TestRoot $script:sandbox).Changed | Should -BeNullOrEmpty
+    }
+}

--- a/Tests/Update-PfbTestModuleImport.Tests.ps1
+++ b/Tests/Update-PfbTestModuleImport.Tests.ps1
@@ -294,6 +294,52 @@ Describe 'Update-PfbTestModuleImport rewrites each known form' -Skip:($PSVersion
             "}`n")
     }
 
+    It 'preserves a semicolon-joined statement that FOLLOWS the import' {
+        # The mirror of K.Tests.ps1. Nothing outside the replaced node's extent may move, so
+        # a following statement has to survive verbatim on the second emitted line.
+        $path = Join-Path $script:sandbox 'S.Tests.ps1'
+        [System.IO.File]::WriteAllText($path,
+            "BeforeAll {`n    Import-Module `$manifest -Force; `$script:after = 7`n}`n")
+
+        $null = & $script:rewriter -TestRoot $script:sandbox
+        [System.IO.File]::ReadAllText($path) | Should -Be (
+            "BeforeAll {`n" +
+            "    . (Join-Path `$PSScriptRoot 'PfbTestModule.ps1')`n" +
+            "    `$null = Import-PfbTestModule; `$script:after = 7`n" +
+            "}`n")
+    }
+
+    It 'reports <Name> as Unrecognised and leaves the file byte-identical' -ForEach @(
+        # The replaced node is not itself in statement position. Splicing two statements over
+        # its extent either fails to parse (the `if` condition) or parses while silently
+        # emptying the caller's variable (the other three) -- the failure class Unrecognised
+        # exists to prevent. Zero sites in the real tree; the guard is what keeps it that way.
+        @{ Name = 'AssignmentInIfCondition'
+            Statement = "    if (`$m = Import-Module `$manifest -Force -PassThru) { }" }
+        @{ Name = 'ChainedAssignment'
+            Statement = "    `$a = `$b = Import-Module `$manifest -Force -PassThru" }
+        @{ Name = 'SubExpressionBody'
+            Statement = "    `$m = `$(Import-Module `$manifest -Force -PassThru)" }
+        @{ Name = 'ArrayExpressionBody'
+            Statement = "    `$m = @(Import-Module `$manifest -Force -PassThru)" }
+        # Import-PfbTestModule cannot honour these, and emitting the helper call anyway would
+        # drop them with nothing on screen to say so. Reject instead of rewriting.
+        @{ Name = 'ExtraParameterErrorAction'
+            Statement = "    Import-Module `$manifest -Force -ErrorAction Stop" }
+        @{ Name = 'ExtraParameterGlobal'
+            Statement = "    `$m = Import-Module `$manifest -Force -PassThru -Global" }
+    ) {
+        $path = Join-Path $script:sandbox "$Name.Tests.ps1"
+        $original = "BeforeAll {`n$Statement`n}`n"
+        [System.IO.File]::WriteAllText($path, $original)
+
+        $summary = & $script:rewriter -TestRoot $script:sandbox -WarningAction SilentlyContinue
+        $summary.Changed.Count | Should -Be 0
+        $summary.Unrecognised.Count | Should -Be 1
+        $summary.Unchanged | Should -Be 1
+        [System.IO.File]::ReadAllText($path) | Should -Be $original
+    }
+
     It 'never emits -Fresh or a PfbTestModulePrepared assignment' {
         $source = [System.IO.File]::ReadAllText($script:rewriter)
         $source.Contains('PfbTestModulePrepared') | Should -BeFalse

--- a/Tests/Update-PfbTestModuleImport.Tests.ps1
+++ b/Tests/Update-PfbTestModuleImport.Tests.ps1
@@ -346,3 +346,11 @@ Describe 'Update-PfbTestModuleImport rewrites each known form' -Skip:($PSVersion
         $source.Contains('-Fresh') | Should -BeFalse
     }
 }
+
+Describe 'Update-PfbTestModuleImport is at a fixed point against the real tree' -Skip:($PSVersionTable.PSVersion.Major -lt 7) {
+    It 'reports zero changes and nothing unrecognised under -WhatIf' {
+        $summary = & $script:rewriter -WhatIf
+        $summary.Changed | Should -BeNullOrEmpty
+        $summary.Unrecognised | Should -BeNullOrEmpty
+    }
+}

--- a/Tests/Update-PfbTlsPolicy.Tests.ps1
+++ b/Tests/Update-PfbTlsPolicy.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/Update-PfbUserGroupQuotaPolicy.Tests.ps1
+++ b/Tests/Update-PfbUserGroupQuotaPolicy.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.25'; AuthToken = 'x' }
 }

--- a/Tests/Update-PfbUserGroupQuotaPolicyRule.Tests.ps1
+++ b/Tests/Update-PfbUserGroupQuotaPolicyRule.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.25'; AuthToken = 'x' }
 }

--- a/Tests/Update-PfbWormPolicy.Tests.ps1
+++ b/Tests/Update-PfbWormPolicy.Tests.ps1
@@ -3,7 +3,8 @@
 BeforeAll {
     $moduleRoot = Split-Path -Parent $PSScriptRoot
     $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
-    Import-Module $manifest -Force
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
 
     $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
 }

--- a/Tests/coverage-baseline.psd1
+++ b/Tests/coverage-baseline.psd1
@@ -48,6 +48,10 @@
             # Ungated for the same reason: it parses tracked .ps1 files via the AST, so it needs
             # neither the spec cache nor the generated manifest and has no skip path.
             'Build-PfbValueEnumMap: hand-written ValidateSet citations'
+            # Test-module import guard. Ungated -- pure AST over tracked .ps1 files, so it
+            # needs neither the spec cache nor PowerShell 7 and has no skip path. Listed
+            # under winps51 too, for that reason.
+            'Test-module import guard (AST, no spec cache required, every edition)'
             # Issue #90 pipeline-selector rails. Both are PS7-gated, so they belong to this
             # block and not to winps51. Rail B is the one this list exists for: it skips
             # GRACEFULLY when tools/specs is absent, the exact #63 shape a skip ceiling cannot
@@ -145,6 +149,10 @@
             # Ungated for the same reason: it parses tracked .ps1 files via the AST, so it needs
             # neither the spec cache nor the generated manifest and has no skip path.
             'Build-PfbValueEnumMap: hand-written ValidateSet citations'
+            # Test-module import guard. Ungated -- pure AST over tracked .ps1 files, so it
+            # needs neither the spec cache nor PowerShell 7 and has no skip path. Listed
+            # under winps51 too, for that reason.
+            'Test-module import guard (AST, no spec cache required, every edition)'
             # Dead-key gate, ungated half. It reads only the committed
             # Reports/PfbDeadKeyReport.json -- no spec cache, no PowerShell 7, no skip path --
             # so it must contribute executed tests on BOTH legs. Its two PS7-only siblings,

--- a/Tests/coverage-baseline.psd1
+++ b/Tests/coverage-baseline.psd1
@@ -134,7 +134,34 @@
         # spec cache nor ConvertFrom-Json -Depth, so it executes on both legs and adds no skips.
         #
         # 273 keeps the same +16 headroom over an expected measured 257.
-        MaxSkipped        = 273
+        #
+        # RAISED 273 -> 313 for the test-module import branch. This is a REBASE RESOLUTION: that
+        # branch was cut before #112 landed and raised 268 -> 308 against its own measurement of
+        # 292, so the two raises collided in exactly the way the top of this block warns about.
+        # They are additive rather than competing, because they gate different files:
+        #
+        #   252  the figure that justified 268, from run 31830362870.
+        #   +5   Build-PfbCapabilityMap.ContextScopeDrift.Tests.ps1, from #112 (above).
+        #   +34  Update-PfbTestModuleImport.Tests.ps1, added by THIS branch -- 33 fixture Its
+        #        plus the one real-tree -WhatIf fixed-point It. The rewriter it tests declares
+        #        `#Requires -Version 7.0`, so a PS7 gate is correct for it, and the whole file
+        #        runs on 7 (that leg measures 2 skipped against its ceiling of 8).
+        #   +6   Build-PfbDeadKeyReport.Tests.ps1, which is from NEITHER branch. It arrived on
+        #        2026-08-16 in 302f9e4 (#120), two days AFTER 364a0fe set this ceiling to 268 on
+        #        2026-08-14. #120 had slack and passed without touching this file, so 268 was
+        #        already stale against main before either branch existed -- the exact "ceiling
+        #        measured before an unrelated merge goes stale" hazard described at the top of
+        #        this block, caught in a rebase rather than in CI.
+        #   ---
+        #   297  expected measured on the merged tree.
+        #
+        # The 292 half of that is a REAL CI figure, not a local one: run 32338515336
+        # (windows-latest, Windows PowerShell 5.1) reported 2984 passed / 0 failed / 292 skipped
+        # on the pre-rebase tree, matching the local run exactly. The +5 is #112's own
+        # measurement. 313 keeps the standing +16 headroom over 297. If CI reports materially
+        # more than 297, something other than these three files moved and the delta should be
+        # re-attributed before raising again.
+        MaxSkipped        = 313
         # Only the ungated blocks are required here. The six spec-cache blocks above are
         # PS7-gated by design, so requiring them on 5.1 would be a permanent false red.
         RequiredDescribes = @(

--- a/scripts/Invoke-PfbCiPester.ps1
+++ b/scripts/Invoke-PfbCiPester.ps1
@@ -60,6 +60,54 @@ try {
 
     $result = Invoke-Pester -Configuration $cfg
 
+    # Import-PfbTestModule (Tests/PfbTestModule.ps1) counts every call it receives and every
+    # time it had to fall back to a real force-import. Both counters are globals set in THIS
+    # process: Run.Exit is $false above, so nothing has terminated yet and they are in scope
+    # here. Emitted unconditionally so the numbers appear in every CI job log whether or not
+    # the gate below trips -- they are the only visibility into whether the shared-import
+    # optimisation is actually working.
+    #
+    # Why the gate is a RATIO and not a small absolute number: the healthy force count is an
+    # enumeration of legitimate contributors -- one cold import at the start of the run, about
+    # four from Tests/PfbTestModule.Tests.ps1, which force-imports deliberately because the
+    # force path IS its subject, and one recovery per selector-harness container that installs
+    # an unmarked module instance. That total moves whenever such a file is added, so a tight
+    # absolute pin would red on ordinary maintenance. Meanwhile the failure this exists to
+    # catch is not a small drift: the helper's module-identity check fails CLOSED, so if the
+    # ModuleBase path spelling ever stops matching, every container force-imports and FORCE
+    # rises to roughly equal CALLS while the suite stays green. An order-of-magnitude gate
+    # separates those two regimes cleanly and still tolerates a new harness file.
+    $forceCount = 0
+    $callCount = 0
+    if (Test-Path variable:global:PfbTestModuleForceCount) {
+        $forceCount = [int]$global:PfbTestModuleForceCount
+    }
+    if (Test-Path variable:global:PfbTestModuleCallCount) {
+        $callCount = [int]$global:PfbTestModuleCallCount
+    }
+    Write-Host ("Import-PfbTestModule: calls={0} force-imports={1}" -f $callCount, $forceCount)
+
+    $importGateFailed = $false
+    if ($callCount -le 0) {
+        # Zero calls is not a quiet pass. In a full-suite run it means no test file loaded the
+        # module through the helper at all, so the ratio would be vacuously satisfied rather
+        # than met -- and it also guards the division below.
+        $importGateFailed = $true
+        Write-Host ('Import-PfbTestModule force-import gate FAILED: the helper was never ' +
+            'called in this run, so the force-import ratio cannot be evaluated. Either the ' +
+            'suite no longer loads the module through Tests/PfbTestModule.ps1, or the run ' +
+            'did not execute the tests it was supposed to.')
+    }
+    elseif ($forceCount -ge ($callCount / 10)) {
+        $importGateFailed = $true
+        $importGateMessage = 'Import-PfbTestModule force-import gate FAILED: {0} force-imports ' +
+            'out of {1} calls; the limit is fewer than {2}. Force-imports at that scale mean ' +
+            "the helper's module-identity check is failing closed and the suite is paying the " +
+            'full per-container import cost. Check the ModuleBase path spelling the helper ' +
+            'compares against.'
+        Write-Host ($importGateMessage -f $forceCount, $callCount, ($callCount / 10))
+    }
+
     # Ordering is load-bearing: the coverage gate runs BEFORE the failure exit, so a run that
     # both fails tests and lost coverage reports both problems rather than only the first.
     $gateFailed = $false
@@ -71,7 +119,7 @@ try {
         Write-Host $_.Exception.Message
     }
 
-    if ($result.FailedCount -gt 0 -or $gateFailed) { exit 1 }
+    if ($result.FailedCount -gt 0 -or $gateFailed -or $importGateFailed) { exit 1 }
     exit 0
 }
 finally {

--- a/tools/Update-PfbTestModuleImport.ps1
+++ b/tools/Update-PfbTestModuleImport.ps1
@@ -4,8 +4,8 @@
     Rewrites every `Import-Module <manifest> -Force` in Tests/*.Tests.ps1 to load through
     Tests/PfbTestModule.ps1 instead.
 .DESCRIPTION
-    Run once to produce the 162-file diff, then kept tracked. It is NOT a build step and
-    must not be wired into CI. It stays because (a) a 162-file diff must be reproducible
+    Run once to produce the 165-file diff, then kept tracked. It is NOT a build step and
+    must not be wired into CI. It stays because (a) a 165-file diff must be reproducible
     and reviewable as generated output, and (b) it is the tool for the next bulk change of
     this shape. Its -WhatIf fixed-point test is what keeps it honest against a drifting
     tree (Tests/Update-PfbTestModuleImport.Tests.ps1).
@@ -16,14 +16,33 @@
     Tests/ArrayConnection.ShouldProcessTarget.Tests.ps1 passes it to Get-PfbTargetRecorder).
     Deleting them would be a much larger, riskier diff for no gain.
 
-    Line endings are read, detected and preserved per file. Both LF and CRLF live in this
-    tree because .gitattributes does not normalise .ps1, and splicing the wrong newline in
-    makes every file differ, which reddens an idempotency test on one platform only.
+    WHAT GETS REPLACED IS AN AST NODE, NOT A LINE. If the import is the right-hand side of
+    a plain assignment, the enclosing AssignmentStatementAst is the replaced node and the
+    emitted target is copied verbatim from that assignment's left-hand side. Otherwise the
+    single-element pipeline containing the command is the replaced node and the target is
+    $null. Nothing outside the replaced node's extent is ever touched: no leading
+    indentation, no earlier statement on the same line, no trailing comment, no
+    semicolon-joined following statement. An import the AST does not model as one of those
+    two shapes is reported Unrecognised rather than rewritten -- hardcoding a target name
+    would silently RENAME the caller's variable, and moving the left edge of the splice
+    back to the line's indentation would silently DELETE whatever preceded it.
+
+    Line endings are read, detected and preserved per file, and the newline spliced in is
+    the one that terminates the preceding line rather than a per-file guess, so a file with
+    mixed terminators neither loses its indentation nor gains a foreign terminator. Both LF
+    and CRLF live in this tree because .gitattributes does not normalise .ps1, and splicing
+    the wrong newline in makes every file differ, which reddens an idempotency test on one
+    platform only.
 .OUTPUTS
     Changed      - files this run changed, or would change under -WhatIf
-    Unchanged    - count of files that already load through the helper
-    Unrecognised - manifest -Force imports whose spelling has no rewrite arm. NEVER
-                   silently skipped: a silent skip reads as "covered everything".
+    Unchanged    - count of files that already load through the helper, or that carry
+                   nothing rewritable
+    Excluded     - files never examined at all, per $script:ExcludedFileName below.
+                   Reported, not silently absent: Changed.Count + Unchanged +
+                   Excluded.Count accounts for every *.Tests.ps1 under -TestRoot.
+    Unrecognised - manifest -Force imports whose spelling or syntactic position has no
+                   rewrite arm. NEVER silently skipped: a silent skip reads as
+                   "covered everything".
 .EXAMPLE
     ./tools/Update-PfbTestModuleImport.ps1 -WhatIf
 .EXAMPLE
@@ -41,60 +60,167 @@ $repoRoot = Split-Path -Parent $PSScriptRoot
 
 if ([string]::IsNullOrWhiteSpace($TestRoot)) { $TestRoot = Join-Path $repoRoot 'Tests' }
 
+# Files this rewriter must never examine. Checked before the file is read or parsed, so the
+# rewriter is STRUCTURALLY incapable of touching them (spec 0.3, risk 6) rather than merely
+# happening not to match them.
+#
+#   PfbTestModule.Tests.ps1 -- its raw `Import-Module -Name $script:manifest -Force -PassThru`
+#   is not a redundant import, it is the fixture of the 'force-reimports after an unmarked
+#   instance is installed by something else' test: it deliberately installs a module instance
+#   carrying no prepared-marker so the test can prove Import-PfbTestModule notices and
+#   rebuilds. Rewriting it to a helper call means no unmarked instance is ever installed and
+#   the condition under test can never occur.
+$script:ExcludedFileName = @(
+    'PfbTestModule.Tests.ps1'
+)
+
 $dotSourceLine = ". (Join-Path `$PSScriptRoot 'PfbTestModule.ps1')"
+$newlineChar = [char[]]@("`n", "`r")
 $changed = @()
+$excluded = @()
 $unrecognised = @()
 $unchanged = 0
 
-foreach ($file in (Get-ChildItem -Path $TestRoot -Filter '*.Tests.ps1' -File | Sort-Object Name)) {
-    $content = [System.IO.File]::ReadAllText($file.FullName)
-    $imports = @(Get-PfbTestManifestImport -Path $file.FullName)
+function Resolve-PfbImportSplice {
+    <#
+        Map an Import-Module CommandAst to the extent that should be replaced and the
+        assignment target that should be emitted. Returns $null when the command sits in a
+        syntactic position this rewriter does not model, which the caller turns into an
+        Unrecognised record.
+
+        Two modelled shapes, and only two:
+          <indent>$target = Import-Module ...   -> replace the AssignmentStatementAst,
+                                                   target = its Left extent text verbatim
+          <indent>Import-Module ...             -> replace the PipelineAst, target = $null
+    #>
+    [CmdletBinding()]
+    param([Parameter(Mandatory = $true)]$Command)
+
+    $pipeline = $Command.Parent
+    if ($pipeline -isnot [System.Management.Automation.Language.PipelineAst]) { return $null }
+    # A multi-element pipeline would put another command's extent inside the replaced node.
+    if ($pipeline.PipelineElements.Count -ne 1) { return $null }
+
+    $parent = $pipeline.Parent
+
+    if ($parent -is [System.Management.Automation.Language.AssignmentStatementAst]) {
+        # Only a plain `=`; a `+=` or `??=` around an import is not something to reproduce.
+        if ($parent.Operator -ne [System.Management.Automation.Language.TokenKind]::Equals) { return $null }
+        if (-not [object]::ReferenceEquals($parent.Right, $pipeline)) { return $null }
+        return [PSCustomObject]@{
+            StartOffset = $parent.Extent.StartOffset
+            EndOffset   = $parent.Extent.EndOffset
+            Target      = $parent.Left.Extent.Text
+        }
+    }
+
+    $isStatementPosition =
+        ($parent -is [System.Management.Automation.Language.StatementBlockAst]) -or
+        ($parent -is [System.Management.Automation.Language.NamedBlockAst]) -or
+        ($parent -is [System.Management.Automation.Language.ScriptBlockAst])
+    if (-not $isStatementPosition) { return $null }
+
+    return [PSCustomObject]@{
+        StartOffset = $pipeline.Extent.StartOffset
+        EndOffset   = $pipeline.Extent.EndOffset
+        Target      = '$null'
+    }
+}
+
+# Ordinal sort: 5.1 and 7 disagree on invariant linguistic order, so a culture-sensitive
+# Sort-Object would make the reported order edition-dependent (issue #85 convention).
+$filePath = [string[]]@(Get-ChildItem -Path $TestRoot -Filter '*.Tests.ps1' -File -Recurse |
+    ForEach-Object { $_.FullName })
+[Array]::Sort($filePath, [System.StringComparer]::Ordinal)
+
+foreach ($path in $filePath) {
+    $name = [System.IO.Path]::GetFileName($path)
+
+    if ($script:ExcludedFileName -contains $name) {
+        Write-Verbose ("Update-PfbTestModuleImport: {0} is on the exclusion list; not examined." -f $name)
+        $excluded += $path
+        continue
+    }
+
+    $content = [System.IO.File]::ReadAllText($path)
+    $imports = @(Get-PfbTestManifestImport -Path $path)
 
     if ($imports.Count -eq 0) {
         $unchanged++
         continue
     }
 
-    $unknown = @($imports | Where-Object { $_.Form -eq 'Unrecognised' })
-    foreach ($item in $unknown) {
+    foreach ($item in @($imports | Where-Object { $_.Form -eq 'Unrecognised' })) {
         Write-Warning ("Update-PfbTestModuleImport: unrecognised manifest -Force import at {0}:{1} -- '{2}'. Not rewritten." -f
-            $file.Name, $item.Line, $item.Text)
-        $unrecognised += [PSCustomObject]@{ File = $file.Name; Line = $item.Line; Text = $item.Text }
+            $name, $item.Line, $item.Text)
+        $unrecognised += [PSCustomObject]@{ File = $name; Line = $item.Line; Text = $item.Text }
     }
 
-    $rewritable = @($imports | Where-Object { $_.Form -ne 'Unrecognised' })
-    if ($rewritable.Count -eq 0) { continue }
+    # Re-walk the AST to recover each import's syntactic position. Get-PfbTestManifestImport
+    # returns offsets, not nodes, and the enclosing assignment is what has to be replaced.
+    $commandByOffset = @{}
+    foreach ($command in (Get-PfbCommandAst -Ast (Get-PfbTestImportAst -Path $path))) {
+        $commandByOffset[$command.Extent.StartOffset] = $command
+    }
+
+    $site = @()
+    foreach ($item in @($imports | Where-Object { $_.Form -ne 'Unrecognised' })) {
+        $command = $commandByOffset[$item.StartOffset]
+        $splice = $null
+        if ($null -ne $command) { $splice = Resolve-PfbImportSplice -Command $command }
+        if ($null -eq $splice) {
+            Write-Warning ("Update-PfbTestModuleImport: manifest -Force import at {0}:{1} is not a plain statement or assignment -- '{2}'. Not rewritten." -f
+                $name, $item.Line, $item.Text)
+            $unrecognised += [PSCustomObject]@{ File = $name; Line = $item.Line; Text = $item.Text }
+            continue
+        }
+        $site += $splice
+    }
+
+    if ($site.Count -eq 0) {
+        $unchanged++
+        continue
+    }
 
     # Detect from the file, not from [Environment]::NewLine: the platform does not decide
-    # this, the checked-out file does.
+    # this, the checked-out file does. Only a fallback -- a site on line 1 has no preceding
+    # terminator to copy.
     $nl = "`n"
     if ($content -match "`r`n") { $nl = "`r`n" }
 
     # Splice back-to-front so earlier offsets stay valid.
     $updated = $content
-    foreach ($item in ($rewritable | Sort-Object StartOffset -Descending)) {
-        $lineStart = $updated.LastIndexOf($nl, $item.StartOffset)
-        if ($lineStart -lt 0) { $indentStart = 0 } else { $indentStart = $lineStart + $nl.Length }
+    foreach ($item in ($site | Sort-Object StartOffset -Descending)) {
+        # Terminator-agnostic line start: LastIndexOf($nl, ...) skips lines ended with the
+        # other convention, which recovers the indent of the wrong line in a mixed file.
+        $lineStart = 0
+        if ($item.StartOffset -gt 0) {
+            $found = $updated.LastIndexOfAny($newlineChar, ($item.StartOffset - 1))
+            if ($found -ge 0) { $lineStart = $found + 1 }
+        }
+
+        # The terminator that ends the PRECEDING line, so a mixed-ending file keeps its mix.
+        $lineNl = $nl
+        if ($lineStart -gt 0) {
+            if ($updated[$lineStart - 1] -eq "`n" -and $lineStart -ge 2 -and $updated[$lineStart - 2] -eq "`r") {
+                $lineNl = "`r`n"
+            }
+            else {
+                $lineNl = [string]$updated[$lineStart - 1]
+            }
+        }
+
+        # Indentation of the physical line the replaced node starts on, taken as characters
+        # so tabs stay tabs.
         $indent = ''
-        for ($i = $indentStart; $i -lt $item.StartOffset; $i++) {
+        for ($i = $lineStart; $i -lt $item.StartOffset; $i++) {
             $ch = $updated[$i]
             if ($ch -ne ' ' -and $ch -ne "`t") { break }
             $indent += $ch
         }
 
-        if ($item.Form -eq 'PassThru') {
-            $replacement = $dotSourceLine + $nl + $indent + '$script:module = Import-PfbTestModule'
-        }
-        else {
-            $replacement = $dotSourceLine + $nl + $indent + '$null = Import-PfbTestModule'
-        }
-
-        if ($item.Form -eq 'PassThru') {
-            $head = $updated.Substring(0, $indentStart) + $indent
-        }
-        else {
-            $head = $updated.Substring(0, $item.StartOffset)
-        }
+        $replacement = $dotSourceLine + $lineNl + $indent + $item.Target + ' = Import-PfbTestModule'
+        $head = $updated.Substring(0, $item.StartOffset)
         $tail = $updated.Substring($item.EndOffset)
         $updated = $head + $replacement + $tail
     }
@@ -104,19 +230,20 @@ foreach ($file in (Get-ChildItem -Path $TestRoot -Filter '*.Tests.ps1' -File | S
         continue
     }
 
-    $changed += $file.FullName
-    if ($PSCmdlet.ShouldProcess($file.FullName, 'Rewrite manifest import to use Import-PfbTestModule')) {
+    $changed += $path
+    if ($PSCmdlet.ShouldProcess($path, 'Rewrite manifest import to use Import-PfbTestModule')) {
         # WriteAllText with a BOM-less UTF8 encoding, not Set-Content: no test file has a
         # BOM, and Set-Content would append its own trailing newline.
-        [System.IO.File]::WriteAllText($file.FullName, $updated, (New-Object System.Text.UTF8Encoding($false)))
+        [System.IO.File]::WriteAllText($path, $updated, (New-Object System.Text.UTF8Encoding($false)))
     }
 }
 
-Write-Verbose ("Test-module imports: {0} changed, {1} already current, {2} unrecognised." -f
-    $changed.Count, $unchanged, $unrecognised.Count)
+Write-Verbose ("Test-module imports: {0} changed, {1} already current, {2} excluded, {3} unrecognised (of {4} files)." -f
+    $changed.Count, $unchanged, $excluded.Count, $unrecognised.Count, $filePath.Count)
 
 [PSCustomObject]@{
     Changed      = $changed
     Unchanged    = $unchanged
+    Excluded     = $excluded
     Unrecognised = $unrecognised
 }

--- a/tools/Update-PfbTestModuleImport.ps1
+++ b/tools/Update-PfbTestModuleImport.ps1
@@ -27,6 +27,12 @@
     would silently RENAME the caller's variable, and moving the left edge of the splice
     back to the line's indentation would silently DELETE whatever preceded it.
 
+    An import carrying any parameter other than -Force/-PassThru/-Name is likewise
+    Unrecognised, because Import-PfbTestModule has no way to honour it and emitting the
+    helper call regardless would silently DROP it (-Global, -ErrorAction Stop). Zero such
+    sites exist in this tree today; the point is that the next one stops the tool instead
+    of changing behaviour quietly.
+
     Line endings are read, detected and preserved per file, and the newline spliced in is
     the one that terminates the preceding line rather than a per-file guess, so a file with
     mixed terminators neither loses its indentation nor gains a foreign terminator. Both LF
@@ -81,6 +87,42 @@ $excluded = @()
 $unrecognised = @()
 $unchanged = 0
 
+# Parameters Import-PfbTestModule can stand in for. Anything else on the import (-Global,
+# -ErrorAction Stop, -Scope, ...) has no equivalent in the emitted call, so the import goes
+# to Unrecognised rather than being rewritten with the parameter silently dropped. Rejecting
+# is the right direction: a spelling that would have rewritten cleanly now needs a human,
+# whereas a dropped parameter changes behaviour with nothing on screen to say so.
+$script:AllowedImportParameter = @('Force', 'PassThru', 'Name')
+
+function Test-PfbSpliceStatementPosition {
+    <#
+        Is $Node itself in statement position -- i.e. would replacing its whole extent with
+        two statements be legal? True only when its parent is a statement container, and
+        never when that container is the body of an expression ($( ), @( ), ( )), where two
+        spliced statements either fail to parse or silently discard the module.
+    #>
+    [CmdletBinding()]
+    param([Parameter(Mandatory = $true)]$Node)
+
+    $parent = $Node.Parent
+    $isStatementPosition =
+        ($parent -is [System.Management.Automation.Language.StatementBlockAst]) -or
+        ($parent -is [System.Management.Automation.Language.NamedBlockAst]) -or
+        ($parent -is [System.Management.Automation.Language.ScriptBlockAst])
+    if (-not $isStatementPosition) { return $false }
+
+    if ($parent -is [System.Management.Automation.Language.StatementBlockAst]) {
+        $grandparent = $parent.Parent
+        if (($grandparent -is [System.Management.Automation.Language.SubExpressionAst]) -or
+            ($grandparent -is [System.Management.Automation.Language.ArrayExpressionAst]) -or
+            ($grandparent -is [System.Management.Automation.Language.ParenExpressionAst])) {
+            return $false
+        }
+    }
+
+    return $true
+}
+
 function Resolve-PfbImportSplice {
     <#
         Map an Import-Module CommandAst to the extent that should be replaced and the
@@ -92,9 +134,20 @@ function Resolve-PfbImportSplice {
           <indent>$target = Import-Module ...   -> replace the AssignmentStatementAst,
                                                    target = its Left extent text verbatim
           <indent>Import-Module ...             -> replace the PipelineAst, target = $null
+
+        In BOTH arms the node whose extent will be replaced must itself be in statement
+        position, checked identically by Test-PfbSpliceStatementPosition. Without that
+        check `if ($m = Import-Module ... -PassThru) { }` emits a file that does not parse,
+        and `$a = $b = ...` / `$m = $(...)` / `$m = @(...)` all parse but leave the caller's
+        variable silently empty -- the exact failure class Unrecognised exists to prevent.
     #>
     [CmdletBinding()]
     param([Parameter(Mandatory = $true)]$Command)
+
+    foreach ($element in $Command.CommandElements) {
+        if ($element -isnot [System.Management.Automation.Language.CommandParameterAst]) { continue }
+        if ($script:AllowedImportParameter -notcontains $element.ParameterName) { return $null }
+    }
 
     $pipeline = $Command.Parent
     if ($pipeline -isnot [System.Management.Automation.Language.PipelineAst]) { return $null }
@@ -107,6 +160,7 @@ function Resolve-PfbImportSplice {
         # Only a plain `=`; a `+=` or `??=` around an import is not something to reproduce.
         if ($parent.Operator -ne [System.Management.Automation.Language.TokenKind]::Equals) { return $null }
         if (-not [object]::ReferenceEquals($parent.Right, $pipeline)) { return $null }
+        if (-not (Test-PfbSpliceStatementPosition -Node $parent)) { return $null }
         return [PSCustomObject]@{
             StartOffset = $parent.Extent.StartOffset
             EndOffset   = $parent.Extent.EndOffset
@@ -114,11 +168,7 @@ function Resolve-PfbImportSplice {
         }
     }
 
-    $isStatementPosition =
-        ($parent -is [System.Management.Automation.Language.StatementBlockAst]) -or
-        ($parent -is [System.Management.Automation.Language.NamedBlockAst]) -or
-        ($parent -is [System.Management.Automation.Language.ScriptBlockAst])
-    if (-not $isStatementPosition) { return $null }
+    if (-not (Test-PfbSpliceStatementPosition -Node $pipeline)) { return $null }
 
     return [PSCustomObject]@{
         StartOffset = $pipeline.Extent.StartOffset

--- a/tools/Update-PfbTestModuleImport.ps1
+++ b/tools/Update-PfbTestModuleImport.ps1
@@ -1,0 +1,122 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Rewrites every `Import-Module <manifest> -Force` in Tests/*.Tests.ps1 to load through
+    Tests/PfbTestModule.ps1 instead.
+.DESCRIPTION
+    Run once to produce the 162-file diff, then kept tracked. It is NOT a build step and
+    must not be wired into CI. It stays because (a) a 162-file diff must be reproducible
+    and reviewable as generated output, and (b) it is the tool for the next bulk change of
+    this shape. Its -WhatIf fixed-point test is what keeps it honest against a drifting
+    tree (Tests/Update-PfbTestModuleImport.Tests.ps1).
+
+    Only the import STATEMENT is replaced, in place, at its own indentation. Surrounding
+    $moduleRoot / $manifest assignments are left alone: several files go on to use them
+    (Tests/RemovedCmdlets.Tests.ps1 asserts against $manifest;
+    Tests/ArrayConnection.ShouldProcessTarget.Tests.ps1 passes it to Get-PfbTargetRecorder).
+    Deleting them would be a much larger, riskier diff for no gain.
+
+    Line endings are read, detected and preserved per file. Both LF and CRLF live in this
+    tree because .gitattributes does not normalise .ps1, and splicing the wrong newline in
+    makes every file differ, which reddens an idempotency test on one platform only.
+.OUTPUTS
+    Changed      - files this run changed, or would change under -WhatIf
+    Unchanged    - count of files that already load through the helper
+    Unrecognised - manifest -Force imports whose spelling has no rewrite arm. NEVER
+                   silently skipped: a silent skip reads as "covered everything".
+.EXAMPLE
+    ./tools/Update-PfbTestModuleImport.ps1 -WhatIf
+.EXAMPLE
+    ./tools/Update-PfbTestModuleImport.ps1
+#>
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [string]$TestRoot
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+. (Join-Path $repoRoot 'tools/lib/PfbTestImportTools.ps1')
+
+if ([string]::IsNullOrWhiteSpace($TestRoot)) { $TestRoot = Join-Path $repoRoot 'Tests' }
+
+$dotSourceLine = ". (Join-Path `$PSScriptRoot 'PfbTestModule.ps1')"
+$changed = @()
+$unrecognised = @()
+$unchanged = 0
+
+foreach ($file in (Get-ChildItem -Path $TestRoot -Filter '*.Tests.ps1' -File | Sort-Object Name)) {
+    $content = [System.IO.File]::ReadAllText($file.FullName)
+    $imports = @(Get-PfbTestManifestImport -Path $file.FullName)
+
+    if ($imports.Count -eq 0) {
+        $unchanged++
+        continue
+    }
+
+    $unknown = @($imports | Where-Object { $_.Form -eq 'Unrecognised' })
+    foreach ($item in $unknown) {
+        Write-Warning ("Update-PfbTestModuleImport: unrecognised manifest -Force import at {0}:{1} -- '{2}'. Not rewritten." -f
+            $file.Name, $item.Line, $item.Text)
+        $unrecognised += [PSCustomObject]@{ File = $file.Name; Line = $item.Line; Text = $item.Text }
+    }
+
+    $rewritable = @($imports | Where-Object { $_.Form -ne 'Unrecognised' })
+    if ($rewritable.Count -eq 0) { continue }
+
+    # Detect from the file, not from [Environment]::NewLine: the platform does not decide
+    # this, the checked-out file does.
+    $nl = "`n"
+    if ($content -match "`r`n") { $nl = "`r`n" }
+
+    # Splice back-to-front so earlier offsets stay valid.
+    $updated = $content
+    foreach ($item in ($rewritable | Sort-Object StartOffset -Descending)) {
+        $lineStart = $updated.LastIndexOf($nl, $item.StartOffset)
+        if ($lineStart -lt 0) { $indentStart = 0 } else { $indentStart = $lineStart + $nl.Length }
+        $indent = ''
+        for ($i = $indentStart; $i -lt $item.StartOffset; $i++) {
+            $ch = $updated[$i]
+            if ($ch -ne ' ' -and $ch -ne "`t") { break }
+            $indent += $ch
+        }
+
+        if ($item.Form -eq 'PassThru') {
+            $replacement = $dotSourceLine + $nl + $indent + '$script:module = Import-PfbTestModule'
+        }
+        else {
+            $replacement = $dotSourceLine + $nl + $indent + '$null = Import-PfbTestModule'
+        }
+
+        if ($item.Form -eq 'PassThru') {
+            $head = $updated.Substring(0, $indentStart) + $indent
+        }
+        else {
+            $head = $updated.Substring(0, $item.StartOffset)
+        }
+        $tail = $updated.Substring($item.EndOffset)
+        $updated = $head + $replacement + $tail
+    }
+
+    if ($updated -eq $content) {
+        $unchanged++
+        continue
+    }
+
+    $changed += $file.FullName
+    if ($PSCmdlet.ShouldProcess($file.FullName, 'Rewrite manifest import to use Import-PfbTestModule')) {
+        # WriteAllText with a BOM-less UTF8 encoding, not Set-Content: no test file has a
+        # BOM, and Set-Content would append its own trailing newline.
+        [System.IO.File]::WriteAllText($file.FullName, $updated, (New-Object System.Text.UTF8Encoding($false)))
+    }
+}
+
+Write-Verbose ("Test-module imports: {0} changed, {1} already current, {2} unrecognised." -f
+    $changed.Count, $unchanged, $unrecognised.Count)
+
+[PSCustomObject]@{
+    Changed      = $changed
+    Unchanged    = $unchanged
+    Unrecognised = $unrecognised
+}

--- a/tools/lib/PfbTestImportTools.ps1
+++ b/tools/lib/PfbTestImportTools.ps1
@@ -1,0 +1,224 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    The single AST predicate over test-file module imports.
+.DESCRIPTION
+    Two consumers depend on this file and they must never disagree:
+    tools/Update-PfbTestModuleImport.ps1 rewrites what it finds, and
+    Tests/TestModuleImportGuard.Tests.ps1 asserts there is nothing left to find.
+    A second, drifting copy of this logic would let the rewriter miss a site the
+    guard still forbids, or vice versa.
+
+    Everything here is AST-based on purpose. Two lines under Tests/ mention
+    Import-Module and must NEVER be rewritten -- the separate-runspace
+    $ps.AddCommand('Import-Module') in ArrayConnection.ShouldProcessTarget.Tests.ps1
+    and `Mock ... Import-Module { }` in Get-PfbApiTokenViaSsh.Tests.ps1. Neither is
+    a CommandAst named Import-Module, so an AST predicate cannot touch them. A
+    negative-lookahead regex would be a permanent liability by comparison.
+
+    5.1 CONSTRAINT: this is dot-sourced by a guard test that runs on Windows
+    PowerShell 5.1 as well as pwsh 7. No ternaries, no ??, no pipeline chain operators.
+
+    Deliberately does NOT call Set-StrictMode. This file is dot-sourced into a Pester
+    BeforeAll scope, where a strict-mode setting would leak into unrelated test code
+    in the same container and red it for reasons that have nothing to do with this library.
+#>
+
+$script:PfbManifestLeafName = 'PureStorageFlashBladePowerShell.psd1'
+$script:PfbModuleName = 'PureStorageFlashBladePowerShell'
+
+function Get-PfbTestImportAst {
+    <#
+        Parse one file and return every CommandAst in it. Throws on a parse error rather
+        than returning a partial tree -- a file we cannot parse is a file we cannot make
+        any claim about, and silently returning zero matches would read as "clean".
+    #>
+    [CmdletBinding()]
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    $tokens = $null
+    $errors = $null
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile($Path, [ref]$tokens, [ref]$errors)
+    if ($null -ne $errors -and $errors.Count -gt 0) {
+        throw ("Get-PfbTestImportAst: '{0}' failed to parse: {1}" -f $Path, $errors[0].Message)
+    }
+    return $ast
+}
+
+function Get-PfbCommandAst {
+    [CmdletBinding()]
+    param([Parameter(Mandatory = $true)]$Ast)
+
+    return @($Ast.FindAll({
+        param($node)
+        return ($node -is [System.Management.Automation.Language.CommandAst])
+    }, $true))
+}
+
+function Get-PfbTestManifestImport {
+    <#
+        Returns one record per `Import-Module <manifest> -Force` in the file, classified
+        into one of the five known call-site forms, or 'Unrecognised'.
+
+        Unrecognised is never dropped: a silent skip reads as "covered everything", which
+        is the specific mistake tools/Update-PfbContextHelp.ps1 documents at length.
+        Offsets are byte-exact so a caller can splice without re-finding the text.
+    #>
+    [CmdletBinding()]
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    $ast = Get-PfbTestImportAst -Path $Path
+    $results = @()
+
+    foreach ($command in (Get-PfbCommandAst -Ast $ast)) {
+        $name = $command.GetCommandName()
+        if ($name -ne 'Import-Module') { continue }
+
+        $hasForce = $false
+        $hasPassThru = $false
+        $moduleArgument = $null
+
+        # Element 0 is the command name itself. A bare (unnamed) argument is the module.
+        for ($i = 1; $i -lt $command.CommandElements.Count; $i++) {
+            $element = $command.CommandElements[$i]
+            if ($element -is [System.Management.Automation.Language.CommandParameterAst]) {
+                if ($element.ParameterName -eq 'Force') { $hasForce = $true }
+                if ($element.ParameterName -eq 'PassThru') { $hasPassThru = $true }
+                if ($element.ParameterName -eq 'Name' -and $null -ne $element.Argument) {
+                    $moduleArgument = $element.Argument
+                }
+                continue
+            }
+            if ($null -eq $moduleArgument) { $moduleArgument = $element }
+        }
+
+        if (-not $hasForce) { continue }
+        if ($null -eq $moduleArgument) { continue }
+
+        $argumentText = $moduleArgument.Extent.Text
+        $namesManifest = ($argumentText -match [regex]::Escape($script:PfbManifestLeafName)) -or
+            ($argumentText -eq '$manifest') -or ($argumentText -eq '$script:manifest')
+        if (-not $namesManifest) { continue }
+
+        $form = 'Unrecognised'
+        if ($hasPassThru) {
+            $form = 'PassThru'
+        }
+        elseif ($argumentText -eq '$manifest') {
+            $form = 'Manifest'
+        }
+        elseif ($argumentText -eq '$script:manifest') {
+            $form = 'ScriptManifest'
+        }
+        elseif ($argumentText -match '^"\$PSScriptRoot/\.\./PureStorageFlashBladePowerShell\.psd1"$') {
+            $form = 'PSScriptRoot'
+        }
+        elseif ($argumentText -match "^\(Join-Path \`$\w+ '$([regex]::Escape($script:PfbManifestLeafName))'\)$") {
+            $form = 'JoinPath'
+        }
+        elseif (($argumentText -match 'Join-Path') -and
+            ($argumentText -match [regex]::Escape($script:PfbManifestLeafName))) {
+            # Sixth form, added by PR #125 (Tests/Test-PfbEmptyPipelineRead.Tests.ps1:4):
+            #     Import-Module (Join-Path (Split-Path -Parent $PSScriptRoot) `
+            #             'PureStorageFlashBladePowerShell.psd1') -Force
+            # Deliberately AFTER the specific JoinPath arm, and keyed on structure rather than
+            # on an exact spelling, because the extent carries an embedded backtick and newline
+            # that no single-line anchored regex can match. Safe to rewrite sight-unseen because
+            # the replacement never references the old argument, and no manifest -Force import in
+            # this tree carries any parameter other than Force/PassThru -- so there is no import
+            # whose extra parameters Import-PfbTestModule would fail to reproduce.
+            $form = 'NestedJoinPath'
+        }
+
+        $results += [PSCustomObject]@{
+            Form        = $form
+            StartOffset = $command.Extent.StartOffset
+            EndOffset   = $command.Extent.EndOffset
+            Text        = $command.Extent.Text
+            Line        = $command.Extent.StartLineNumber
+        }
+    }
+
+    return $results
+}
+
+function Get-PfbExportedFunctionName {
+    <#
+        The exported-function list, read statically from the manifest. Verified to be an
+        explicit literal array in PureStorageFlashBladePowerShell.psd1 -- not '*' and not
+        a wildcard -- which is what lets the guard's obligation predicate track the module
+        automatically instead of carrying a hand-maintained name table.
+    #>
+    [CmdletBinding()]
+    param([Parameter(Mandatory = $true)][string]$ManifestPath)
+
+    $data = Import-PowerShellDataFile -LiteralPath $ManifestPath
+    return @($data.FunctionsToExport)
+}
+
+function Test-PfbTestModuleUsage {
+    <#
+        Does this test file oblige itself to load the module? True if it calls an EXPORTED
+        function, or names the module in InModuleScope, or names it in Mock -ModuleName.
+
+        Rules 2 and 3 are not redundant with rule 1: the files that test PRIVATE functions
+        (Get-PfbCapabilityMap, Get-PfbVersionMap) never call an exported name, and reach
+        module internals through InModuleScope instead.
+
+        Matching is on CommandAst command names only. A cmdlet name inside a string -- a
+        Should -Throw message, a comment, a -ParameterFilter -- is not a call.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][AllowEmptyCollection()][string[]]$ExportedFunction
+    )
+
+    $exportedLookup = @{}
+    foreach ($name in $ExportedFunction) { $exportedLookup[$name] = $true }
+
+    $reasons = @()
+    $callsHelper = $false
+
+    foreach ($command in (Get-PfbCommandAst -Ast (Get-PfbTestImportAst -Path $Path))) {
+        $name = $command.GetCommandName()
+        if ([string]::IsNullOrEmpty($name)) { continue }
+
+        if ($name -eq 'Import-PfbTestModule') {
+            $callsHelper = $true
+            continue
+        }
+        if ($exportedLookup.ContainsKey($name)) {
+            $reasons += ("calls exported cmdlet {0} (line {1})" -f $name, $command.Extent.StartLineNumber)
+            continue
+        }
+        if ($name -eq 'InModuleScope' -and $command.Extent.Text -match [regex]::Escape($script:PfbModuleName)) {
+            $reasons += ("InModuleScope {0} (line {1})" -f $script:PfbModuleName, $command.Extent.StartLineNumber)
+            continue
+        }
+        if ($name -eq 'Mock') {
+            for ($i = 1; $i -lt $command.CommandElements.Count; $i++) {
+                $element = $command.CommandElements[$i]
+                if ($element -is [System.Management.Automation.Language.CommandParameterAst] -and
+                    $element.ParameterName -eq 'ModuleName') {
+                    $valueText = ''
+                    if ($null -ne $element.Argument) {
+                        $valueText = $element.Argument.Extent.Text
+                    }
+                    elseif (($i + 1) -lt $command.CommandElements.Count) {
+                        $valueText = $command.CommandElements[$i + 1].Extent.Text
+                    }
+                    if ($valueText -match [regex]::Escape($script:PfbModuleName)) {
+                        $reasons += ("Mock -ModuleName {0} (line {1})" -f $script:PfbModuleName, $command.Extent.StartLineNumber)
+                    }
+                }
+            }
+        }
+    }
+
+    return [PSCustomObject]@{
+        Uses        = ($reasons.Count -gt 0)
+        Reasons     = @($reasons)
+        CallsHelper = $callsHelper
+    }
+}

--- a/tools/lib/PfbTestImportTools.ps1
+++ b/tools/lib/PfbTestImportTools.ps1
@@ -29,9 +29,14 @@ $script:PfbModuleName = 'PureStorageFlashBladePowerShell'
 
 function Get-PfbTestImportAst {
     <#
-        Parse one file and return every CommandAst in it. Throws on a parse error rather
-        than returning a partial tree -- a file we cannot parse is a file we cannot make
-        any claim about, and silently returning zero matches would read as "clean".
+        Parse one file and return the AST ROOT (the ScriptBlockAst) for it -- not the
+        imports, and not a CommandAst list. Use Get-PfbCommandAst on the returned root to
+        get the CommandAst nodes. The name is retained because Task 3's rewriter and the
+        Task 5 guard test are both written against it.
+
+        Throws on a parse error rather than returning a partial tree -- a file we cannot
+        parse is a file we cannot make any claim about, and silently returning zero
+        matches would read as "clean".
     #>
     [CmdletBinding()]
     param([Parameter(Mandatory = $true)][string]$Path)
@@ -58,11 +63,20 @@ function Get-PfbCommandAst {
 function Get-PfbTestManifestImport {
     <#
         Returns one record per `Import-Module <manifest> -Force` in the file, classified
-        into one of the five known call-site forms, or 'Unrecognised'.
+        into one of the six known call-site forms -- Manifest, PSScriptRoot, JoinPath,
+        NestedJoinPath, ScriptManifest, PassThru -- or 'Unrecognised'.
 
         Unrecognised is never dropped: a silent skip reads as "covered everything", which
         is the specific mistake tools/Update-PfbContextHelp.ps1 documents at length.
-        Offsets are byte-exact so a caller can splice without re-finding the text.
+
+        OFFSETS ARE CHARACTER OFFSETS, NOT BYTE OFFSETS. StartOffset/EndOffset index into
+        the DECODED text of the file (EndOffset is exclusive), so a consumer must splice a
+        decoded string -- [System.IO.File]::ReadAllText($path) followed by
+        .Substring($StartOffset, $EndOffset - $StartOffset) -- and must NEVER index a byte
+        array with them. Eight test files in this tree contain multi-byte UTF-8, where the
+        two counts diverge; today only one of those carries a manifest import and its
+        import happens to precede the non-ASCII, so byte-indexing would work there by luck
+        alone. Do not rely on that.
     #>
     [CmdletBinding()]
     param([Parameter(Mandatory = $true)][string]$Path)


### PR DESCRIPTION
# Reuse the loaded module in tests instead of force-importing it 165 times

## The problem

Test containers loaded the module in their `BeforeAll` like this:

```powershell
Import-Module $manifest -Force
```

`-Force` discards the loaded module and rebuilds it, re-dot-sourcing the 574 `.ps1` files
under `Public/` and `Private/`. That costs roughly 4.2 s. Pester runs the whole suite in one
host process, so 165 containers each paid it — and 164 of those rebuilds were of an
already-loaded, byte-identical module.

## The change

`Tests/PfbTestModule.ps1` provides `Import-PfbTestModule`, which reuses the loaded instance
and resets the volatile module-scope state instead of rebuilding. Every converted container now
has two lines in its `BeforeAll`:

```powershell
. (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
$null = Import-PfbTestModule
```

The rewrite was applied mechanically by `tools/Update-PfbTestModuleImport.ps1`, an AST rewriter
that splices the replacement over the `Import-Module` command node rather than editing lines.
It is idempotent and re-runnable: on this tree `-WhatIf` reports
`Changed=0 Unchanged=195 Excluded=1 Unrecognised=0`, which sums to all 196 `*.Tests.ps1` files.

`-Force` equivalence is the whole correctness question, and it is what the helper's reset block
buys. All five volatile module-scope variables are cleared unconditionally on every call:

```powershell
$script:PfbDefaultArray = $null
$script:PfbArrays = @{}
$script:PfbCachedCredential = $null
$script:PfbCapabilityMap = $null
$script:PfbVersionMap = $null
```

An earlier revision cleared the two JSON caches only when the module root changed, on the
grounds that they are read-only and safe to reuse. That was reversed. The condition keyed off
the module root, which is one of several ways a stale cache arrives — a test that populates
`$script:PfbCapabilityMap` directly leaves it warm and visible to the next container, which is
precisely the order-dependent leakage `-Force` used to make impossible. The reset must not
become conditional again; `Tests/PfbTestModule.ps1` says so at the site.

## Scope

175 files: 172 under `Tests/`, two new files under `tools/`, and one under `scripts/`.

**Nothing under `Public/` or `Private/` is touched, and neither the manifest nor the root
module is.** That is the basis on which the repo owner waived live-FlashBlade verification for
this change — it cannot alter what goes on the wire. The claim was verified mechanically rather
than asserted: the file list contains no `.psm1`, no `.psd1`, and nothing under `Data/`,
`Reports/` or `.github/`. Both new `tools/` files are dot-sourced by exactly three consumers,
no wildcard `tools/lib/*.ps1` dot-source picks them up, and none of their eight function names
collides with an existing definition.

The `scripts/` file is a deliberate addition to the original scope — see the CI gate below.

## What stops this silently regressing

The helper's module-identity check **fails closed**. If the `ModuleBase` path spelling it
compares against ever stops matching, every container force-imports anyway, the whole suite
stays green, the coverage gate stays green, and the entire saving evaporates with nothing able
to detect it. A performance change whose failure mode is "still passes, just slow again" needs
an instrument, not a test.

So there are two, and both are new:

**`Tests/TestModuleImportGuard.Tests.ps1`** — pure AST over tracked `.ps1` files, so it needs
neither the spec cache nor PowerShell 7 and runs ungated on both editions. Three `It`s catch a
raw `-Force` manifest import returning, a test file that uses the module without loading it
through the helper, and a new module-scope `$script:` variable the helper does not know to
reset. A fourth asserts the guard's allowlist and the rewriter's exclusion set are equal as
sets, so the two cannot drift apart in the direction that hides a real offender.

**A force-import ratio gate in `scripts/Invoke-PfbCiPester.ps1`** — emits both counters
unconditionally into every CI job log, then fails the run if
`force-imports >= calls / 10`.

The gate is a ratio rather than a small absolute number on purpose. The healthy force count is
an enumeration of legitimate contributors — one cold import per run, about four from
`Tests/PfbTestModule.Tests.ps1` (which force-imports deliberately, because the force path is
its subject), and one recovery per selector-harness container that installs an unmarked
instance — so a tight pin would red on ordinary maintenance. The failure it exists to catch is
not a small drift: it drives force-imports up to roughly equal calls. An order-of-magnitude
gate separates those two regimes and still tolerates a new harness file.

The threshold is not marginal, and it is measured rather than estimated — every pwsh leg reports
**183 calls / 7 force-imports** and the 5.1 leg **182 / 5**, against limits of 18.3 and 18.2.
That is 2.6x and 3.6x headroom. Put the other way: at 7 force-imports the call count would have
to fall below 70 for this to false-red, so a leg would need to stop running roughly two-thirds
of its containers first.

The ubuntu and macOS legs matter here specifically, because the fail-closed hazard is a
`ModuleBase` path-spelling mismatch and those runners could plausibly have differed. They do not
— all three pwsh legs report the same 183 / 7.

Adding this expanded the change into `scripts/`, which the branch otherwise leaves alone. The
justification is that the original design deferred the assertion on the belief that the
counters could not be read after `Invoke-Pester` returns. That belief was wrong:
`Run.Exit = $false` is set deliberately so the coverage gate is not skipped, and
`Invoke-Pester`, the gate call and `exit` all run in one process with the globals in scope.
Without the assertion, the entire value of this PR can evaporate and no test can see it.

## Verification

CI on this branch, all four matrix legs green
([run 32340782815](https://github.com/juemerson-at-purestorage/fb-powershell/actions/runs/32340782815)):

| leg | passed | failed | skipped | helper calls / force imports |
|---|---|---|---|---|
| windows-latest, pwsh | 3301 | 0 | 2 (ceiling 8) | 183 / 7 |
| windows-latest, WinPS 5.1 | 3006 | 0 | 297 (ceiling 313) | 182 / 5 |
| ubuntu-latest, pwsh | 3301 | 0 | 2 (ceiling 8) | 183 / 7 |
| macos-latest, pwsh | 3301 | 0 | 2 (ceiling 8) | 183 / 7 |

Every leg passes both the coverage gate and the new force-import ratio gate. The three pwsh legs
report identical counters, and both Windows legs match a local full-suite run exactly (596.38 s
on pwsh7, 226.05 s on 5.1 locally).

On every leg, `expected base` equalled `loaded base(s)` on every logged line, so the fail-closed
condition is absent rather than merely unobserved.

A note for anyone reading a full run log: `Tests/CiCoverageGate.Tests.ps1` prints several
`COVERAGE GATE FAILED (issue #63)` blocks as it exercises the gate's own failure paths on
purpose. The real verdicts are the `Coverage gate passed` lines at the end.

Because the risk this change introduces is order-dependent state leakage between containers,
that was exercised directly rather than inferred from a green suite: a 26-file subset run five
times — control, three seeded permutations, and one hand-built adversarial order placing a
module-root redirector immediately upstream of the cache consumers — on both editions, all
green. The permutations were confirmed to have actually taken effect by checking that the
*sequence* of force-import reasons differed between them, since five identical green runs would
otherwise be consistent with Pester ignoring the ordering entirely. 21 files were additionally
run standalone, and the grouped totals reconcile exactly to the sum of the isolated totals on
both editions, so grouping neither skipped nor silently added tests.

## Disclosures

**The recovered-time figure is an estimate, not a controlled measurement.** The 596.38 s and
226.05 s above are measured on this tree, but the "before" figure comes from the originating
analysis rather than a run on the same machine. The saving is inferred from the force-import
count — 7 forced imports where there were once 165, which is solid — but this is not a
before/after benchmark on identical hardware.

**The 5.1 skip ceiling was raised 273 → 313, and it absorbs +6 of drift that is not from this
branch.** The branch was cut before #112 landed, so its own raise (268 → 308) collided with
#112's (268 → 273) on rebase. The two are additive rather than competing, because they gate
different files, and the total is attributed exactly:

| | |
|---:|---|
| 252 | the figure that justified 268, from run 31830362870 |
| +5 | `Build-PfbCapabilityMap.ContextScopeDrift.Tests.ps1`, from #112 |
| +34 | `Update-PfbTestModuleImport.Tests.ps1`, added here — PS7-gated because the tool it tests declares `#Requires -Version 7.0` |
| +6 | `Build-PfbDeadKeyReport.Tests.ps1`, from **neither** branch |
| **297** | expected, and exactly what CI measured |

The +6 is the part worth a maintainer's eye. It landed in #120 two days *after* the ceiling was
last set; #120 still had slack and passed without touching this file, so 268 was already stale
against main before either branch existed. Whether folding those 6 in here is acceptable or
should be split out is your call. 313 keeps the standing +16 headroom over 297.

That collision is a symptom rather than a one-off, and #132 proposes the fix: a per-file
expected-skip map, so movement reds the PR that caused it and names the file, instead of being
absorbed by headroom and billed to a later innocent PR.

**Live-FlashBlade verification was waived** by the repo owner for this change, on the basis that
it touches only CI test scaffolding and no cmdlet behaviour. The scope section above is the
evidence for the second half of that.

No version bump and no `CHANGELOG.md` entry — those are separate maintainer decisions.
