### PR TITLE
Fix P0 wire contracts and output shape

### DIFF
--- a/Private/Assert-PfbAdminNameNotCoerced.ps1
+++ b/Private/Assert-PfbAdminNameNotCoerced.ps1
@@ -33,9 +33,9 @@ function Assert-PfbAdminNameNotCoerced {
         the silent-misbinding class this guard exists to remove. The imperative throw
         terminates the pipeline, which is the required behaviour.
 
-        Unlike Assert-PfbRemoteNameNotCoerced this returns NOTHING on success. That helper
-        ends with `return $true` and its callers invoke it bare, so it leaks a stray True
-        into each cmdlet's success stream. Do not reintroduce that here.
+        This imperative assertion helper returns NOTHING on success and reports failure
+        only through a terminating throw. Callers invoke it bare, so any success-stream
+        value it returned would leak into the cmdlet's own output.
     #>
     param([Parameter(Mandatory)] [object]$Value)
 

--- a/Private/Assert-PfbRemoteNameNotCoerced.ps1
+++ b/Private/Assert-PfbRemoteNameNotCoerced.ps1
@@ -46,5 +46,4 @@ function Assert-PfbRemoteNameNotCoerced {
                   'Select-Object -ExpandProperty name | Get-PfbArrayConnectionPath, or pass -RemoteName explicitly.'
         }
     }
-    return $true
 }

--- a/Public/Network/Invoke-PfbNetworkPing.ps1
+++ b/Public/Network/Invoke-PfbNetworkPing.ps1
@@ -40,7 +40,7 @@ function Invoke-PfbNetworkPing {
     begin { Assert-PfbConnection -Array ([ref]$Array) }
     process {
         $queryParams = @{ 'destination' = $Destination }
-        if ($SourceName)    { $queryParams['source.name']  = $SourceName }
+        if ($SourceName)    { $queryParams['source']       = $SourceName }
         if ($Count -gt 0)   { $queryParams['count']        = $Count }
         if ($PacketSize -gt 0) { $queryParams['packet_size'] = $PacketSize }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'network-interfaces/ping' -QueryParams $queryParams

--- a/Public/Network/Invoke-PfbNetworkTrace.ps1
+++ b/Public/Network/Invoke-PfbNetworkTrace.ps1
@@ -39,7 +39,7 @@ function Invoke-PfbNetworkTrace {
     begin { Assert-PfbConnection -Array ([ref]$Array) }
     process {
         $queryParams = @{ 'destination' = $Destination }
-        if ($SourceName) { $queryParams['source.name'] = $SourceName }
+        if ($SourceName) { $queryParams['source']      = $SourceName }
         if ($Method)     { $queryParams['method']       = $Method }
         Invoke-PfbApiRequest -Array $Array -Method GET -Endpoint 'network-interfaces/trace' -QueryParams $queryParams
     }

--- a/Public/ObjectStore/New-PfbObjectStoreAccessPolicyRule.ps1
+++ b/Public/ObjectStore/New-PfbObjectStoreAccessPolicyRule.ps1
@@ -8,26 +8,29 @@ function New-PfbObjectStoreAccessPolicyRule {
         constraints.
     .PARAMETER PolicyName
         The name of the access policy to which the rule will be added.
+    .PARAMETER Name
+        The name of the rule to create. The REST endpoint requires a rule name,
+        so this parameter is mandatory.
     .PARAMETER Attributes
         A hashtable of rule properties including effect, actions, resources,
         and conditions.
     .PARAMETER Array
         The FlashBlade connection object.
     .EXAMPLE
-        New-PfbObjectStoreAccessPolicyRule -PolicyName "full-access-policy" -Attributes @{
+        New-PfbObjectStoreAccessPolicyRule -PolicyName "full-access-policy" -Name "get-put-all" -Attributes @{
             effect  = "allow"
             actions = @("s3:GetObject", "s3:PutObject")
             resources = @("*")
         }
         Creates a rule allowing get and put operations on all resources.
     .EXAMPLE
-        New-PfbObjectStoreAccessPolicyRule -PolicyName "readonly-policy" -Attributes @{
+        New-PfbObjectStoreAccessPolicyRule -PolicyName "readonly-policy" -Name "read-only" -Attributes @{
             effect  = "allow"
             actions = @("s3:GetObject", "s3:ListBucket")
         }
         Creates a read-only rule in the specified policy.
     .EXAMPLE
-        New-PfbObjectStoreAccessPolicyRule -PolicyName "deny-delete-policy" -Attributes @{
+        New-PfbObjectStoreAccessPolicyRule -PolicyName "deny-delete-policy" -Name "no-deletes" -Attributes @{
             effect  = "deny"
             actions = @("s3:DeleteObject")
             resources = @("*")
@@ -39,6 +42,9 @@ function New-PfbObjectStoreAccessPolicyRule {
         [Parameter(Mandatory, Position = 0)]
         [string]$PolicyName,
 
+        [Parameter(Mandatory, Position = 1)]
+        [string]$Name,
+
         [Parameter()]
         [hashtable]$Attributes,
 
@@ -48,9 +54,12 @@ function New-PfbObjectStoreAccessPolicyRule {
     Assert-PfbConnection -Array ([ref]$Array)
 
     $body = if ($Attributes) { $Attributes } else { @{} }
-    $queryParams = @{ 'policy_names' = $PolicyName }
+    $queryParams = @{
+        'names'        = $Name
+        'policy_names' = $PolicyName
+    }
 
-    if ($PSCmdlet.ShouldProcess($PolicyName, 'Create access policy rule')) {
+    if ($PSCmdlet.ShouldProcess($Name, 'Create access policy rule')) {
         Invoke-PfbApiRequest -Array $Array -Method POST -Endpoint 'object-store-access-policies/rules' -Body $body -QueryParams $queryParams
     }
 }

--- a/Reports/PfbApiDriftReport.json
+++ b/Reports/PfbApiDriftReport.json
@@ -4058,8 +4058,7 @@
       "missingQueryParameters": [
         "component_name",
         "print_latency",
-        "resolve_hostname",
-        "source"
+        "resolve_hostname"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -4081,8 +4080,7 @@
         "discover_mtu",
         "fragment_packet",
         "port",
-        "resolve_hostname",
-        "source"
+        "resolve_hostname"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -11825,7 +11823,6 @@
       "missingQueryParameters": [
         "context_names",
         "enforce_action_restrictions",
-        "names",
         "policy_ids"
       ],
       "missingBodyProperties": [
@@ -11840,7 +11837,7 @@
           "enumStatus": "not-found-in-resource",
           "target": {
             "file": "Public/ObjectStore/New-PfbObjectStoreAccessPolicyRule.ps1",
-            "paramBlockLine": 45,
+            "paramBlockLine": 51,
             "payloadVariable": "body",
             "assignmentStyle": "unknown",
             "hasAttributes": true
@@ -11857,7 +11854,7 @@
           "enumStatus": "no-spec-enum-found",
           "target": {
             "file": "Public/ObjectStore/New-PfbObjectStoreAccessPolicyRule.ps1",
-            "paramBlockLine": 45,
+            "paramBlockLine": 51,
             "payloadVariable": "body",
             "assignmentStyle": "unknown",
             "hasAttributes": true
@@ -11877,7 +11874,7 @@
           "enumStatus": "matched",
           "target": {
             "file": "Public/ObjectStore/New-PfbObjectStoreAccessPolicyRule.ps1",
-            "paramBlockLine": 45,
+            "paramBlockLine": 51,
             "payloadVariable": "body",
             "assignmentStyle": "unknown",
             "hasAttributes": true
@@ -11894,7 +11891,7 @@
           "enumStatus": "no-spec-enum-found",
           "target": {
             "file": "Public/ObjectStore/New-PfbObjectStoreAccessPolicyRule.ps1",
-            "paramBlockLine": 45,
+            "paramBlockLine": 51,
             "payloadVariable": "body",
             "assignmentStyle": "unknown",
             "hasAttributes": true
@@ -14620,8 +14617,8 @@
     },
     {
       "name": "names",
-      "endpointCount": 24,
-      "queryEndpointCount": 24,
+      "endpointCount": 23,
+      "queryEndpointCount": 23,
       "bodyEndpointCount": 0,
       "endpoints": [
         "GET /arrays/clients/performance",
@@ -14646,7 +14643,6 @@
         "PATCH /syslog-servers/settings",
         "POST /maintenance-windows",
         "POST /object-store-access-keys",
-        "POST /object-store-access-policies/rules",
         "POST /object-store-roles/object-store-trust-policies/rules"
       ],
       "annotations": []
@@ -15366,18 +15362,6 @@
         "PATCH /admins",
         "PATCH /directory-services/roles",
         "POST /directory-services/roles"
-      ],
-      "annotations": []
-    },
-    {
-      "name": "source",
-      "endpointCount": 3,
-      "queryEndpointCount": 2,
-      "bodyEndpointCount": 1,
-      "endpoints": [
-        "GET /network-interfaces/ping",
-        "GET /network-interfaces/trace",
-        "POST /keytabs"
       ],
       "annotations": []
     },
@@ -17166,6 +17150,16 @@
       "annotations": []
     },
     {
+      "name": "source",
+      "endpointCount": 1,
+      "queryEndpointCount": 0,
+      "bodyEndpointCount": 1,
+      "endpoints": [
+        "POST /keytabs"
+      ],
+      "annotations": []
+    },
+    {
       "name": "sp",
       "endpointCount": 1,
       "queryEndpointCount": 0,
@@ -17279,7 +17273,7 @@
   "conventionStrength": [
     {
       "name": "names",
-      "cmdletCount": 300,
+      "cmdletCount": 301,
       "cmdlets": [
         "Get-PfbActiveDirectory",
         "Get-PfbAdmin",
@@ -17418,6 +17412,7 @@
         "New-PfbNfsExportPolicy",
         "New-PfbNlmReclamation",
         "New-PfbObjectStoreAccessPolicy",
+        "New-PfbObjectStoreAccessPolicyRule",
         "New-PfbObjectStoreAccount",
         "New-PfbObjectStoreRemoteCredential",
         "New-PfbObjectStoreRole",
@@ -19147,6 +19142,15 @@
       ]
     },
     {
+      "name": "source",
+      "cmdletCount": 3,
+      "cmdlets": [
+        "Invoke-PfbNetworkPing",
+        "Invoke-PfbNetworkTrace",
+        "New-PfbFileSystem"
+      ]
+    },
+    {
       "name": "actions",
       "cmdletCount": 2,
       "cmdlets": [
@@ -19727,13 +19731,6 @@
       "cmdletCount": 1,
       "cmdlets": [
         "New-PfbNfsExportRule"
-      ]
-    },
-    {
-      "name": "source",
-      "cmdletCount": 1,
-      "cmdlets": [
-        "New-PfbFileSystem"
       ]
     },
     {

--- a/Reports/PfbApiDriftReport.md
+++ b/Reports/PfbApiDriftReport.md
@@ -23,7 +23,7 @@ This report accepts **false positives in order to eliminate false negatives**. A
 - Uncovered endpoints: 95
 - Endpoints with parameter gaps: 439
 - Missing body properties (addable): 426
-- Missing query parameters (addable): 883
+- Missing query parameters (addable): 880
 - Read-only body fields (not addable -- see the Read-only fields section below): 384
 - Phantom fields silently excluded (accumulated in the capability map, absent from the newest analysed spec): 40
 - Partial-confidence endpoints (see `How to read this report` above, and each row's marker in the Parameter gaps table): 61
@@ -47,7 +47,7 @@ Showing the top 25 of 241 findings by endpoint count -- the full list is in the 
 | `allow_errors` | 118 | 118 | 0 | 0 | not yet implemented; deferred to Phase 2 |
 | `ids` | 38 | 38 | 0 | 220 |  |
 | `sort` | 28 | 28 | 0 | 179 |  |
-| `names` | 24 | 24 | 0 | 300 |  |
+| `names` | 23 | 23 | 0 | 301 |  |
 | `total_only` | 17 | 17 | 0 | 12 |  |
 | `policy_ids` | 16 | 16 | 0 | 97 |  |
 | `member_ids` | 14 | 14 | 0 | 81 |  |
@@ -254,8 +254,8 @@ Endpoints an existing cmdlet already calls, where the capability map knows of a 
 | `GET /network-interfaces/connectors/settings` | Get-PfbNetworkInterfaceConnectorSettings | ids |  | `high` |  |
 | `GET /network-interfaces/neighbors` | Get-PfbNetworkInterfaceNeighbor | total_item_count |  | `high` |  |
 | `GET /network-interfaces/network-connection-statistics` | Get-PfbNetworkConnectionStatistics | current_state, local_host, local_port, remote_host, remote_port |  | `high` |  |
-| `GET /network-interfaces/ping` | Invoke-PfbNetworkPing | component_name, print_latency, resolve_hostname, source |  | `high` |  |
-| `GET /network-interfaces/trace` | Invoke-PfbNetworkTrace | component_name, discover_mtu, fragment_packet, port, resolve_hostname, source |  | `high` |  |
+| `GET /network-interfaces/ping` | Invoke-PfbNetworkPing | component_name, print_latency, resolve_hostname |  | `high` |  |
+| `GET /network-interfaces/trace` | Invoke-PfbNetworkTrace | component_name, discover_mtu, fragment_packet, port, resolve_hostname |  | `high` |  |
 | `GET /nfs-export-policies` | Get-PfbNfsExportPolicy | allow_errors, context_names, workload_ids, workload_names |  | `high` |  |
 | `GET /nfs-export-policies/rules` | Get-PfbNfsExportRule | allow_errors, context_names, ids |  | `high` |  |
 | `GET /node-groups/nodes` | Get-PfbNodeGroupNode | node_group_ids, node_group_names, node_ids, node_names |  | `high` |  |
@@ -466,7 +466,7 @@ Endpoints an existing cmdlet already calls, where the capability map knows of a 
 | `POST /object-store-access-policies` | New-PfbObjectStoreAccessPolicy | context_names, enforce_action_restrictions | description, rules | `high` |  |
 | `POST /object-store-access-policies/object-store-roles` | New-PfbObjectStoreAccessPolicyRole | context_names, member_ids, policy_ids |  | `high` |  |
 | `POST /object-store-access-policies/object-store-users` | New-PfbObjectStoreAccessPolicyUser | context_names, member_ids, policy_ids |  | `high` |  |
-| `POST /object-store-access-policies/rules` | New-PfbObjectStoreAccessPolicyRule | context_names, enforce_action_restrictions, names, policy_ids | actions, conditions, effect, resources | `high` |  |
+| `POST /object-store-access-policies/rules` | New-PfbObjectStoreAccessPolicyRule | context_names, enforce_action_restrictions, policy_ids | actions, conditions, effect, resources | `high` |  |
 | `POST /object-store-account-exports` | New-PfbObjectStoreAccountExport | context_names |  | `high` |  |
 | `POST /object-store-accounts` | New-PfbObjectStoreAccount | context_names | account_exports, bucket_defaults, hard_limit_enabled, quota_limit | `high` |  |
 | `POST /object-store-remote-credentials` | New-PfbObjectStoreRemoteCredential | context_names | access_key_id, secret_access_key | `high` |  |

--- a/Reports/PfbDeadKeyReport.json
+++ b/Reports/PfbDeadKeyReport.json
@@ -1,10 +1,10 @@
 {
   "specVersion": "2.28",
   "counts": {
-    "parametersInventoried": 2164,
-    "keysEvaluated": 1746,
-    "ok": 1661,
-    "deadKey": 85,
+    "parametersInventoried": 2165,
+    "keysEvaluated": 1747,
+    "ok": 1664,
+    "deadKey": 83,
     "skipReasons": {
       "wire name unresolved": 126,
       "body property": 278,
@@ -1100,41 +1100,6 @@
         "ids",
         "limit",
         "names"
-      ]
-    },
-    {
-      "severity": "WRONG-RESULTS",
-      "cmdlet": "Invoke-PfbNetworkPing",
-      "parameter": "SourceName",
-      "wireKey": "source.name",
-      "method": "GET",
-      "endpoint": "network-interfaces/ping",
-      "declared": [
-        "component_name",
-        "count",
-        "destination",
-        "packet_size",
-        "print_latency",
-        "resolve_hostname",
-        "source"
-      ]
-    },
-    {
-      "severity": "WRONG-RESULTS",
-      "cmdlet": "Invoke-PfbNetworkTrace",
-      "parameter": "SourceName",
-      "wireKey": "source.name",
-      "method": "GET",
-      "endpoint": "network-interfaces/trace",
-      "declared": [
-        "component_name",
-        "destination",
-        "discover_mtu",
-        "fragment_packet",
-        "method",
-        "port",
-        "resolve_hostname",
-        "source"
       ]
     },
     {

--- a/Reports/PfbFieldCmdletMap.json
+++ b/Reports/PfbFieldCmdletMap.json
@@ -11130,7 +11130,7 @@
     {
       "cmdlet": "Invoke-PfbNetworkPing",
       "parameter": "SourceName",
-      "wireName": "source.name",
+      "wireName": "source",
       "status": "no-spec-enum-found",
       "matchedKey": null,
       "specValues": null,
@@ -11150,7 +11150,7 @@
     {
       "cmdlet": "Invoke-PfbNetworkTrace",
       "parameter": "SourceName",
-      "wireName": "source.name",
+      "wireName": "source",
       "status": "no-spec-enum-found",
       "matchedKey": null,
       "specValues": null,
@@ -12821,6 +12821,16 @@
       "cmdlet": "New-PfbObjectStoreAccessPolicyRole",
       "parameter": "PolicyName",
       "wireName": "policy_names",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "New-PfbObjectStoreAccessPolicyRule",
+      "parameter": "Name",
+      "wireName": "names",
       "status": "no-spec-enum-found",
       "matchedKey": null,
       "specValues": null,

--- a/Reports/PfbFieldCmdletMapping.md
+++ b/Reports/PfbFieldCmdletMapping.md
@@ -9,7 +9,7 @@ Reporting only -- no `Public/` cmdlet is edited by this script. Every `matched` 
 - matched: 2
 - collision: 1
 - not-found-in-resource: 29
-- no-spec-enum-found: 1971
+- no-spec-enum-found: 1972
 
 | Cmdlet | Parameter | Wire name | Status | Spec values | Recommendation |
 |---|---|---|---|---|---|

--- a/Tests/Assert-PfbRemoteNameNotCoerced.Tests.ps1
+++ b/Tests/Assert-PfbRemoteNameNotCoerced.Tests.ps1
@@ -1,0 +1,67 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    Import-Module "$PSScriptRoot/../PureStorageFlashBladePowerShell.psd1" -Force
+    $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
+}
+
+Describe 'Assert-PfbRemoteNameNotCoerced success-stream shape (issue #129)' {
+
+    Context 'the helper itself' {
+
+        It 'emits nothing for a valid scalar remote name' {
+            InModuleScope PureStorageFlashBladePowerShell {
+                $out = @(Assert-PfbRemoteNameNotCoerced -Value 'FB-B')
+                $out.Count | Should -Be 0 -Because 'an imperative assertion helper must not write to the success stream'
+            }
+        }
+
+        It 'emits nothing for a valid collection of remote names' {
+            InModuleScope PureStorageFlashBladePowerShell {
+                $out = @(Assert-PfbRemoteNameNotCoerced -Value @('FB-B', 'FB-C'))
+                $out.Count | Should -Be 0 -Because 'an imperative assertion helper must not write to the success stream'
+            }
+        }
+
+        It 'still throws on a stringified object' {
+            InModuleScope PureStorageFlashBladePowerShell {
+                { Assert-PfbRemoteNameNotCoerced -Value '@{id=10314f42-aaaa; status=connected; remote=}' } |
+                    Should -Throw -ExpectedMessage '*stringified object*'
+            }
+        }
+
+        It 'still throws when only a later element of a collection is malformed' {
+            InModuleScope PureStorageFlashBladePowerShell {
+                { Assert-PfbRemoteNameNotCoerced -Value @('FB-B', '@{id=x}') } |
+                    Should -Throw -ExpectedMessage '*stringified object*'
+            }
+        }
+    }
+
+    Context 'public callers with -RemoteName' {
+
+        BeforeEach {
+            Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+            Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest {
+                [PSCustomObject]@{ PfbSentinel = 'api-result' }
+            }
+        }
+
+        It '<Command> emits only the API result' -ForEach @(
+            @{ Command = 'Get-PfbArrayConnection';                          Extra = @{} }
+            @{ Command = 'Get-PfbArrayConnectionPath';                      Extra = @{} }
+            @{ Command = 'Get-PfbArrayConnectionPerformanceReplication';    Extra = @{} }
+            @{ Command = 'Remove-PfbArrayConnection';                       Extra = @{ Confirm = $false } }
+        ) {
+            $params = $Extra.Clone()
+            $params['RemoteName'] = 'FB-B'
+            $params['Array'] = $script:fakeArray
+
+            $out = @(& $Command @params)
+
+            $out.Count | Should -Be 1 -Because "$Command must emit the API result and nothing else"
+            $out[0].PfbSentinel | Should -BeExactly 'api-result'
+            Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly
+        }
+    }
+}

--- a/Tests/Invoke-PfbNetworkSource.Tests.ps1
+++ b/Tests/Invoke-PfbNetworkSource.Tests.ps1
@@ -1,0 +1,80 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    Import-Module "$PSScriptRoot/../PureStorageFlashBladePowerShell.psd1" -Force
+    $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
+}
+
+Describe 'Network source query key (issue #119)' {
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+    }
+
+    Context 'Invoke-PfbNetworkPing' {
+        It 'sends -SourceName under the declared query key source' {
+            Invoke-PfbNetworkPing -Destination '10.0.0.1' -SourceName 'mgmt-vip' -Array $fakeArray
+            Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+                $Method -eq 'GET' -and
+                $Endpoint -eq 'network-interfaces/ping' -and
+                $QueryParams['source'] -eq 'mgmt-vip'
+            }
+        }
+
+        It 'never sends the unknown query key source.name' {
+            Invoke-PfbNetworkPing -Destination '10.0.0.1' -SourceName 'mgmt-vip' -Array $fakeArray
+            Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+                -not $QueryParams.ContainsKey('source.name')
+            }
+        }
+
+        It 'leaves destination, count and packet size unchanged' {
+            Invoke-PfbNetworkPing -Destination '10.0.0.1' -SourceName 'mgmt-vip' -Count 5 -PacketSize 1400 -Array $fakeArray
+            Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+                $QueryParams['destination'] -eq '10.0.0.1' -and
+                $QueryParams['count'] -eq 5 -and
+                $QueryParams['packet_size'] -eq 1400
+            }
+        }
+
+        It 'omits the source key entirely when -SourceName is not supplied' {
+            Invoke-PfbNetworkPing -Destination '10.0.0.1' -Array $fakeArray
+            Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+                (-not $QueryParams.ContainsKey('source')) -and (-not $QueryParams.ContainsKey('source.name'))
+            }
+        }
+    }
+
+    Context 'Invoke-PfbNetworkTrace' {
+        It 'sends -SourceName under the declared query key source' {
+            Invoke-PfbNetworkTrace -Destination '10.0.0.1' -SourceName 'mgmt-vip' -Array $fakeArray
+            Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+                $Method -eq 'GET' -and
+                $Endpoint -eq 'network-interfaces/trace' -and
+                $QueryParams['source'] -eq 'mgmt-vip'
+            }
+        }
+
+        It 'never sends the unknown query key source.name' {
+            Invoke-PfbNetworkTrace -Destination '10.0.0.1' -SourceName 'mgmt-vip' -Array $fakeArray
+            Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+                -not $QueryParams.ContainsKey('source.name')
+            }
+        }
+
+        It 'leaves destination and trace method unchanged' {
+            Invoke-PfbNetworkTrace -Destination '10.0.0.1' -SourceName 'mgmt-vip' -Method 'udp' -Array $fakeArray
+            Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+                $QueryParams['destination'] -eq '10.0.0.1' -and
+                $QueryParams['method'] -eq 'udp'
+            }
+        }
+
+        It 'omits the source key entirely when -SourceName is not supplied' {
+            Invoke-PfbNetworkTrace -Destination '10.0.0.1' -Array $fakeArray
+            Should -Invoke Invoke-PfbApiRequest -ModuleName PureStorageFlashBladePowerShell -Times 1 -Exactly -ParameterFilter {
+                (-not $QueryParams.ContainsKey('source')) -and (-not $QueryParams.ContainsKey('source.name'))
+            }
+        }
+    }
+}

--- a/Tests/New-PfbObjectStoreAccessPolicyRule.Tests.ps1
+++ b/Tests/New-PfbObjectStoreAccessPolicyRule.Tests.ps1
@@ -1,0 +1,275 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+# ShouldProcess WhatIf text is written to the PSHost, not to any redirectable stream, so
+# `... -WhatIf *>&1` captures nothing and an assertion built on that is vacuous on BOTH
+# Windows PowerShell 5.1 and PowerShell 7 (proved by Tests/ArrayConnection.ShouldProcessTarget.Tests.ps1).
+# The WhatIf-target assertion below therefore runs the cmdlet in a private runspace whose host
+# records every UI write. Nothing the recording host captures is ever emitted to the Pester
+# output stream, so no host text leaks into the assertions.
+
+class PfbRuleRecordingRawUI : System.Management.Automation.Host.PSHostRawUserInterface {
+    [System.ConsoleColor]$Back = [System.ConsoleColor]::Black
+    [System.ConsoleColor]$Fore = [System.ConsoleColor]::White
+    [System.Management.Automation.Host.Coordinates]$Cursor = [System.Management.Automation.Host.Coordinates]::new(0, 0)
+    [System.Management.Automation.Host.Coordinates]$Window = [System.Management.Automation.Host.Coordinates]::new(0, 0)
+    [System.Management.Automation.Host.Size]$Buffer = [System.Management.Automation.Host.Size]::new(120, 500)
+    [System.Management.Automation.Host.Size]$WinSize = [System.Management.Automation.Host.Size]::new(120, 50)
+
+    [System.ConsoleColor] get_BackgroundColor() { return $this.Back }
+    [void] set_BackgroundColor([System.ConsoleColor]$value) { $this.Back = $value }
+    [System.ConsoleColor] get_ForegroundColor() { return $this.Fore }
+    [void] set_ForegroundColor([System.ConsoleColor]$value) { $this.Fore = $value }
+    [System.Management.Automation.Host.Coordinates] get_CursorPosition() { return $this.Cursor }
+    [void] set_CursorPosition([System.Management.Automation.Host.Coordinates]$value) { $this.Cursor = $value }
+    [int] get_CursorSize() { return 25 }
+    [void] set_CursorSize([int]$value) { }
+    [System.Management.Automation.Host.Size] get_BufferSize() { return $this.Buffer }
+    [void] set_BufferSize([System.Management.Automation.Host.Size]$value) { $this.Buffer = $value }
+    [System.Management.Automation.Host.Coordinates] get_WindowPosition() { return $this.Window }
+    [void] set_WindowPosition([System.Management.Automation.Host.Coordinates]$value) { $this.Window = $value }
+    [System.Management.Automation.Host.Size] get_WindowSize() { return $this.WinSize }
+    [void] set_WindowSize([System.Management.Automation.Host.Size]$value) { $this.WinSize = $value }
+    [System.Management.Automation.Host.Size] get_MaxPhysicalWindowSize() { return $this.WinSize }
+    [System.Management.Automation.Host.Size] get_MaxWindowSize() { return $this.WinSize }
+    [string] get_WindowTitle() { return 'PfbRuleRecordingHost' }
+    [void] set_WindowTitle([string]$value) { }
+    [bool] get_KeyAvailable() { return $false }
+    [void] FlushInputBuffer() { }
+    [System.Management.Automation.Host.KeyInfo] ReadKey([System.Management.Automation.Host.ReadKeyOptions]$options) {
+        throw [System.NotImplementedException]::new()
+    }
+    [System.Management.Automation.Host.BufferCell[,]] GetBufferContents([System.Management.Automation.Host.Rectangle]$rectangle) {
+        throw [System.NotImplementedException]::new()
+    }
+    [void] SetBufferContents([System.Management.Automation.Host.Coordinates]$origin, [System.Management.Automation.Host.BufferCell[,]]$contents) { }
+    [void] SetBufferContents([System.Management.Automation.Host.Rectangle]$rectangle, [System.Management.Automation.Host.BufferCell]$fill) { }
+    [void] ScrollBufferContents([System.Management.Automation.Host.Rectangle]$source, [System.Management.Automation.Host.Coordinates]$destination, [System.Management.Automation.Host.Rectangle]$clip, [System.Management.Automation.Host.BufferCell]$fill) { }
+}
+
+class PfbRuleRecordingUI : System.Management.Automation.Host.PSHostUserInterface {
+    [System.Collections.Generic.List[string]]$Lines = [System.Collections.Generic.List[string]]::new()
+    [PfbRuleRecordingRawUI]$Raw = [PfbRuleRecordingRawUI]::new()
+
+    [System.Management.Automation.Host.PSHostRawUserInterface] get_RawUI() { return $this.Raw }
+    [void] Write([string]$value) { $this.Lines.Add($value) }
+    [void] Write([System.ConsoleColor]$f, [System.ConsoleColor]$b, [string]$value) { $this.Lines.Add($value) }
+    [void] WriteLine() { $this.Lines.Add('') }
+    [void] WriteLine([string]$value) { $this.Lines.Add($value) }
+    [void] WriteLine([System.ConsoleColor]$f, [System.ConsoleColor]$b, [string]$value) { $this.Lines.Add($value) }
+    [void] WriteDebugLine([string]$message) { $this.Lines.Add($message) }
+    [void] WriteErrorLine([string]$message) { $this.Lines.Add($message) }
+    [void] WriteVerboseLine([string]$message) { $this.Lines.Add($message) }
+    [void] WriteWarningLine([string]$message) { $this.Lines.Add($message) }
+    [void] WriteProgress([long]$sourceId, [System.Management.Automation.ProgressRecord]$record) { }
+    [string] ReadLine() { throw [System.NotImplementedException]::new() }
+    [System.Security.SecureString] ReadLineAsSecureString() { throw [System.NotImplementedException]::new() }
+    [System.Collections.Generic.Dictionary[string, psobject]] Prompt([string]$caption, [string]$message, [System.Collections.ObjectModel.Collection[System.Management.Automation.Host.FieldDescription]]$descriptions) {
+        throw [System.NotImplementedException]::new()
+    }
+    [int] PromptForChoice([string]$caption, [string]$message, [System.Collections.ObjectModel.Collection[System.Management.Automation.Host.ChoiceDescription]]$choices, [int]$defaultChoice) {
+        # Recorded rather than thrown so an accidental confirmation prompt shows up as data
+        # instead of hanging. The answer is always "No" -- nothing must reach the wire.
+        $this.Lines.Add("CONFIRM: $caption / $message")
+        return 1
+    }
+    [System.Management.Automation.PSCredential] PromptForCredential([string]$caption, [string]$message, [string]$userName, [string]$targetName) {
+        throw [System.NotImplementedException]::new()
+    }
+    [System.Management.Automation.PSCredential] PromptForCredential([string]$caption, [string]$message, [string]$userName, [string]$targetName, [System.Management.Automation.PSCredentialTypes]$allowedCredentialTypes, [System.Management.Automation.PSCredentialUIOptions]$options) {
+        throw [System.NotImplementedException]::new()
+    }
+}
+
+class PfbRuleRecordingHost : System.Management.Automation.Host.PSHost {
+    # Named Sink, not UI: a field differing from the PSHost.UI property only in casing is
+    # rejected as non-CLS-compliant when the runspace opens.
+    [PfbRuleRecordingUI]$Sink = [PfbRuleRecordingUI]::new()
+    [guid]$Id = [guid]::NewGuid()
+
+    [string] get_Name() { return 'PfbRuleRecordingHost' }
+    [version] get_Version() { return [version]'1.0.0' }
+    [guid] get_InstanceId() { return $this.Id }
+    [System.Management.Automation.Host.PSHostUserInterface] get_UI() { return $this.Sink }
+    [System.Globalization.CultureInfo] get_CurrentCulture() { return [System.Globalization.CultureInfo]::InvariantCulture }
+    [System.Globalization.CultureInfo] get_CurrentUICulture() { return [System.Globalization.CultureInfo]::InvariantCulture }
+    [void] EnterNestedPrompt() { throw [System.NotImplementedException]::new() }
+    [void] ExitNestedPrompt() { throw [System.NotImplementedException]::new() }
+    [void] NotifyBeginApplication() { }
+    [void] NotifyEndApplication() { }
+    [void] SetShouldExit([int]$exitCode) { }
+}
+
+BeforeAll {
+    $moduleRoot = Split-Path -Parent $PSScriptRoot
+    $script:manifest = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
+    Import-Module $script:manifest -Force
+
+    $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.25'; AuthToken = 'x' }
+}
+
+Describe 'New-PfbObjectStoreAccessPolicyRule requires a rule name on the wire (issue #106 Part 1)' {
+
+    Context 'parameter metadata' {
+
+        BeforeAll {
+            $script:cmd = Get-Command New-PfbObjectStoreAccessPolicyRule -Module PureStorageFlashBladePowerShell
+        }
+
+        It 'declares a -Name parameter' {
+            $script:cmd.Parameters.Keys | Should -Contain 'Name'
+        }
+
+        It 'types -Name as a single string' {
+            $script:cmd.Parameters['Name'].ParameterType | Should -Be ([string])
+        }
+
+        It 'makes -Name mandatory' {
+            @($script:cmd.Parameters['Name'].Attributes |
+                Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] } |
+                ForEach-Object { $_.Mandatory }) | Should -Contain $true
+        }
+
+        It 'gives -Name positional slot 1' {
+            @($script:cmd.Parameters['Name'].Attributes |
+                Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] } |
+                ForEach-Object { $_.Position }) | Should -Contain 1
+        }
+
+        It 'keeps -PolicyName mandatory in positional slot 0' {
+            $attrs = @($script:cmd.Parameters['PolicyName'].Attributes |
+                Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] })
+            @($attrs | ForEach-Object { $_.Position }) | Should -Contain 0
+            @($attrs | ForEach-Object { $_.Mandatory }) | Should -Contain $true
+        }
+
+        It 'documents -Name in the comment-based help' {
+            (Get-Help New-PfbObjectStoreAccessPolicyRule -Parameter Name).Description.Text |
+                Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context 'the request that goes on the wire' {
+
+        BeforeEach {
+            Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+            Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+        }
+
+        It 'POSTs object-store-access-policies/rules with names and policy_names and the raw -Attributes body' {
+            New-PfbObjectStoreAccessPolicyRule -PolicyName 'full-access-policy' -Name 'rule-1' -Attributes @{
+                effect    = 'allow'
+                actions   = @('s3:GetObject')
+                resources = @('*')
+            } -Confirm:$false -Array $script:fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                $Method -eq 'POST' -and
+                $Endpoint -eq 'object-store-access-policies/rules' -and
+                $QueryParams.Keys.Count -eq 2 -and
+                $QueryParams['names'] -eq 'rule-1' -and
+                $QueryParams['policy_names'] -eq 'full-access-policy' -and
+                $Body.Keys.Count -eq 3 -and
+                $Body['effect'] -eq 'allow' -and
+                $Body['actions'][0] -eq 's3:GetObject' -and
+                $Body['resources'][0] -eq '*'
+            }
+        }
+
+        It 'binds -PolicyName then -Name positionally' {
+            New-PfbObjectStoreAccessPolicyRule 'pol-2' 'rule-2' -Confirm:$false -Array $script:fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                $QueryParams['policy_names'] -eq 'pol-2' -and $QueryParams['names'] -eq 'rule-2'
+            }
+        }
+
+        It 'sends an empty body when -Attributes is omitted' {
+            New-PfbObjectStoreAccessPolicyRule -PolicyName 'pol-3' -Name 'rule-3' -Confirm:$false -Array $script:fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                $null -ne $Body -and $Body.Keys.Count -eq 0
+            }
+        }
+
+        # Deliberately no "omit -Name" invocation test: an unbound mandatory parameter can raise
+        # an interactive "Supply values for the following parameters" prompt and hang the run.
+        # Mandatory-ness is asserted from parameter metadata above instead.
+
+        It 'fires no request under -WhatIf' {
+            New-PfbObjectStoreAccessPolicyRule -PolicyName 'pol-5' -Name 'rule-5' -WhatIf -Array $script:fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 0 -Exactly
+        }
+    }
+
+    Context 'the ShouldProcess target' {
+
+        BeforeAll {
+            $recordingHost = [PfbRuleRecordingHost]::new()
+            $runspace = [runspacefactory]::CreateRunspace($recordingHost)
+            $runspace.Open()
+
+            $ps = [powershell]::Create()
+            $ps.Runspace = $runspace
+            try {
+                $null = $ps.AddCommand('Import-Module').AddParameter('Name', $script:manifest).AddParameter('Force', $true)
+                $null = $ps.Invoke()
+                if ($ps.Streams.Error.Count -gt 0) {
+                    throw "Module import failed in the recording runspace: $($ps.Streams.Error[0])"
+                }
+                $ps.Commands.Clear()
+                # Replace the transport inside the module scope so this runspace physically cannot
+                # reach a network, even if -WhatIf failed to short-circuit.
+                $null = $ps.AddScript(@'
+& (Get-Module PureStorageFlashBladePowerShell) {
+    function script:Invoke-PfbApiRequest {
+        [CmdletBinding()] param($Array, $Method, $Endpoint, $Body, $QueryParams)
+        throw 'Invoke-PfbApiRequest was reached under -WhatIf'
+    }
+}
+'@)
+                $null = $ps.Invoke()
+                if ($ps.Streams.Error.Count -gt 0) {
+                    throw "Transport stub install failed: $($ps.Streams.Error[0])"
+                }
+            }
+            finally { $ps.Dispose() }
+
+            $script:recordingHost = $recordingHost
+            $script:runspace = $runspace
+        }
+
+        AfterAll {
+            if ($script:runspace) {
+                $script:runspace.Dispose()
+                $script:runspace = $null
+            }
+        }
+
+        It 'names the rule, not the policy' {
+            $script:recordingHost.Sink.Lines.Clear()
+
+            $ps = [powershell]::Create()
+            $ps.Runspace = $script:runspace
+            try {
+                $null = $ps.AddCommand('New-PfbObjectStoreAccessPolicyRule').
+                    AddParameter('PolicyName', 'pol-6').
+                    AddParameter('Name', 'rule-6').
+                    AddParameter('Array', $script:fakeArray).
+                    AddParameter('WhatIf', $true)
+                $null = $ps.Invoke()
+                $errorText = if ($ps.Streams.Error.Count -gt 0) { "$($ps.Streams.Error[0])" } else { '' }
+            }
+            finally { $ps.Dispose() }
+
+            $errorText | Should -BeExactly ''
+
+            $lines = @($script:recordingHost.Sink.Lines)
+            $lines.Count | Should -Be 1 -Because 'exactly one WhatIf message is expected; silence would make this assertion vacuous'
+
+            $match = [regex]::Match($lines[0], 'on target "(?<target>.*)"\.\s*$')
+            $match.Success | Should -BeTrue -Because 'the recorded host line must be a WhatIf message'
+            $match.Groups['target'].Value | Should -BeExactly 'rule-6'
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Fix `Invoke-PfbNetworkPing` and `Invoke-PfbNetworkTrace` to send the declared `source` query key instead of dead `source.name` (#119).
- Stop `Assert-PfbRemoteNameNotCoerced` from leaking `$true` into four replication cmdlets while preserving its terminating validation behavior (#129).
- Require a rule `-Name` in `New-PfbObjectStoreAccessPolicyRule`, send it as `names`, and identify the rule in `ShouldProcess` while preserving raw `-Attributes` bodies (#106 Part 1).
- Regenerate field mapping, API drift, and dead-key reports. Dead keys fall from 85 to 83 and missing query parameters from 883 to 880.

## Design decisions

- Keep the network fix to two literal wire-key replacements; no shared-query-helper refactor.
- Fix the success-stream leak at the private assertion helper rather than suppressing output in four callers.
- Keep #106 Part 2 typed rule fields outside this PR; this change adds only the mandatory selector needed for a valid request.
- Keep the existing empty-body and escape-hatch `-Attributes` behavior.

## Test plan

- [x] RED/GREEN regression cycles under PowerShell 7 and Windows PowerShell 5.1 for all three fixes.
- [x] Integrated regression and import-guard set: 31 passed, 0 failed, 0 skipped under each edition.
- [x] Shared test-loader helper suites: PowerShell 7 61 passed; Windows PowerShell 5.1 27 passed and 34 expected PS7-only skips; 0 failures.
- [x] All five changed derived artifacts reproduce byte-for-byte from 29 pinned REST specs (2.0-2.28).
- [x] Live #129 on FB-A REST 2.26: 4 connection rows narrowed to 2 FB-B rows, both correctly named, with zero Boolean output.
- [x] Live #119 on FB-A Purity 4.8.2 / REST 2.26: ping and ICMP trace to `google.com` both succeeded with `-SourceName vir0`; responses echoed `source: vir0`, proving the corrected `source` query key was accepted. IPv4 ping returned 3/3 replies at ~11.5 ms, and trace completed from all three components in 24-25 hops.
- [x] Live #106 Part 1 reached FB-A with both `names` and `policy_names`; the array rejected the harness-required hyphenated `pslivetest-` rule name because rule names must be alphanumeric. A valid alphanumeric name is blocked by the harness prefix rail. No residue remained, and the rail was not bypassed.

Closes #119.
Closes #129.
Addresses #106 Part 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)