### PR TITLE
Give New-PfbApiClient a typed body and require legal-hold `released`

### DIFF
--- a/Public/Admin/New-PfbApiClient.ps1
+++ b/Public/Admin/New-PfbApiClient.ps1
@@ -4,33 +4,55 @@ function New-PfbApiClient {
         Creates a new API client on the FlashBlade.
     .DESCRIPTION
         The New-PfbApiClient cmdlet creates a new API client on the connected Pure Storage
-        FlashBlade. API clients are used for OAuth2 authentication and require at minimum
-        a public key and a maximum role assignment.
+        FlashBlade. API clients require a public key. On REST 2.0-2.18, they also require
+        a maximum role assignment; from REST 2.19 onward, max_role is deprecated in favour
+        of access_policies.
+
+        The typed parameters and the raw -Attributes hashtable are mutually exclusive: they
+        live in separate parameter sets, so PowerShell rejects a mixed invocation at bind time
+        rather than letting -Attributes silently override an explicitly supplied value.
     .PARAMETER Name
         The name of the API client to create.
+    .PARAMETER PublicKey
+        The public key for the API client. Required by the API client's POST body schema.
+    .PARAMETER MaxRole
+        The maximum role assignment for the API client. The API requires this on REST 2.0-2.18;
+        it is deprecated in favour of access_policies from REST 2.19 onward.
     .PARAMETER Attributes
-        A hashtable defining the API client properties, including the public key and role.
+        A raw hashtable defining the API client properties. This parameter is mutually exclusive
+        with the typed parameters. When using -Attributes, the caller is responsible for supplying
+        the required public_key (and max_role on REST 2.0-2.18).
     .PARAMETER Array
         The FlashBlade connection object. If not specified, the default connection is used.
     .EXAMPLE
-        New-PfbApiClient -Name 'automation-client' -Attributes @{ max_role = @{ name = 'storage_admin' }; public_key = $key }
+        New-PfbApiClient -Name 'automation-client' -PublicKey $key -MaxRole 'storage_admin'
 
         Creates a new API client with the storage_admin role and the specified public key.
     .EXAMPLE
-        New-PfbApiClient -Name 'readonly-client' -Attributes @{ max_role = @{ name = 'readonly' }; public_key = $key }
+        New-PfbApiClient -Name 'readonly-client' -PublicKey $key
 
-        Creates a new read-only API client.
+        Creates a new API client with the specified public key. On REST 2.0-2.18, supply
+        -MaxRole as well; from REST 2.19 onward, max_role is deprecated in favour of access_policies.
     .EXAMPLE
         New-PfbApiClient -Name 'ops-client' -Attributes @{ max_role = @{ name = 'ops_admin' }; public_key = $key } -Confirm:$false
 
-        Creates a new API client without prompting for confirmation.
+        Creates a new API client from a hand-rolled body without prompting for confirmation.
+        When using -Attributes, the caller is responsible for supplying the required public_key.
     #>
-    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium',
+                   DefaultParameterSetName = 'Typed')]
     param(
-        [Parameter(Mandatory, Position = 0)]
+        [Parameter(ParameterSetName = 'Typed', Mandatory, Position = 0)]
+        [Parameter(ParameterSetName = 'Attributes', Mandatory, Position = 0)]
         [string]$Name,
 
-        [Parameter()]
+        [Parameter(ParameterSetName = 'Typed', Mandatory)]
+        [string]$PublicKey,
+
+        [Parameter(ParameterSetName = 'Typed')]
+        [string]$MaxRole,
+
+        [Parameter(ParameterSetName = 'Attributes', Mandatory)]
         [hashtable]$Attributes,
 
         [Parameter()] [PSCustomObject]$Array
@@ -38,7 +60,18 @@ function New-PfbApiClient {
 
     Assert-PfbConnection -Array ([ref]$Array)
 
-    $body = if ($Attributes) { $Attributes } else { @{} }
+    if ($PSCmdlet.ParameterSetName -eq 'Attributes') {
+        $body = $Attributes.Clone()
+    }
+    else {
+        $body = @{ public_key = $PublicKey }
+        # max_role is a scalar reference ({id, name, resource_type}); resource_type
+        # is readOnly and must never be sent.
+        if ($PSBoundParameters.ContainsKey('MaxRole')) {
+            $body['max_role'] = @{ name = $MaxRole }
+        }
+    }
+
     $queryParams = @{ 'names' = $Name }
 
     if ($PSCmdlet.ShouldProcess($Name, 'Create API client')) {

--- a/Public/Misc/Update-PfbLegalHoldEntity.ps1
+++ b/Public/Misc/Update-PfbLegalHoldEntity.ps1
@@ -3,11 +3,22 @@ function Update-PfbLegalHoldEntity {
     .SYNOPSIS
         Updates a held entity under a legal hold on the FlashBlade.
     .DESCRIPTION
-        The Update-PfbLegalHoldEntity cmdlet modifies the properties of an entity that is
-        subject to a legal hold on the connected Pure Storage FlashBlade. Identify the
-        held entity by name and supply the changed properties via Attributes.
+        The Update-PfbLegalHoldEntity cmdlet applies or releases a legal hold over a
+        file-system path on the connected Pure Storage FlashBlade. `released` is required
+        by the API, so -Released must always be supplied: `$true` releases the hold,
+        `$false` applies it.
+
+        A held entity has no name of its own -- `LegalHoldHeldEntity` carries only
+        `file_system`, `legal_hold`, `path` and `status` -- so it is addressed by the
+        file system plus the path, together with -Recursive. Measured on a live array
+        (Purity//FB 4.8.2, REST 2.26): a request naming only the hold is rejected with
+        "Either names or ids query parameter is required", and one naming the file system
+        and path but omitting -Recursive is rejected with "Can't apply or release legal
+        holds to directories without the recursive flag provided". Both directions behave
+        identically here, so a release is symmetric with an apply rather than special.
     .PARAMETER Name
-        The name of the held entity to update.
+        The name of the legal hold. Sent as `names`, which the endpoint declares but which
+        does not on its own identify a held entity -- see the description above.
     .PARAMETER FileSystemIds
         The IDs of the file systems whose held entities to update.
     .PARAMETER FileSystemNames
@@ -20,7 +31,8 @@ function Update-PfbLegalHoldEntity {
         If set to `true`, the update is applied recursively to the specified path or file
         system.
     .PARAMETER Released
-        If set to `true`, the held entity is released from its legal hold.
+        Required by the API on REST 2.17 and later. `$true` releases the held entity from its
+        legal hold; `$false` applies or keeps the legal hold.
     .PARAMETER Attributes
         A hashtable of attributes to update on the held entity. `PATCH
         /legal-holds/held-entities` accepts no request body, so nothing supplied here is sent
@@ -28,17 +40,21 @@ function Update-PfbLegalHoldEntity {
     .PARAMETER Array
         The FlashBlade connection object. If not specified, the default connection is used.
     .EXAMPLE
-        Update-PfbLegalHoldEntity -Name "fs1" -Released $true
+        Update-PfbLegalHoldEntity -Name 'pslivetest-hold-1' -FileSystemNames 'pslivetest-fs-1' -Paths '/' -Recursive $true -Released $true
 
-        Releases the held entity named "fs1" from its legal hold.
+        Releases the held entity named "pslivetest-hold-1" from its legal hold. The file-system
+        name, path, and recursive flag are all required together for this release request.
     .EXAMPLE
-        Update-PfbLegalHoldEntity -Name "bucket1" -Recursive $false
+        Update-PfbLegalHoldEntity -Name 'pslivetest-hold-1' -FileSystemNames 'pslivetest-fs-1' -Paths '/' -Recursive $true -Released $false
 
-        Updates the held entity named "bucket1" without applying the change recursively.
+        Applies the legal hold to the same path. This is the release example with -Released
+        flipped -- the two directions take the same arguments.
     .EXAMPLE
-        Update-PfbLegalHoldEntity -Name "fs1" -Attributes @{ hold_type = 'litigation' }
+        Update-PfbLegalHoldEntity -Name 'pslivetest-hold-1' -FileSystemIds '10314f42-020d-7080-8013-000ddt400090' -Paths '/' -Recursive $true -Released $true
 
-        Updates the held entity using a raw attributes hashtable.
+        Releases the hold identifying the file system by ID instead of by name. Note that
+        `file_system_ids` refers to the file system, which has an ID; the held entity itself
+        does not, so -Ids is not a substitute for this form.
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
     param(
@@ -60,8 +76,8 @@ function Update-PfbLegalHoldEntity {
         [Parameter()]
         [Nullable[bool]]$Recursive,
 
-        [Parameter()]
-        [Nullable[bool]]$Released,
+        [Parameter(Mandatory)]
+        [bool]$Released,
 
         [Parameter()]
         [hashtable]$Attributes,
@@ -88,7 +104,9 @@ function Update-PfbLegalHoldEntity {
         if ($PSBoundParameters.ContainsKey('Ids'))              { $queryParams['ids']               = $Ids -join ',' }
         if ($PSBoundParameters.ContainsKey('Paths'))            { $queryParams['paths']             = $Paths -join ',' }
         if ($PSBoundParameters.ContainsKey('Recursive'))        { $queryParams['recursive']         = $Recursive }
-        if ($PSBoundParameters.ContainsKey('Released'))         { $queryParams['released']          = $Released }
+        # Unlike optional parameters, released is required by the spec, so no legal request omits it;
+        # the usual ContainsKey distinction between omitted and supplied as false cannot arise here.
+        $queryParams['released'] = $Released
 
         if ($PSCmdlet.ShouldProcess($Name, 'Update legal hold entity')) {
             Invoke-PfbApiRequest -Array $Array -Method PATCH -Endpoint 'legal-holds/held-entities' -Body $body -QueryParams $queryParams

--- a/Reports/PfbApiDriftReport.json
+++ b/Reports/PfbApiDriftReport.json
@@ -9267,9 +9267,9 @@
           "enumStatus": "no-spec-enum-found",
           "target": {
             "file": "Public/Admin/New-PfbApiClient.ps1",
-            "paramBlockLine": 36,
+            "paramBlockLine": 58,
             "payloadVariable": "body",
-            "assignmentStyle": "unknown",
+            "assignmentStyle": "literal",
             "hasAttributes": true
           }
         },
@@ -9284,9 +9284,9 @@
           "enumStatus": "no-spec-enum-found",
           "target": {
             "file": "Public/Admin/New-PfbApiClient.ps1",
-            "paramBlockLine": 36,
+            "paramBlockLine": 58,
             "payloadVariable": "body",
-            "assignmentStyle": "unknown",
+            "assignmentStyle": "literal",
             "hasAttributes": true
           }
         },
@@ -9301,43 +9301,9 @@
           "enumStatus": "no-spec-enum-found",
           "target": {
             "file": "Public/Admin/New-PfbApiClient.ps1",
-            "paramBlockLine": 36,
+            "paramBlockLine": 58,
             "payloadVariable": "body",
-            "assignmentStyle": "unknown",
-            "hasAttributes": true
-          }
-        },
-        {
-          "name": "max_role",
-          "type": null,
-          "format": null,
-          "specRequired": false,
-          "synopsis": "Deprecated.",
-          "suggestedPowerShellType": "[object]",
-          "enumValues": [],
-          "enumStatus": "no-spec-enum-found",
-          "target": {
-            "file": "Public/Admin/New-PfbApiClient.ps1",
-            "paramBlockLine": 36,
-            "payloadVariable": "body",
-            "assignmentStyle": "unknown",
-            "hasAttributes": true
-          }
-        },
-        {
-          "name": "public_key",
-          "type": "string",
-          "format": null,
-          "specRequired": true,
-          "synopsis": "The API client's PEM formatted (Base64 encoded) RSA public key.",
-          "suggestedPowerShellType": "[string]",
-          "enumValues": [],
-          "enumStatus": "no-spec-enum-found",
-          "target": {
-            "file": "Public/Admin/New-PfbApiClient.ps1",
-            "paramBlockLine": 36,
-            "payloadVariable": "body",
-            "assignmentStyle": "unknown",
+            "assignmentStyle": "literal",
             "hasAttributes": true
           }
         }
@@ -15533,17 +15499,6 @@
       "annotations": []
     },
     {
-      "name": "max_role",
-      "endpointCount": 2,
-      "queryEndpointCount": 0,
-      "bodyEndpointCount": 2,
-      "endpoints": [
-        "PATCH /api-clients",
-        "POST /api-clients"
-      ],
-      "annotations": []
-    },
-    {
       "name": "member_sids",
       "endpointCount": 2,
       "queryEndpointCount": 2,
@@ -15683,17 +15638,6 @@
       "endpoints": [
         "POST /presets/workload",
         "PUT /presets/workload"
-      ],
-      "annotations": []
-    },
-    {
-      "name": "public_key",
-      "endpointCount": 2,
-      "queryEndpointCount": 0,
-      "bodyEndpointCount": 2,
-      "endpoints": [
-        "POST /api-clients",
-        "POST /public-keys"
       ],
       "annotations": []
     },
@@ -16680,6 +16624,16 @@
       "annotations": []
     },
     {
+      "name": "max_role",
+      "endpointCount": 1,
+      "queryEndpointCount": 0,
+      "bodyEndpointCount": 1,
+      "endpoints": [
+        "PATCH /api-clients"
+      ],
+      "annotations": []
+    },
+    {
       "name": "max_session_duration",
       "endpointCount": 1,
       "queryEndpointCount": 0,
@@ -16926,6 +16880,16 @@
       "bodyEndpointCount": 1,
       "endpoints": [
         "PATCH /support"
+      ],
+      "annotations": []
+    },
+    {
+      "name": "public_key",
+      "endpointCount": 1,
+      "queryEndpointCount": 0,
+      "bodyEndpointCount": 1,
+      "endpoints": [
+        "POST /public-keys"
       ],
       "annotations": []
     },
@@ -19247,6 +19211,14 @@
       ]
     },
     {
+      "name": "public_key",
+      "cmdletCount": 2,
+      "cmdlets": [
+        "New-PfbApiClient",
+        "Update-PfbAdmin"
+      ]
+    },
+    {
       "name": "recursive",
       "cmdletCount": 2,
       "cmdlets": [
@@ -19559,6 +19531,13 @@
       ]
     },
     {
+      "name": "max_role",
+      "cmdletCount": 1,
+      "cmdlets": [
+        "New-PfbApiClient"
+      ]
+    },
+    {
       "name": "max_session_duration",
       "cmdletCount": 1,
       "cmdlets": [
@@ -19661,13 +19640,6 @@
       "cmdletCount": 1,
       "cmdlets": [
         "Get-PfbArrayPerformance"
-      ]
-    },
-    {
-      "name": "public_key",
-      "cmdletCount": 1,
-      "cmdlets": [
-        "Update-PfbAdmin"
       ]
     },
     {
@@ -20069,11 +20041,6 @@
     },
     {
       "name": "max_password_age",
-      "cmdletCount": 0,
-      "cmdlets": []
-    },
-    {
-      "name": "max_role",
       "cmdletCount": 0,
       "cmdlets": []
     },

--- a/Reports/PfbApiDriftReport.md
+++ b/Reports/PfbApiDriftReport.md
@@ -22,7 +22,7 @@ This report accepts **false positives in order to eliminate false negatives**. A
 
 - Uncovered endpoints: 95
 - Endpoints with parameter gaps: 439
-- Missing body properties (addable): 426
+- Missing body properties (addable): 424
 - Missing query parameters (addable): 880
 - Read-only body fields (not addable -- see the Read-only fields section below): 384
 - Phantom fields silently excluded (accumulated in the capability map, absent from the newest analysed spec): 40
@@ -414,7 +414,7 @@ Endpoints an existing cmdlet already calls, where the capability map knows of a 
 | `POST /admins/api-tokens` | New-PfbApiToken | context_names |  | `high` |  |
 | `POST /admins/management-access-policies` | New-PfbAdminManagementAccessPolicy | context_names |  | `high` | POST/PATCH/DELETE return 403 regardless of account; not an implementation bug |
 | `POST /admins/ssh-certificate-authority-policies` | New-PfbAdminSshCaPolicy | context_names |  | `high` |  |
-| `POST /api-clients` | New-PfbApiClient |  | access_policies, access_token_ttl_in_ms, issuer, max_role, public_key | `high` |  |
+| `POST /api-clients` | New-PfbApiClient |  | access_policies, access_token_ttl_in_ms, issuer | `high` |  |
 | `POST /array-connections` | New-PfbArrayConnection | context_names |  | `high` |  |
 | `POST /arrays/erasures` | New-PfbArrayErasure | eradicate_all_data, preserve_configuration_data, skip_phonehome_check |  | `high` |  |
 | `POST /arrays/ssh-certificate-authority-policies` | New-PfbArraySshCaPolicy | context_names |  | `high` |  |

--- a/Reports/PfbDeadKeyReport.json
+++ b/Reports/PfbDeadKeyReport.json
@@ -1,13 +1,13 @@
 {
   "specVersion": "2.28",
   "counts": {
-    "parametersInventoried": 2165,
+    "parametersInventoried": 2167,
     "keysEvaluated": 1747,
     "ok": 1664,
     "deadKey": 83,
     "skipReasons": {
       "wire name unresolved": 126,
-      "body property": 278,
+      "body property": 280,
       "endpoint/method ambiguous": 14,
       "endpoint/verb absent from spec": 0
     }

--- a/Reports/PfbFieldCmdletMap.json
+++ b/Reports/PfbFieldCmdletMap.json
@@ -11249,8 +11249,28 @@
     },
     {
       "cmdlet": "New-PfbApiClient",
+      "parameter": "MaxRole",
+      "wireName": "max_role",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "New-PfbApiClient",
       "parameter": "Name",
       "wireName": "names",
+      "status": "no-spec-enum-found",
+      "matchedKey": null,
+      "specValues": null,
+      "stableSinceOldestVersion": null,
+      "recommendation": null
+    },
+    {
+      "cmdlet": "New-PfbApiClient",
+      "parameter": "PublicKey",
+      "wireName": "public_key",
       "status": "no-spec-enum-found",
       "matchedKey": null,
       "specValues": null,

--- a/Reports/PfbFieldCmdletMapping.md
+++ b/Reports/PfbFieldCmdletMapping.md
@@ -9,7 +9,7 @@ Reporting only -- no `Public/` cmdlet is edited by this script. Every `matched` 
 - matched: 2
 - collision: 1
 - not-found-in-resource: 29
-- no-spec-enum-found: 1972
+- no-spec-enum-found: 1974
 
 | Cmdlet | Parameter | Wire name | Status | Spec values | Recommendation |
 |---|---|---|---|---|---|

--- a/Reports/PfbPipelineSelectorMap.json
+++ b/Reports/PfbPipelineSelectorMap.json
@@ -15,16 +15,16 @@
     "findingPairs": 101,
     "confirmationRate": 0.4197,
     "controlLeakage": 0,
-    "assistedRows": 213
+    "assistedRows": 212
   },
   "outcomeBreakdown": [
     {
       "Outcome": "BindError",
-      "Count": 2
+      "Count": 4
     },
     {
       "Outcome": "Bound",
-      "Count": 578
+      "Count": 577
     },
     {
       "Outcome": "CmdletError",
@@ -44,7 +44,7 @@
     },
     {
       "Outcome": "Unbindable",
-      "Count": 234
+      "Count": 233
     }
   ],
   "gateBreakdown": [
@@ -42765,11 +42765,11 @@
       "IsCandidate": false,
       "Gate": "Matched",
       "ValueFromPipeline": false,
-      "Outcome": "Bound",
-      "Evidence": "names=PROBE-name (from property 'name')",
-      "BoundWireKey": "names",
-      "BoundValue": "PROBE-name",
-      "ErrorKind": null,
+      "Outcome": "BindError",
+      "Evidence": "would prompt for an unbound mandatory parameter -- __AllParameterSets: Released",
+      "BoundWireKey": null,
+      "BoundValue": null,
+      "ErrorKind": "HarnessRefusal",
       "FilledParameter": [],
       "ProbeProperties": [
         "description",
@@ -42795,14 +42795,12 @@
       "IsCandidate": true,
       "Gate": "Candidate",
       "ValueFromPipeline": false,
-      "Outcome": "Unbindable",
-      "Evidence": "The input object cannot be bound to any parameters for the command either because the command does not take pipeline input or the input and its properties do not match any of the parameters that take pipeline input.",
+      "Outcome": "BindError",
+      "Evidence": "would prompt for an unbound mandatory parameter -- __AllParameterSets: Name, Released",
       "BoundWireKey": null,
       "BoundValue": null,
-      "ErrorKind": "InputObjectNotBound",
-      "FilledParameter": [
-        "Name"
-      ],
+      "ErrorKind": "HarnessRefusal",
+      "FilledParameter": [],
       "ProbeProperties": [
         "file_system",
         "legal_hold",

--- a/Reports/PfbPipelineSelectorMap.md
+++ b/Reports/PfbPipelineSelectorMap.md
@@ -18,7 +18,7 @@ no request leaves the machine, and nothing here is inferred from pattern-matchin
 | `findingPairs` | 101 |
 | `confirmationRate` | 0.4197 |
 | `controlLeakage` | 0 |
-| `assistedRows` | 213 |
+| `assistedRows` | 212 |
 
 `findings` counts probe ROWS; `findingPairs` counts distinct (cmdlet, parameter) pairs. One
 defect appears once per producing endpoint, so rows always exceed pairs.
@@ -27,13 +27,13 @@ defect appears once per producing endpoint, so rows always exceed pairs.
 
 | Outcome | Rows | Finding? |
 |---|---:|---|
-| `BindError` | 2 | triage -- the harness never invoked, the only unmeasured outcome |
-| `Bound` | 578 | no -- the selector bound as intended |
+| `BindError` | 4 | triage -- the harness never invoked, the only unmeasured outcome |
+| `Bound` | 577 | no -- the selector bound as intended |
 | `CmdletError` | 6 | no -- the cmdlet threw before any request was built |
 | `Coerced` | 264 | **yes** -- a stringified object reached the wire |
 | `Guarded` | 116 | no -- a #64/#90 coercion guard fired |
 | `NoSelector` | 47 | no -- reported observation |
-| `Unbindable` | 234 | no -- PowerShell declined to bind this probe object at all. Note that pass 4 is ByPropertyName WITH coercion, so a ByPropertyName-only parameter whose alias matches an object-valued property CAN still coerce; this outcome is not a structural immunity |
+| `Unbindable` | 233 | no -- PowerShell declined to bind this probe object at all. Note that pass 4 is ByPropertyName WITH coercion, so a ByPropertyName-only parameter whose alias matches an object-valued property CAN still coerce; this outcome is not a structural immunity |
 
 ## Findings
 

--- a/Tests/Build-PfbPipelineSelectorMap.Tests.ps1
+++ b/Tests/Build-PfbPipelineSelectorMap.Tests.ps1
@@ -112,8 +112,15 @@ Describe 'Build-PfbPipelineSelectorMap' {
         # Unbindable and CmdletError are VERDICTS -- PowerShell declining to bind at all, and
         # the cmdlet throwing before the shim. Collapsing them into BindError is what made 8
         # measured pairs look like blind spots in the first revision of the audit.
+        #
+        # RE-BASELINED 2 -> 4 alongside the twin pin in PfbPipelineSelectorRail.Tests.ps1, which
+        # carries the full account: making Update-PfbLegalHoldEntity -Released mandatory (#106
+        # Part 2) means the probe can no longer construct a call for that cmdlet, so its two rows
+        # move from Bound/Unbindable to a HarnessRefusal BindError. Unlike its twin, this
+        # assertion reads the COMMITTED report instead of regenerating, so it is not PS7-gated
+        # and reds on Windows PowerShell 5.1 too.
         $report = Get-Content $script:reportPath -Raw | ConvertFrom-Json
-        @($report.results | Where-Object Outcome -eq 'BindError').Count | Should -Be 2
+        @($report.results | Where-Object Outcome -eq 'BindError').Count | Should -Be 4
         @($report.results | Where-Object Outcome -eq 'Unbindable').Count | Should -BeGreaterThan 0
     }
 

--- a/Tests/New-PfbApiClient.Tests.ps1
+++ b/Tests/New-PfbApiClient.Tests.ps1
@@ -1,0 +1,88 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    $moduleRoot = Split-Path -Parent $PSScriptRoot
+    $manifest   = Join-Path $moduleRoot 'PureStorageFlashBladePowerShell.psd1'
+    . (Join-Path $PSScriptRoot 'PfbTestModule.ps1')
+    $null = Import-PfbTestModule
+
+    $script:fakeArray = [PSCustomObject]@{ Endpoint = 'fb.example.test'; ApiVersion = '2.0'; AuthToken = 'x' }
+}
+
+Describe 'New-PfbApiClient - typed body parameters (#106)' {
+
+    BeforeEach {
+        Mock -ModuleName PureStorageFlashBladePowerShell Assert-PfbConnection { }
+        Mock -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest { }
+    }
+
+    Context 'typed parameters build the body' {
+        It 'sends -PublicKey in the body and -Name as names' {
+            New-PfbApiClient -Name 'automation-client' -PublicKey 'public-key' -Confirm:$false -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                $Method -eq 'POST' -and $Endpoint -eq 'api-clients' -and
+                $QueryParams['names'] -eq 'automation-client' -and
+                $Body['public_key'] -eq 'public-key'
+            }
+        }
+
+        It 'sends -MaxRole as a nested reference without resource_type' {
+            New-PfbApiClient -Name 'automation-client' -PublicKey 'public-key' -MaxRole 'storage_admin' -Confirm:$false -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                $Body['max_role'] -is [hashtable] -and
+                $Body['max_role']['name'] -eq 'storage_admin' -and
+                -not $Body['max_role'].ContainsKey('resource_type')
+            }
+        }
+
+        It 'omits max_role when -MaxRole is not supplied' {
+            New-PfbApiClient -Name 'automation-client' -PublicKey 'public-key' -Confirm:$false -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                $Body.ContainsKey('public_key') -and -not $Body.ContainsKey('max_role')
+            }
+        }
+    }
+
+    Context '-Attributes remains supported as a raw body' {
+        It 'sends the raw hashtable body' {
+            $attributes = @{ public_key = 'raw-key'; max_role = @{ name = 'storage_admin' } }
+
+            New-PfbApiClient -Name 'automation-client' -Attributes $attributes -Confirm:$false -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                $Body['public_key'] -eq 'raw-key' -and
+                $Body['max_role']['name'] -eq 'storage_admin'
+            }
+        }
+
+        It 'does not mutate the caller hashtable' {
+            $attributes = @{ public_key = 'raw-key'; custom = 'value' }
+            $originalCount = $attributes.Count
+
+            New-PfbApiClient -Name 'automation-client' -Attributes $attributes -Confirm:$false -Array $fakeArray
+
+            $attributes.Count | Should -Be $originalCount
+        }
+
+        It 'rejects -Attributes combined with typed parameters at bind time' {
+            { New-PfbApiClient -Name 'x' -PublicKey 'k' -Attributes @{} -Confirm:$false -Array $fakeArray } |
+                Should -Throw
+        }
+    }
+
+    Context 'typed parameter metadata' {
+        It 'makes -PublicKey mandatory in the default Typed parameter set' {
+            $publicKeyParameter = (Get-Command New-PfbApiClient).Parameters['PublicKey']
+            $typedParameterAttribute = $publicKeyParameter.Attributes |
+                Where-Object {
+                    $_ -is [System.Management.Automation.ParameterAttribute] -and
+                    $_.ParameterSetName -eq 'Typed'
+                }
+
+            $typedParameterAttribute.Mandatory | Should -BeTrue
+        }
+    }
+}

--- a/Tests/PfbPipelineSelectorRail.Tests.ps1
+++ b/Tests/PfbPipelineSelectorRail.Tests.ps1
@@ -244,17 +244,34 @@ Describe 'Rail A - no unwaived selector coercion' -Skip:($PSVersionTable.PSVersi
         $stale -join ', ' | Should -BeNullOrEmpty
     }
 
-    It 'still measures every pair it used to: BindError stays at 2 rows' {
+    It 'still measures every pair it used to: BindError stays at 4 rows' {
         # Only BindError means UNMEASURED -- Unbindable (PowerShell declined to bind at all)
         # and CmdletError (the cmdlet threw before the shim) are verdicts carrying evidence.
         # A rise here means the harness has started refusing cmdlets it used to measure, which
         # is precisely the regression that produced the original 33-pair blind spot.
         #
-        # BindError is an OUTCOME, not an ErrorKind. ErrorKind is non-null on 358 rows (234
-        # InputObjectNotBound, 122 CmdletError, 2 ParameterBindingError); only the 2
-        # ParameterBindingError rows classify as the BindError outcome, and only that outcome
-        # means unmeasured. Asserting on ErrorKind -eq 'BindError' matches nothing at all.
-        @($script:measured | Where-Object { $_.Outcome -eq 'BindError' }).Count | Should -Be 2
+        # BindError is an OUTCOME, not an ErrorKind. ErrorKind is non-null on 359 rows (233
+        # InputObjectNotBound, 122 CmdletError, 2 ParameterBindingError, 2 HarnessRefusal);
+        # only the ParameterBindingError and HarnessRefusal rows classify as the BindError
+        # outcome, and only that outcome means unmeasured. Asserting on
+        # ErrorKind -eq 'BindError' matches nothing at all.
+        #
+        # RE-BASELINED 2 -> 4, with the movement accounted for rather than absorbed. The two
+        # new rows are both Update-PfbLegalHoldEntity/Name, refused as "would prompt for an
+        # unbound mandatory parameter" once -Released became mandatory (the required-query-key
+        # fix for dmann000/fb-powershell#106 Part 2). They were Bound and Unbindable before.
+        #
+        # This is the honest cost of that fix and not a harness regression: the probe supplies
+        # a selector and nothing else, so a REQUIRED parameter it does not know to supply
+        # cannot be bound, and the row it replaces measured `names=PROBE-name` on a key that
+        # cannot identify a held entity anyway (#139).
+        #
+        # It does generalise, which is what a future reader needs to know: any fix that
+        # correctly makes a required parameter mandatory converts that cmdlet's
+        # pipeline-selector coverage into a triage row. If this number climbs again for that
+        # reason, the answer is probably to teach the probe generator to satisfy mandatory
+        # parameters outside the selector under test -- not to keep re-baselining.
+        @($script:measured | Where-Object { $_.Outcome -eq 'BindError' }).Count | Should -Be 4
     }
 }
 

--- a/Tests/Update-PfbLegalHoldEntity.Tests.ps1
+++ b/Tests/Update-PfbLegalHoldEntity.Tests.ps1
@@ -18,7 +18,7 @@ Describe 'Update-PfbLegalHoldEntity - query parameters (#31)' {
 
     Context 'existing -Name selector (regression, unchanged)' {
         It 'still sends -Name as names' {
-            Update-PfbLegalHoldEntity -Name 'fs1' -Confirm:$false -Array $fakeArray
+            Update-PfbLegalHoldEntity -Name 'fs1' -Released $true -Confirm:$false -Array $fakeArray
 
             Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
                 $Method -eq 'PATCH' -and $Endpoint -eq 'legal-holds/held-entities' -and
@@ -29,7 +29,7 @@ Describe 'Update-PfbLegalHoldEntity - query parameters (#31)' {
 
     Context 'new query parameters' {
         It 'joins -FileSystemIds and -FileSystemNames with commas' {
-            Update-PfbLegalHoldEntity -Name 'fs1' -FileSystemIds 'fsid-1', 'fsid-2' -FileSystemNames 'fs1', 'fs2' -Confirm:$false -Array $fakeArray
+            Update-PfbLegalHoldEntity -Name 'fs1' -FileSystemIds 'fsid-1', 'fsid-2' -FileSystemNames 'fs1', 'fs2' -Released $true -Confirm:$false -Array $fakeArray
 
             Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
                 $QueryParams['file_system_ids'] -eq 'fsid-1,fsid-2' -and
@@ -38,7 +38,7 @@ Describe 'Update-PfbLegalHoldEntity - query parameters (#31)' {
         }
 
         It 'joins -Ids and -Paths with commas' {
-            Update-PfbLegalHoldEntity -Name 'fs1' -Ids 'id-1', 'id-2' -Paths '/dir1', '/dir2' -Confirm:$false -Array $fakeArray
+            Update-PfbLegalHoldEntity -Name 'fs1' -Ids 'id-1', 'id-2' -Paths '/dir1', '/dir2' -Released $true -Confirm:$false -Array $fakeArray
 
             Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
                 $QueryParams['ids'] -eq 'id-1,id-2' -and
@@ -47,7 +47,7 @@ Describe 'Update-PfbLegalHoldEntity - query parameters (#31)' {
         }
 
         It 'sends an EMPTY array for -Ids @() so the query key still reaches the wire (constraint 2)' {
-            Update-PfbLegalHoldEntity -Name 'fs1' -Ids @() -Confirm:$false -Array $fakeArray
+            Update-PfbLegalHoldEntity -Name 'fs1' -Ids @() -Released $true -Confirm:$false -Array $fakeArray
 
             Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
                 $QueryParams.ContainsKey('ids') -and @($QueryParams['ids'] -split ',' | Where-Object { $_ }).Count -eq 0
@@ -55,7 +55,7 @@ Describe 'Update-PfbLegalHoldEntity - query parameters (#31)' {
         }
 
         It 'sends an explicit -Recursive:$false (ContainsKey semantics, not truthiness)' {
-            Update-PfbLegalHoldEntity -Name 'fs1' -Recursive $false -Confirm:$false -Array $fakeArray
+            Update-PfbLegalHoldEntity -Name 'fs1' -Recursive $false -Released $true -Confirm:$false -Array $fakeArray
 
             Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
                 $QueryParams.ContainsKey('recursive') -and $QueryParams['recursive'] -eq $false
@@ -70,18 +70,37 @@ Describe 'Update-PfbLegalHoldEntity - query parameters (#31)' {
             }
         }
 
-        It 'omits recursive and released entirely when not supplied' {
-            Update-PfbLegalHoldEntity -Name 'fs1' -Confirm:$false -Array $fakeArray
+        It 'omits recursive when not supplied but always sends released' {
+            Update-PfbLegalHoldEntity -Name 'fs1' -Released $true -Confirm:$false -Array $fakeArray
 
             Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
-                -not $QueryParams.ContainsKey('recursive') -and -not $QueryParams.ContainsKey('released')
+                -not $QueryParams.ContainsKey('recursive') -and $QueryParams.ContainsKey('released')
             }
+        }
+
+        It 'sends an explicit -Released:$false so a hold can be applied' {
+            Update-PfbLegalHoldEntity -Name 'fs1' -Released $false -Confirm:$false -Array $fakeArray
+
+            Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
+                $QueryParams.ContainsKey('released') -and $QueryParams['released'] -eq $false
+            }
+        }
+
+        It 'requires -Released as a mandatory boolean parameter' {
+            $parameter = (Get-Command Update-PfbLegalHoldEntity).Parameters['Released']
+            $attribute = $parameter.Attributes | Where-Object {
+                $_ -is [System.Management.Automation.ParameterAttribute]
+            }
+
+            $attribute.Mandatory | Should -BeTrue
+            $parameter.ParameterType | Should -Be ([bool])
+            $parameter.ParameterType | Should -Not -Be ([System.Nullable[bool]])
         }
     }
 
     Context 'endpoint accepts no request body' {
         It 'sends an empty body when -Attributes is not supplied' {
-            Update-PfbLegalHoldEntity -Name 'fs1' -Confirm:$false -Array $fakeArray
+            Update-PfbLegalHoldEntity -Name 'fs1' -Released $true -Confirm:$false -Array $fakeArray
 
             Should -Invoke -ModuleName PureStorageFlashBladePowerShell Invoke-PfbApiRequest -Times 1 -Exactly -ParameterFilter {
                 $Body.Count -eq 0


### PR DESCRIPTION
Fixes the two confirmed findings of the issue #106 Part 2 audit: cmdlets that build a semantic empty `@{}` body and, in doing so, send a request the published contract forbids.

Closes #106 — **Part 2 only.** Part 1 of that issue (`New-PfbObjectStoreAccessPolicyRule` omitting the required `names` query parameter) was fixed separately and landed on `main` in #134; this PR completes the Part 2 audit and fixes what it found, which is the last of #106's two deliverables. The audit record itself is a comment on the issue rather than duplicated here.

## `New-PfbApiClient` — impossible through the public interface

`#/components/schemas/ApiClientsPost` requires body property `public_key` on REST 2.0-2.28, and `max_role` on 2.0-2.18 (optional and deprecated from 2.19). The cmdlet exposed only `-Name`, `-Attributes` and `-Array`, so

```powershell
New-PfbApiClient -Name 'automation-client'
```

bound cleanly and sent `{}`. There was no typed route to either required field; the only way to succeed was to hand-build `-Attributes`, which #106 treats as an escape hatch rather than the intended interface.

Adds a `Typed` default parameter set with mandatory `-PublicKey` and optional `-MaxRole`, and moves `-Attributes` into its own mandatory set so a mixed invocation is rejected at bind time instead of letting the raw hashtable silently override a typed value. This is the shape `New-PfbObjectStoreAccountExport` already uses for the same problem (the #101 fix), down to the comment noting that a reference's `resource_type` is readOnly and must never be sent. The `-Attributes` branch now uses `.Clone()` so the caller's hashtable cannot be mutated.

**Deliberately not done:** no runtime REST-version check making `-MaxRole` mandatory below 2.19. The defect being fixed is that no typed path existed, and version-conditional mandatory-ness is not a pattern this module has — inventing one here is a larger decision than this fix. The version boundary is documented in the help instead. The other optional body properties (`access_policies`, `access_token_ttl_in_ms`, `issuer`) stay with #57/#65.

## `Update-PfbLegalHoldEntity` — typed but not enforced

A category #106 did not anticipate, and the reason nothing had flagged it. In every spec from `fb2.17.json` through `fb2.28.json`, `PATCH /legal-holds/held-entities` references `#/components/parameters/Legal_holds_release`, resolving to `released`, `in: query`, `required: true`. `-Released` existed but was optional, and the key was sent only when explicitly bound, so

```powershell
Update-PfbLegalHoldEntity -Name 'fs1' -Recursive $true
```

omitted it. Two of the cmdlet's own examples documented that shape.

`-Released` becomes mandatory `[bool]` and is always sent. A mandatory nullable boolean is a contradiction, and plain `[bool]` still binds `-Released $false`, which matters because false is the *apply* direction. This is the one parameter in the file not guarded by `ContainsKey`; the comment says why — the convention exists to distinguish "not supplied" from "supplied as false", a distinction that cannot arise for a parameter with no legal omission.

The help needed more than a parameter line. The description claimed the entity is identified by name and changed via `-Attributes`, and neither is true: a held entity has no name at all (`LegalHoldHeldEntity` declares only `file_system`, `legal_hold`, `path`, `status`) and the endpoint accepts no request body. Two of three examples would no longer bind, so they were not merely stale but uncallable. All three are replaced with forms measured on a live array.

Because the drift report scores typed-parameter *presence* rather than requiredness, this endpoint read as fully covered — that blind spot is #137.

## Derived reports

**Four** artifact pairs move, not two. `PfbDeadKeyReport.json` and `PfbApiDriftReport.json|.md` were regenerated up front; CI's "Verify derived artifacts are not stale" job then found `PfbFieldCmdletMap.json|Mapping.md` and `PfbPipelineSelectorMap.json|.md` stale as well, since both also walk cmdlet parameter metadata. Those two were regenerated through `scripts/Assert-PfbDerivedArtifacts.ps1 -KeepWorkDirectory` rather than by running the generators bare, per that script's own warning: `Build-PfbFieldCmdletMap.ps1` records what it finds in the whole spec directory, so a bare run against a cache holding anything past the 29 pinned versions writes different output and the gate reports the same artifact stale again.

`PfbFieldCmdletMap` moves by `no-spec-enum-found` 1972 → 1974 — the two new parameters, neither of which has a spec enum to match.

`PfbPipelineSelectorMap` is the one worth reading rather than rubber-stamping, and it cost two test re-baselines. Making `-Released` mandatory means the probe harness can no longer construct a call for `Update-PfbLegalHoldEntity`, so its two rows move from `Bound`/`Unbindable` to `BindError`/`HarnessRefusal` ("would prompt for an unbound mandatory parameter"). `BindError` is that map's **only unmeasured outcome**, and two tests pin it at 2 precisely so a rise stops the build — it is the regression shape that produced the original 33-pair blind spot.

Both reds were the tripwires working. Re-baselined 2 → 4 with the movement accounted for in the comments rather than absorbed: the probe supplies a selector and nothing else, so a *required* parameter it does not know to supply cannot be bound, and the row it replaces measured `names=PROBE-name` on a key that cannot identify a held entity anyway (#139). The comments also record the part that generalises — any future fix correctly making a required parameter mandatory will convert that cmdlet's pipeline-selector coverage into a triage row, and if this number climbs again for that reason the answer is to teach the probe generator to satisfy mandatory parameters outside the selector under test, not to keep re-baselining.

Neither pin appeared in this branch's scoped runs, which is the module-wide-tripwire gap: a test asserting a whole-repo total belongs to no changed file's touched set. Note they are not symmetric either — the `PfbPipelineSelectorRail` pin regenerates and is PS7-gated, while the `Build-PfbPipelineSelectorMap` one reads the committed report and reds on 5.1 too. CI caught both.

The two originally-regenerated reports carry content-identity gates that the source change also reds. Note that the `Committed*Report.Tests.ps1` pair is not the gate — those are shape and absolute-path guards that pass regardless; the real gates live in `Build-PfbDeadKeyReport.Tests.ps1` and `Build-PfbApiDriftReport.Tests.ps1`.

Verified as caused-by-this-change rather than assumed: each failure was attributed by stashing the diff, confirming the gate passes on a clean tree, then unstashing.

| | before | after |
|---|---:|---:|
| dead keys | 83 | 83 |
| `parametersInventoried` | 2165 | 2167 |
| skip reason `body property` | 278 | 280 |
| drift: missing addable body properties | 426 | 424 |

The dead-key total is a ceiling and holds. The `body property` skip reason is the one `CommittedDeadKeyReport.Tests.ps1` deliberately leaves unceilinged, its comment predicting exactly this case — that ceilinging it would red any PR adding a typed body parameter.

The drift report drops `public_key` and `max_role` from the `POST /api-clients` gap row, and both lose their `systemicGaps` aggregate rows by falling from two endpoints to one. `PATCH /api-clients` keeps its own `max_role` gap row, so the Task 8 canary still fires. All three reports are written LF-only to match their committed form; the generators emit CRLF on Windows, which `autocrlf` hides from `git diff` while leaving a mixed-endings file.

## Verification

Scoped and dual-edition throughout — the aggregate suite is CI's job, never a task's completion check here.

| Scope | pwsh 7 | WinPS 5.1 |
|---|---|---|
| Changed cmdlets + family siblings (8 files) | 60 passed / 0 failed | 60 passed / 0 failed |
| Report gates + module-wide tripwires (11 files) | 537 / 0 | 457 / 0, 80 skipped |

`Container ok` on every row, both editions.

Rebased onto `main` after #135 landed, which replaced the global `MaxSkipped` ceiling with the per-file `ExpectedSkips` map. No baseline entry is needed for the new test file: `Assert-PfbTestCoverage.ps1` fails an **undeclared file that skips anything at all**, and both changed test files skip zero on both editions (17 passed / 0 skipped each), so there is nothing to declare. Confirmed by running them alone rather than inferring it from a mixed run — `CiCoverageGate.Tests.ps1` exercises the gate against synthetic results, so its own green says nothing about this branch's skip profile.

Both cmdlets were driven test-first. `Tests/New-PfbApiClient.Tests.ps1` is new — the cmdlet had no test file — and failed 4 of 7 against the unmodified source before passing 7 of 7. `Tests/Update-PfbLegalHoldEntity.Tests.ps1` had every invocation updated to bind, and its "omits recursive and released entirely when not supplied" assertion split: the `recursive` half kept, the `released` half replaced by an always-present one. Both mandatory-ness tests assert on command **metadata** rather than by invoking, because an unbound mandatory parameter prompts rather than throwing and hangs a non-interactive run.

## Live verification

This PR touches `Public/`, so the live-FlashBlade requirement applies in full. No exemption is claimed.

`Update-PfbLegalHoldEntity` was verified on a physical FlashBlade (Purity//FB 4.8.2, REST 2.26) against this branch's committed code — 7 calls, 7 Pass:

```
New-PfbFileSystem          Pass   486ms   create
New-PfbLegalHold           Pass   138ms   create
New-PfbLegalHoldEntity     Pass   274ms   create   (apply the hold)
Update-PfbLegalHoldEntity  Pass   178ms   update   <- the call under test
Remove-PfbLegalHold        Pass   145ms   delete
Update-PfbFileSystem       Pass   206ms   update   (destroy)
Remove-PfbFileSystem       Pass   175ms   delete   (eradicate)
```

The teardown is the proof rather than a formality: while a hold is applied the array refuses to delete it (`Can't delete legal hold because it is still in use.`) and refuses to destroy the file system (`File system with legal holds applied does not support destroy.`). Those two steps succeeding is what shows the release actually landed. The array was left clean — zero holds, zero held entities, zero test file systems.

The working release form was measured rather than assumed, and is what the new help examples show:

```powershell
Update-PfbLegalHoldEntity -Name <hold> -FileSystemNames <fs> -Paths '/' -Recursive $true -Released $true
```

Two things could **not** be verified live, stated rather than glossed:

- **`New-PfbApiClient` cannot be live-tested at all.** `api-clients` is a denied family in the live-test harness — minting real credentials on the lab array is out of scope for it — so the call records `Skipped-Policy` with the family resolved from the cmdlet's own endpoint rather than from a caller-supplied string. That is the rail working, not a coverage gap that was routed around. Its evidence is the dual-edition unit coverage above.
- **The pre-fix shape cannot be run live either.** `-Released` is now an unbound mandatory parameter, which prompts rather than throws and would hang a non-interactive run, so there is no request left to send. Mandatory-ness is asserted from command metadata instead. Worth recording that a harness dry run returned `WouldRun` for that shape: it validates supplied arguments against the module's real parameters but does not check mandatory satisfaction, so a dry run could never have proven this either way.

## Not in this PR

- No version bump and no `CHANGELOG.md` edit — those are maintainer decisions.
- `-Name` on `Update-PfbLegalHoldEntity` stays mandatory even though it is an unusable selector. Held entities have no name, so `names` can never match one; a live array rejects a request selected only by it with `Either names or ids query parameter is required` despite the key being sent. Demoting a mandatory parameter is a breaking change for positional callers, so it is filed as #139 rather than folded in here.

## Follow-ups filed from the audit

- #137 — drift reporting scores typed-parameter presence, not requiredness, which is why the `released` defect was invisible to it.
- #138 — `New-PfbNlmReclamation -Name` is a mandatory dead selector: the endpoint declares no `names` parameter and the operation is array-wide.
- #139 — `Update-PfbLegalHoldEntity -Name` is a mandatory but unusable selector.

## One correction to #106's own arithmetic

The list of 23 was built by matching one exact literal, `$body = if ($Attributes) { $Attributes } else { @{} }`. Three cmdlets use a `.Clone()` variant the pattern does not match (`New-PfbLocalDirectoryService`, `New-PfbLocalGroup`, `New-PfbFileSystemExport`), so the convention is **25** cmdlets, not 23. All three were audited. `New-PfbLocalGroup` is confirmed broken on the wire for this same failure mode and is #136; the other two came back clean.

The convention has now produced four broken creates (#101, #136, and the two fixed here). For the next sweep of it, match on `else { @{} }` or on the AST rather than on the whole assignment — `.Clone()` is a deliberate improvement that avoids mutating the caller's hashtable, so more such variants are likely, and a literal-string sweep under-reports while reading exactly like a complete one.
