### PR TITLE
fix: drift AST scanners miscount coverage (#113)

### DIFF
--- a/Reports/PfbApiDriftReport.json
+++ b/Reports/PfbApiDriftReport.json
@@ -467,255 +467,6 @@
       "annotations": []
     },
     {
-      "endpoint": "DELETE /admins/api-tokens",
-      "cmdlets": [
-        "Remove-PfbApiToken"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "DELETE /admins/cache",
-      "cmdlets": [
-        "Remove-PfbAdminCache"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "DELETE /admins/management-access-policies",
-      "cmdlets": [
-        "Remove-PfbAdminManagementAccessPolicy"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": [
-        {
-          "matchType": "endpoint",
-          "match": "management-access-policies",
-          "kind": "liveTestingHazard",
-          "note": "POST/PATCH/DELETE return 403 regardless of account; not an implementation bug",
-          "reference": null
-        }
-      ]
-    },
-    {
-      "endpoint": "DELETE /admins/ssh-certificate-authority-policies",
-      "cmdlets": [
-        "Remove-PfbAdminSshCaPolicy"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "DELETE /array-connections",
-      "cmdlets": [
-        "Remove-PfbArrayConnection"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "DELETE /arrays/ssh-certificate-authority-policies",
-      "cmdlets": [
-        "Remove-PfbArraySshCaPolicy"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "DELETE /audit-file-systems-policies",
-      "cmdlets": [
-        "Remove-PfbAuditFileSystemPolicy"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "DELETE /audit-file-systems-policies/members",
-      "cmdlets": [
-        "Remove-PfbAuditFileSystemPolicyMember"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "DELETE /audit-object-store-policies",
-      "cmdlets": [
-        "Remove-PfbAuditObjectStorePolicy"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "DELETE /audit-object-store-policies/members",
-      "cmdlets": [
-        "Remove-PfbAuditObjectStorePolicyMember"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "DELETE /buckets",
-      "cmdlets": [
-        "Remove-PfbBucket"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "partial",
-        "unresolvedParameters": [
-          {
-            "parameter": "Eradicate",
-            "surface": "TypedUnresolved",
-            "file": "Public/Bucket/Remove-PfbBucket.ps1",
-            "line": 27
-          }
-        ],
-        "escapeHatchOnly": [],
-        "caveat": "one or more parameters could not be traced to a wire name and have no -Attributes escape hatch; lists reflect typed-parameter coverage only, not full wire reachability"
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "DELETE /buckets/audit-filters",
-      "cmdlets": [
-        "Remove-PfbBucketAuditFilter"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "DELETE /buckets/bucket-access-policies",
-      "cmdlets": [
-        "Remove-PfbBucketAccessPolicy"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
       "endpoint": "DELETE /buckets/bucket-access-policies/rules",
       "cmdlets": [
         "Remove-PfbBucketAccessPolicyRule"
@@ -723,26 +474,7 @@
       "missingQueryParameters": [
         "bucket_ids",
         "bucket_names",
-        "context_names",
         "policy_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "DELETE /buckets/cross-origin-resource-sharing-policies",
-      "cmdlets": [
-        "Remove-PfbBucketCorsPolicy"
-      ],
-      "missingQueryParameters": [
-        "context_names"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -762,7 +494,6 @@
       "missingQueryParameters": [
         "bucket_ids",
         "bucket_names",
-        "context_names",
         "policy_names"
       ],
       "missingBodyProperties": [],
@@ -795,48 +526,11 @@
       "annotations": []
     },
     {
-      "endpoint": "DELETE /data-eviction-policies",
-      "cmdlets": [
-        "Remove-PfbDataEvictionPolicy"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "DELETE /data-eviction-policies/file-systems",
-      "cmdlets": [
-        "Remove-PfbDataEvictionPolicyFileSystem"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
       "endpoint": "DELETE /directory-services/local/groups",
       "cmdlets": [
         "Remove-PfbLocalGroup"
       ],
       "missingQueryParameters": [
-        "context_names",
         "gids",
         "local_directory_service_ids",
         "local_directory_service_names",
@@ -858,7 +552,6 @@
         "Remove-PfbLocalGroupMember"
       ],
       "missingQueryParameters": [
-        "context_names",
         "group_gids",
         "group_sids",
         "local_directory_service_ids",
@@ -878,48 +571,11 @@
       "annotations": []
     },
     {
-      "endpoint": "DELETE /dns",
-      "cmdlets": [
-        "Remove-PfbDns"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "DELETE /file-system-exports",
-      "cmdlets": [
-        "Remove-PfbFileSystemExport"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
       "endpoint": "DELETE /file-system-replica-links",
       "cmdlets": [
         "Remove-PfbFileSystemReplicaLink"
       ],
       "missingQueryParameters": [
-        "context_names",
         "local_file_system_ids",
         "remote_file_system_ids"
       ],
@@ -939,113 +595,8 @@
         "Remove-PfbFileSystemReplicaLinkPolicy"
       ],
       "missingQueryParameters": [
-        "context_names",
         "local_file_system_ids",
         "local_file_system_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "DELETE /file-system-snapshots",
-      "cmdlets": [
-        "Remove-PfbFileSystemSnapshot"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "partial",
-        "unresolvedParameters": [
-          {
-            "parameter": "Eradicate",
-            "surface": "TypedUnresolved",
-            "file": "Public/FileSystemSnapshot/Remove-PfbFileSystemSnapshot.ps1",
-            "line": 24
-          }
-        ],
-        "escapeHatchOnly": [],
-        "caveat": "one or more parameters could not be traced to a wire name and have no -Attributes escape hatch; lists reflect typed-parameter coverage only, not full wire reachability"
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "DELETE /file-system-snapshots/policies",
-      "cmdlets": [
-        "Remove-PfbFileSystemSnapshotPolicy"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "DELETE /file-system-snapshots/transfer",
-      "cmdlets": [
-        "Remove-PfbFileSystemSnapshotTransfer"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "DELETE /file-systems",
-      "cmdlets": [
-        "Remove-PfbFileSystem"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "partial",
-        "unresolvedParameters": [
-          {
-            "parameter": "Eradicate",
-            "surface": "TypedUnresolved",
-            "file": "Public/FileSystem/Remove-PfbFileSystem.ps1",
-            "line": 38
-          }
-        ],
-        "escapeHatchOnly": [],
-        "caveat": "one or more parameters could not be traced to a wire name and have no -Attributes escape hatch; lists reflect typed-parameter coverage only, not full wire reachability"
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "DELETE /file-systems/audit-policies",
-      "cmdlets": [
-        "Remove-PfbFileSystemAuditPolicy"
-      ],
-      "missingQueryParameters": [
-        "context_names"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -1064,30 +615,11 @@
       ],
       "missingQueryParameters": [
         "client_names",
-        "context_names",
         "file_system_ids",
         "file_system_names",
         "inodes",
         "paths",
         "recursive"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "DELETE /file-systems/policies",
-      "cmdlets": [
-        "Remove-PfbFileSystemPolicy"
-      ],
-      "missingQueryParameters": [
-        "context_names"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -1106,7 +638,6 @@
       ],
       "missingQueryParameters": [
         "client_names",
-        "context_names",
         "disruptive",
         "user_names"
       ],
@@ -1124,24 +655,6 @@
         ],
         "escapeHatchOnly": [],
         "caveat": "one or more parameters could not be traced to a wire name and have no -Attributes escape hatch; lists reflect typed-parameter coverage only, not full wire reachability"
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "DELETE /file-systems/user-group-quota-policies",
-      "cmdlets": [
-        "Remove-PfbFileSystemUserGroupQuotaPolicy"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
       },
       "annotations": []
     },
@@ -1171,8 +684,7 @@
       ],
       "missingQueryParameters": [
         "bucket_ids",
-        "bucket_names",
-        "context_names"
+        "bucket_names"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -1183,94 +695,6 @@
         "caveat": ""
       },
       "annotations": []
-    },
-    {
-      "endpoint": "DELETE /log-targets/file-systems",
-      "cmdlets": [
-        "Remove-PfbLogTargetFileSystem"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "DELETE /log-targets/object-store",
-      "cmdlets": [
-        "Remove-PfbLogTargetObjectStore"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "DELETE /management-access-policies",
-      "cmdlets": [
-        "Remove-PfbManagementAccessPolicy"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": [
-        {
-          "matchType": "endpoint",
-          "match": "management-access-policies",
-          "kind": "liveTestingHazard",
-          "note": "POST/PATCH/DELETE return 403 regardless of account; not an implementation bug",
-          "reference": null
-        }
-      ]
-    },
-    {
-      "endpoint": "DELETE /management-access-policies/admins",
-      "cmdlets": [
-        "Remove-PfbManagementAccessPolicyAdmin"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": [
-        {
-          "matchType": "endpoint",
-          "match": "management-access-policies",
-          "kind": "liveTestingHazard",
-          "note": "POST/PATCH/DELETE return 403 regardless of account; not an implementation bug",
-          "reference": null
-        }
-      ]
     },
     {
       "endpoint": "DELETE /network-access-policies/rules",
@@ -1316,7 +740,6 @@
         "Remove-PfbNfsExportPolicy"
       ],
       "missingQueryParameters": [
-        "context_names",
         "versions"
       ],
       "missingBodyProperties": [],
@@ -1335,7 +758,6 @@
         "Remove-PfbNfsExportRule"
       ],
       "missingQueryParameters": [
-        "context_names",
         "ids",
         "versions"
       ],
@@ -1371,48 +793,11 @@
       "annotations": []
     },
     {
-      "endpoint": "DELETE /object-store-access-keys",
-      "cmdlets": [
-        "Remove-PfbObjectStoreAccessKey"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "DELETE /object-store-access-policies",
-      "cmdlets": [
-        "Remove-PfbObjectStoreAccessPolicy"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
       "endpoint": "DELETE /object-store-access-policies/object-store-roles",
       "cmdlets": [
         "Remove-PfbObjectStoreAccessPolicyRole"
       ],
       "missingQueryParameters": [
-        "context_names",
         "member_ids",
         "policy_ids"
       ],
@@ -1432,7 +817,6 @@
         "Remove-PfbObjectStoreAccessPolicyUser"
       ],
       "missingQueryParameters": [
-        "context_names",
         "member_ids",
         "policy_ids"
       ],
@@ -1452,80 +836,7 @@
         "Remove-PfbObjectStoreAccessPolicyRule"
       ],
       "missingQueryParameters": [
-        "context_names",
         "policy_ids"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "DELETE /object-store-account-exports",
-      "cmdlets": [
-        "Remove-PfbObjectStoreAccountExport"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "DELETE /object-store-accounts",
-      "cmdlets": [
-        "Remove-PfbObjectStoreAccount"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "DELETE /object-store-remote-credentials",
-      "cmdlets": [
-        "Remove-PfbObjectStoreRemoteCredential"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "DELETE /object-store-roles",
-      "cmdlets": [
-        "Remove-PfbObjectStoreRole"
-      ],
-      "missingQueryParameters": [
-        "context_names"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -1543,7 +854,6 @@
         "Remove-PfbObjectStoreRoleAccessPolicy"
       ],
       "missingQueryParameters": [
-        "context_names",
         "member_ids",
         "policy_ids",
         "policy_names"
@@ -1564,28 +874,9 @@
         "Remove-PfbObjectStoreTrustPolicyRule"
       ],
       "missingQueryParameters": [
-        "context_names",
         "indices",
         "role_ids",
         "role_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "DELETE /object-store-users",
-      "cmdlets": [
-        "Remove-PfbObjectStoreUser"
-      ],
-      "missingQueryParameters": [
-        "context_names"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -1603,45 +894,8 @@
         "Remove-PfbObjectStoreUserAccessPolicy"
       ],
       "missingQueryParameters": [
-        "context_names",
         "member_ids",
         "policy_ids"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "DELETE /object-store-virtual-hosts",
-      "cmdlets": [
-        "Remove-PfbObjectStoreVirtualHost"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "DELETE /policies",
-      "cmdlets": [
-        "Remove-PfbPolicy"
-      ],
-      "missingQueryParameters": [
-        "context_names"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -1659,63 +913,8 @@
         "Remove-PfbPolicyFileSystemReplicaLink"
       ],
       "missingQueryParameters": [
-        "context_names",
         "local_file_system_ids",
         "local_file_system_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "DELETE /policies/file-systems",
-      "cmdlets": [
-        "Remove-PfbPolicyFileSystem"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "DELETE /presets/workload",
-      "cmdlets": [
-        "Remove-PfbPresetWorkload"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "DELETE /qos-policies",
-      "cmdlets": [
-        "Remove-PfbQosPolicy"
-      ],
-      "missingQueryParameters": [
-        "context_names"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -1733,7 +932,6 @@
         "Remove-PfbQosPolicyMember"
       ],
       "missingQueryParameters": [
-        "context_names",
         "member_types"
       ],
       "missingBodyProperties": [],
@@ -1752,7 +950,6 @@
         "Remove-PfbQuotaGroup"
       ],
       "missingQueryParameters": [
-        "context_names",
         "file_system_ids",
         "file_system_names",
         "gids",
@@ -1794,7 +991,6 @@
         "Remove-PfbQuotaUser"
       ],
       "missingQueryParameters": [
-        "context_names",
         "file_system_ids",
         "file_system_names",
         "names",
@@ -1825,42 +1021,6 @@
       "annotations": []
     },
     {
-      "endpoint": "DELETE /s3-export-policies",
-      "cmdlets": [
-        "Remove-PfbS3ExportPolicy"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "DELETE /s3-export-policies/rules",
-      "cmdlets": [
-        "Remove-PfbS3ExportRule"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
       "endpoint": "DELETE /servers",
       "cmdlets": [
         "Remove-PfbServer"
@@ -1886,50 +1046,13 @@
       "annotations": []
     },
     {
-      "endpoint": "DELETE /smb-client-policies",
-      "cmdlets": [
-        "Remove-PfbSmbClientPolicy"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
       "endpoint": "DELETE /smb-client-policies/rules",
       "cmdlets": [
         "Remove-PfbSmbClientRule"
       ],
       "missingQueryParameters": [
-        "context_names",
         "ids",
         "versions"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "DELETE /smb-share-policies",
-      "cmdlets": [
-        "Remove-PfbSmbSharePolicy"
-      ],
-      "missingQueryParameters": [
-        "context_names"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -1947,152 +1070,7 @@
         "Remove-PfbSmbShareRule"
       ],
       "missingQueryParameters": [
-        "context_names",
         "ids"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "DELETE /ssh-certificate-authority-policies/admins",
-      "cmdlets": [
-        "Remove-PfbSshCaPolicyAdmin"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "DELETE /ssh-certificate-authority-policies/arrays",
-      "cmdlets": [
-        "Remove-PfbSshCaPolicyArray"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "DELETE /user-group-quota-policies",
-      "cmdlets": [
-        "Remove-PfbUserGroupQuotaPolicy"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "DELETE /user-group-quota-policies/file-systems",
-      "cmdlets": [
-        "Remove-PfbUserGroupQuotaPolicyFileSystem"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "DELETE /user-group-quota-policies/rules",
-      "cmdlets": [
-        "Remove-PfbUserGroupQuotaPolicyRule"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "DELETE /workloads",
-      "cmdlets": [
-        "Remove-PfbWorkload"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "DELETE /workloads/tags",
-      "cmdlets": [
-        "Remove-PfbWorkloadTag"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "DELETE /worm-data-policies",
-      "cmdlets": [
-        "Remove-PfbWormPolicy"
-      ],
-      "missingQueryParameters": [
-        "context_names"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -2131,7 +1109,6 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "context_names",
         "filter",
         "limit",
         "sort"
@@ -2149,12 +1126,10 @@
     {
       "endpoint": "GET /admins",
       "cmdlets": [
-        "Get-PfbAdmin",
-        "Resolve-PfbAdminLocality"
+        "Get-PfbAdmin"
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "context_names",
         "expose_api_token"
       ],
       "missingBodyProperties": [],
@@ -2173,8 +1148,7 @@
         "Get-PfbApiToken"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -2193,7 +1167,6 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "context_names",
         "refresh"
       ],
       "missingBodyProperties": [],
@@ -2213,7 +1186,6 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "context_names",
         "sort"
       ],
       "missingBodyProperties": [],
@@ -2241,7 +1213,6 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "context_names",
         "sort"
       ],
       "missingBodyProperties": [],
@@ -2279,8 +1250,7 @@
         "Get-PfbArrayConnection"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -2316,8 +1286,7 @@
         "Get-PfbArrayConnectionPath"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -2354,8 +1323,7 @@
         "Test-PfbConnection"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -2419,8 +1387,7 @@
         "Get-PfbArrayHttpPerformance"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -2438,8 +1405,7 @@
         "Get-PfbArrayNfsPerformance"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -2457,8 +1423,7 @@
         "Get-PfbArrayPerformance"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -2476,8 +1441,7 @@
         "Get-PfbArrayPerformanceReplication"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -2495,8 +1459,7 @@
         "Get-PfbArrayS3Performance"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -2515,7 +1478,6 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "context_names",
         "end_time",
         "resolution",
         "start_time"
@@ -2559,7 +1521,6 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "context_names",
         "sort"
       ],
       "missingBodyProperties": [],
@@ -2596,8 +1557,7 @@
         "Get-PfbAuditFileSystemPolicy"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -2615,8 +1575,7 @@
         "Get-PfbAuditFileSystemPolicyMember"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -2635,7 +1594,6 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "context_names",
         "names"
       ],
       "missingBodyProperties": [],
@@ -2654,8 +1612,7 @@
         "Get-PfbAuditObjectStorePolicy"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -2673,8 +1630,7 @@
         "Get-PfbAuditObjectStorePolicyMember"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -2692,8 +1648,7 @@
         "Get-PfbAudit"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -2731,7 +1686,6 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "context_names",
         "names"
       ],
       "missingBodyProperties": [],
@@ -2751,7 +1705,6 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "context_names",
         "local_bucket_ids",
         "total_only"
       ],
@@ -2771,8 +1724,7 @@
         "Get-PfbBucket"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -2790,8 +1742,7 @@
         "Get-PfbBucketAuditFilter"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -2809,8 +1760,7 @@
         "Get-PfbBucketAccessPolicy"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -2829,8 +1779,7 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "bucket_ids",
-        "context_names"
+        "bucket_ids"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -2848,8 +1797,7 @@
         "Get-PfbBucketCorsPolicy"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -2868,8 +1816,7 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "bucket_ids",
-        "context_names"
+        "bucket_ids"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -2962,8 +1909,7 @@
         "Get-PfbDataEvictionPolicy"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -2981,8 +1927,7 @@
         "Get-PfbDataEvictionPolicyFileSystem"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -3000,8 +1945,7 @@
         "Get-PfbDataEvictionPolicyMember"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -3040,7 +1984,6 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "context_names",
         "destroyed",
         "total_item_count"
       ],
@@ -3061,7 +2004,6 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "context_names",
         "gids",
         "sids",
         "total_item_count"
@@ -3083,7 +2025,6 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "context_names",
         "group_gids",
         "group_sids",
         "member_ids",
@@ -3153,7 +2094,6 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "context_names",
         "filter",
         "ids",
         "limit",
@@ -3177,7 +2117,6 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "context_names",
         "ids",
         "names"
       ],
@@ -3216,7 +2155,6 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "context_names",
         "workload_ids",
         "workload_names"
       ],
@@ -3236,8 +2174,7 @@
         "Get-PfbFileSystemGroupQuota"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -3256,7 +2193,6 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "context_names",
         "local_file_system_ids",
         "remote_file_system_ids"
       ],
@@ -3277,7 +2213,6 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "context_names",
         "local_file_system_ids",
         "local_file_system_names",
         "remote_file_system_ids",
@@ -3299,8 +2234,7 @@
         "Get-PfbFileSystemReplicaLinkTransfer"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -3319,7 +2253,6 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "context_names",
         "names_or_owner_names",
         "owner_ids"
       ],
@@ -3339,8 +2272,7 @@
         "Get-PfbFileSystemSnapshotPolicy"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -3359,7 +2291,6 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "context_names",
         "names_or_owner_names"
       ],
       "missingBodyProperties": [],
@@ -3378,8 +2309,7 @@
         "Get-PfbFileSystemUserQuota"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -3398,7 +2328,6 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "context_names",
         "workload_ids",
         "workload_names"
       ],
@@ -3418,8 +2347,7 @@
         "Get-PfbFileSystemAuditPolicy"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -3437,8 +2365,7 @@
         "Get-PfbFileSystemGroup"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -3478,7 +2405,6 @@
       "missingQueryParameters": [
         "allow_errors",
         "client_names",
-        "context_names",
         "file_system_ids",
         "file_system_names",
         "inodes",
@@ -3500,8 +2426,7 @@
         "Get-PfbFileLockClient"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -3543,8 +2468,7 @@
         "Get-PfbFileSystemPolicy"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -3564,7 +2488,6 @@
       "missingQueryParameters": [
         "allow_errors",
         "client_names",
-        "context_names",
         "user_names"
       ],
       "missingBodyProperties": [],
@@ -3601,8 +2524,7 @@
         "Get-PfbFileSystemUserGroupQuotaPolicy"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -3620,8 +2542,7 @@
         "Get-PfbFileSystemUser"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -3659,8 +2580,7 @@
         "Get-PfbFileSystemWormPolicy"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -3795,8 +2715,7 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "bucket_ids",
-        "context_names"
+        "bucket_ids"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -3814,8 +2733,7 @@
         "Get-PfbLogTargetFileSystem"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -3833,8 +2751,7 @@
         "Get-PfbLogTargetObjectStore"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -3852,8 +2769,7 @@
         "Get-PfbManagementAccessPolicy"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -3880,7 +2796,6 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "context_names",
         "sort"
       ],
       "missingBodyProperties": [],
@@ -3934,7 +2849,6 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "context_names",
         "sort"
       ],
       "missingBodyProperties": [],
@@ -4099,7 +3013,6 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "context_names",
         "workload_ids",
         "workload_names"
       ],
@@ -4120,7 +3033,6 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "context_names",
         "ids"
       ],
       "missingBodyProperties": [],
@@ -4196,8 +3108,7 @@
         "Get-PfbObjectStoreAccessKey"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -4216,7 +3127,6 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "context_names",
         "exclude_rules"
       ],
       "missingBodyProperties": [],
@@ -4235,8 +3145,7 @@
         "Get-PfbObjectStoreAccessPolicyRole"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -4254,8 +3163,7 @@
         "Get-PfbObjectStoreAccessPolicyUser"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -4273,8 +3181,7 @@
         "Get-PfbObjectStoreAccessPolicyRule"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -4293,7 +3200,6 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "context_names",
         "names"
       ],
       "missingBodyProperties": [],
@@ -4312,8 +3218,7 @@
         "Get-PfbObjectStoreAccountExport"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -4331,8 +3236,7 @@
         "Get-PfbObjectStoreAccount"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -4350,8 +3254,7 @@
         "Get-PfbObjectStoreRemoteCredential"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -4369,8 +3272,7 @@
         "Get-PfbObjectStoreRole"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -4389,7 +3291,6 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "context_names",
         "policy_ids",
         "policy_names"
       ],
@@ -4410,7 +3311,6 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "context_names",
         "names"
       ],
       "missingBodyProperties": [],
@@ -4430,7 +3330,6 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "context_names",
         "indices",
         "role_ids",
         "role_names"
@@ -4451,8 +3350,7 @@
         "Get-PfbObjectStoreUser"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -4470,8 +3368,7 @@
         "Get-PfbObjectStoreUserAccessPolicy"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -4489,8 +3386,7 @@
         "Get-PfbObjectStoreVirtualHost"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -4528,7 +3424,6 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "context_names",
         "workload_ids",
         "workload_names"
       ],
@@ -4548,8 +3443,7 @@
         "Get-PfbPolicyAll"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -4568,7 +3462,6 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "context_names",
         "local_file_system_ids",
         "local_file_system_names",
         "remote_file_system_ids",
@@ -4592,7 +3485,6 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "context_names",
         "local_file_system_ids",
         "local_file_system_names",
         "remote_file_system_ids",
@@ -4615,8 +3507,7 @@
         "Get-PfbPolicyFileSystemSnapshot"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -4634,26 +3525,7 @@
         "Get-PfbPolicyFileSystem"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "GET /presets/workload",
-      "cmdlets": [
-        "Get-PfbPresetWorkload"
-      ],
-      "missingQueryParameters": [
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -4689,8 +3561,7 @@
         "Get-PfbQosPolicy"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -4709,7 +3580,6 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "context_names",
         "sort"
       ],
       "missingBodyProperties": [],
@@ -4729,7 +3599,6 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "context_names",
         "sort"
       ],
       "missingBodyProperties": [],
@@ -4749,7 +3618,6 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "context_names",
         "member_types",
         "sort"
       ],
@@ -4770,7 +3638,6 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "context_names",
         "file_system_ids",
         "gids",
         "group_names"
@@ -4811,7 +3678,6 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "context_names",
         "file_system_ids",
         "uids",
         "user_names"
@@ -4832,8 +3698,7 @@
         "Get-PfbRealm"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -4852,7 +3717,6 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "context_names",
         "realm_ids"
       ],
       "missingBodyProperties": [],
@@ -4953,8 +3817,7 @@
         "Get-PfbS3ExportPolicy"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -4972,8 +3835,7 @@
         "Get-PfbS3ExportRule"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -4991,8 +3853,7 @@
         "Get-PfbServer"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -5011,7 +3872,6 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "context_names",
         "workload_ids",
         "workload_names"
       ],
@@ -5032,7 +3892,6 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "context_names",
         "ids"
       ],
       "missingBodyProperties": [],
@@ -5052,7 +3911,6 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "context_names",
         "workload_ids",
         "workload_names"
       ],
@@ -5073,7 +3931,6 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "context_names",
         "ids"
       ],
       "missingBodyProperties": [],
@@ -5174,8 +4031,7 @@
         "Get-PfbSshCaPolicy"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -5194,7 +4050,6 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "context_names",
         "sort"
       ],
       "missingBodyProperties": [],
@@ -5214,7 +4069,6 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "context_names",
         "sort"
       ],
       "missingBodyProperties": [],
@@ -5234,7 +4088,6 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "context_names",
         "sort"
       ],
       "missingBodyProperties": [],
@@ -5274,7 +4127,6 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "context_names",
         "sort"
       ],
       "missingBodyProperties": [],
@@ -5330,8 +4182,7 @@
         "Get-PfbSyslogServer"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -5368,8 +4219,7 @@
         "Get-PfbTarget"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -5444,7 +4294,6 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "context_names",
         "file_system_ids",
         "gids",
         "group_names"
@@ -5466,7 +4315,6 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "context_names",
         "file_system_ids",
         "uids",
         "user_names"
@@ -5488,7 +4336,6 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "context_names",
         "ids",
         "names"
       ],
@@ -5521,8 +4368,7 @@
         "Get-PfbUserGroupQuotaPolicyFileSystem"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -5540,8 +4386,7 @@
         "Get-PfbUserGroupQuotaPolicyMember"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -5559,8 +4404,7 @@
         "Get-PfbUserGroupQuotaPolicyRule"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -5578,8 +4422,7 @@
         "Get-PfbWorkload"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -5597,8 +4440,7 @@
         "Get-PfbWorkloadPlacementRecommendation"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -5616,8 +4458,7 @@
         "Get-PfbWorkloadTag"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -5635,8 +4476,7 @@
         "Get-PfbWormPolicy"
       ],
       "missingQueryParameters": [
-        "allow_errors",
-        "context_names"
+        "allow_errors"
       ],
       "missingBodyProperties": [],
       "readOnlyFields": [],
@@ -5655,7 +4495,6 @@
       ],
       "missingQueryParameters": [
         "allow_errors",
-        "context_names",
         "sort"
       ],
       "missingBodyProperties": [],
@@ -5673,9 +4512,7 @@
       "cmdlets": [
         "Update-PfbAdmin"
       ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
+      "missingQueryParameters": [],
       "missingBodyProperties": [
         {
           "name": "role",
@@ -5894,9 +4731,7 @@
       "cmdlets": [
         "Update-PfbArrayConnection"
       ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
+      "missingQueryParameters": [],
       "missingBodyProperties": [],
       "readOnlyFields": [
         "context",
@@ -6139,9 +4974,7 @@
       "cmdlets": [
         "Update-PfbAuditFileSystemPolicy"
       ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
+      "missingQueryParameters": [],
       "missingBodyProperties": [
         "add_log_targets",
         "control_type",
@@ -6180,9 +5013,7 @@
       "cmdlets": [
         "Update-PfbAuditObjectStorePolicy"
       ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
+      "missingQueryParameters": [],
       "missingBodyProperties": [
         "add_log_targets",
         "enabled",
@@ -6222,7 +5053,6 @@
       ],
       "missingQueryParameters": [
         "cancel_in_progress_storage_class_transition",
-        "context_names",
         "ignore_usage"
       ],
       "missingBodyProperties": [
@@ -6260,24 +5090,6 @@
       "annotations": []
     },
     {
-      "endpoint": "PATCH /buckets/audit-filters",
-      "cmdlets": [
-        "Update-PfbBucketAuditFilter"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
       "endpoint": "PATCH /certificates",
       "cmdlets": [
         "Update-PfbCertificate"
@@ -6305,9 +5117,7 @@
       "cmdlets": [
         "Update-PfbDataEvictionPolicy"
       ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
+      "missingQueryParameters": [],
       "missingBodyProperties": [
         "enabled",
         "location"
@@ -6423,9 +5233,7 @@
       "cmdlets": [
         "Update-PfbDns"
       ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
+      "missingQueryParameters": [],
       "missingBodyProperties": [],
       "readOnlyFields": [
         "context",
@@ -6445,9 +5253,7 @@
       "cmdlets": [
         "Update-PfbFileSystemExport"
       ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
+      "missingQueryParameters": [],
       "missingBodyProperties": [],
       "readOnlyFields": [
         "context",
@@ -6471,7 +5277,6 @@
         "Remove-PfbFileSystemSnapshot"
       ],
       "missingQueryParameters": [
-        "context_names",
         "latest_replica"
       ],
       "missingBodyProperties": [
@@ -6513,7 +5318,6 @@
       ],
       "missingQueryParameters": [
         "cancel_in_progress_storage_class_transition",
-        "context_names",
         "discard_detailed_permissions",
         "ignore_usage"
       ],
@@ -6717,31 +5521,11 @@
       "annotations": []
     },
     {
-      "endpoint": "PATCH /lifecycle-rules",
-      "cmdlets": [
-        "Update-PfbLifecycleRule"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
       "endpoint": "PATCH /log-targets/file-systems",
       "cmdlets": [
         "Update-PfbLogTargetFileSystem"
       ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
+      "missingQueryParameters": [],
       "missingBodyProperties": [],
       "readOnlyFields": [
         "id"
@@ -6759,9 +5543,7 @@
       "cmdlets": [
         "Update-PfbLogTargetObjectStore"
       ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
+      "missingQueryParameters": [],
       "missingBodyProperties": [],
       "readOnlyFields": [
         "id"
@@ -6802,9 +5584,7 @@
       "cmdlets": [
         "Update-PfbManagementAccessPolicy"
       ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
+      "missingQueryParameters": [],
       "missingBodyProperties": [],
       "readOnlyFields": [
         "context",
@@ -7015,7 +5795,6 @@
         "Update-PfbNfsExportPolicy"
       ],
       "missingQueryParameters": [
-        "context_names",
         "versions"
       ],
       "missingBodyProperties": [
@@ -7056,7 +5835,6 @@
       "missingQueryParameters": [
         "before_rule_id",
         "before_rule_name",
-        "context_names",
         "ids",
         "versions"
       ],
@@ -7299,7 +6077,6 @@
         "Update-PfbObjectStoreAccessPolicyRule"
       ],
       "missingQueryParameters": [
-        "context_names",
         "enforce_action_restrictions",
         "policy_ids",
         "policy_names"
@@ -7387,31 +6164,11 @@
       "annotations": []
     },
     {
-      "endpoint": "PATCH /object-store-account-exports",
-      "cmdlets": [
-        "Update-PfbObjectStoreAccountExport"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
       "endpoint": "PATCH /object-store-remote-credentials",
       "cmdlets": [
         "Update-PfbObjectStoreRemoteCredential"
       ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
+      "missingQueryParameters": [],
       "missingBodyProperties": [],
       "readOnlyFields": [
         "context",
@@ -7431,9 +6188,7 @@
       "cmdlets": [
         "Update-PfbObjectStoreRole"
       ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
+      "missingQueryParameters": [],
       "missingBodyProperties": [],
       "readOnlyFields": [
         "context",
@@ -7457,7 +6212,6 @@
         "Update-PfbObjectStoreTrustPolicyRule"
       ],
       "missingQueryParameters": [
-        "context_names",
         "indices",
         "policy_names",
         "role_ids",
@@ -7549,9 +6303,7 @@
       "cmdlets": [
         "Update-PfbObjectStoreVirtualHost"
       ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
+      "missingQueryParameters": [],
       "missingBodyProperties": [],
       "readOnlyFields": [
         "id"
@@ -7816,7 +6568,6 @@
         "Update-PfbPolicy"
       ],
       "missingQueryParameters": [
-        "context_names",
         "destroy_snapshots"
       ],
       "missingBodyProperties": [
@@ -7851,31 +6602,11 @@
       "annotations": []
     },
     {
-      "endpoint": "PATCH /presets/workload",
-      "cmdlets": [
-        "Update-PfbPresetWorkload"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
       "endpoint": "PATCH /qos-policies",
       "cmdlets": [
         "Update-PfbQosPolicy"
       ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
+      "missingQueryParameters": [],
       "missingBodyProperties": [],
       "readOnlyFields": [
         "context",
@@ -7898,7 +6629,6 @@
         "Update-PfbQuotaGroup"
       ],
       "missingQueryParameters": [
-        "context_names",
         "file_system_ids",
         "file_system_names",
         "gids",
@@ -8000,7 +6730,6 @@
         "Update-PfbQuotaUser"
       ],
       "missingQueryParameters": [
-        "context_names",
         "file_system_ids",
         "file_system_names",
         "names",
@@ -8129,9 +6858,7 @@
       "cmdlets": [
         "Update-PfbRealmDefaults"
       ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
+      "missingQueryParameters": [],
       "missingBodyProperties": [],
       "readOnlyFields": [
         "context",
@@ -8150,9 +6877,7 @@
       "cmdlets": [
         "Update-PfbS3ExportPolicy"
       ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
+      "missingQueryParameters": [],
       "missingBodyProperties": [
         "enabled",
         "name",
@@ -8182,7 +6907,6 @@
         "Update-PfbS3ExportRule"
       ],
       "missingQueryParameters": [
-        "context_names",
         "policy_ids",
         "policy_names"
       ],
@@ -8253,9 +6977,7 @@
       "cmdlets": [
         "Update-PfbSmbClientPolicy"
       ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
+      "missingQueryParameters": [],
       "missingBodyProperties": [
         "access_based_enumeration_enabled",
         "enabled",
@@ -8295,7 +7017,6 @@
       "missingQueryParameters": [
         "before_rule_id",
         "before_rule_name",
-        "context_names",
         "ids",
         "versions"
       ],
@@ -8412,9 +7133,7 @@
       "cmdlets": [
         "Update-PfbSmbSharePolicy"
       ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
+      "missingQueryParameters": [],
       "missingBodyProperties": [
         "enabled",
         "location",
@@ -8450,7 +7169,6 @@
         "Update-PfbSmbShareRule"
       ],
       "missingQueryParameters": [
-        "context_names",
         "ids",
         "policy_ids",
         "policy_names"
@@ -9040,9 +7758,7 @@
       "cmdlets": [
         "Update-PfbUserGroupQuotaPolicy"
       ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
+      "missingQueryParameters": [],
       "missingBodyProperties": [
         "enabled",
         "name"
@@ -9077,9 +7793,7 @@
       "cmdlets": [
         "Update-PfbUserGroupQuotaPolicyRule"
       ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
+      "missingQueryParameters": [],
       "missingBodyProperties": [],
       "readOnlyFields": [
         "id",
@@ -9098,9 +7812,7 @@
       "cmdlets": [
         "Update-PfbWorkload"
       ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
+      "missingQueryParameters": [],
       "missingBodyProperties": [
         "destroyed"
       ],
@@ -9125,9 +7837,7 @@
       "cmdlets": [
         "Update-PfbWormPolicy"
       ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
+      "missingQueryParameters": [],
       "missingBodyProperties": [],
       "readOnlyFields": [
         "context",
@@ -9184,68 +7894,6 @@
           "Name"
         ],
         "caveat": "body reachable only via -Attributes; lists reflect typed-parameter coverage, not wire reachability"
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "POST /admins/api-tokens",
-      "cmdlets": [
-        "New-PfbApiToken"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "POST /admins/management-access-policies",
-      "cmdlets": [
-        "New-PfbAdminManagementAccessPolicy"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": [
-        {
-          "matchType": "endpoint",
-          "match": "management-access-policies",
-          "kind": "liveTestingHazard",
-          "note": "POST/PATCH/DELETE return 403 regardless of account; not an implementation bug",
-          "reference": null
-        }
-      ]
-    },
-    {
-      "endpoint": "POST /admins/ssh-certificate-authority-policies",
-      "cmdlets": [
-        "New-PfbAdminSshCaPolicy"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
       },
       "annotations": []
     },
@@ -9322,9 +7970,7 @@
       "cmdlets": [
         "New-PfbArrayConnection"
       ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
+      "missingQueryParameters": [],
       "missingBodyProperties": [],
       "readOnlyFields": [
         "context",
@@ -9363,31 +8009,11 @@
       "annotations": []
     },
     {
-      "endpoint": "POST /arrays/ssh-certificate-authority-policies",
-      "cmdlets": [
-        "New-PfbArraySshCaPolicy"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
       "endpoint": "POST /audit-file-systems-policies",
       "cmdlets": [
         "New-PfbAuditFileSystemPolicy"
       ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
+      "missingQueryParameters": [],
       "missingBodyProperties": [
         "control_type",
         "enabled",
@@ -9420,31 +8046,11 @@
       "annotations": []
     },
     {
-      "endpoint": "POST /audit-file-systems-policies/members",
-      "cmdlets": [
-        "New-PfbAuditFileSystemPolicyMember"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
       "endpoint": "POST /audit-object-store-policies",
       "cmdlets": [
         "New-PfbAuditObjectStorePolicy"
       ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
+      "missingQueryParameters": [],
       "missingBodyProperties": [
         "enabled",
         "location",
@@ -9475,31 +8081,11 @@
       "annotations": []
     },
     {
-      "endpoint": "POST /audit-object-store-policies/members",
-      "cmdlets": [
-        "New-PfbAuditObjectStorePolicyMember"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
       "endpoint": "POST /buckets",
       "cmdlets": [
         "New-PfbBucket"
       ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
+      "missingQueryParameters": [],
       "missingBodyProperties": [
         {
           "name": "bucket_type",
@@ -9609,7 +8195,6 @@
       ],
       "missingQueryParameters": [
         "bucket_ids",
-        "context_names",
         "names"
       ],
       "missingBodyProperties": [
@@ -9640,8 +8225,7 @@
         "New-PfbBucketAccessPolicy"
       ],
       "missingQueryParameters": [
-        "bucket_ids",
-        "context_names"
+        "bucket_ids"
       ],
       "missingBodyProperties": [
         {
@@ -9677,8 +8261,7 @@
         "New-PfbBucketAccessPolicyRule"
       ],
       "missingQueryParameters": [
-        "bucket_ids",
-        "context_names"
+        "bucket_ids"
       ],
       "missingBodyProperties": [
         {
@@ -9750,8 +8333,7 @@
         "New-PfbBucketCorsPolicy"
       ],
       "missingQueryParameters": [
-        "bucket_ids",
-        "context_names"
+        "bucket_ids"
       ],
       "missingBodyProperties": [
         {
@@ -9787,8 +8369,7 @@
         "New-PfbBucketCorsPolicyRule"
       ],
       "missingQueryParameters": [
-        "bucket_ids",
-        "context_names"
+        "bucket_ids"
       ],
       "missingBodyProperties": [
         {
@@ -10191,9 +8772,7 @@
       "cmdlets": [
         "New-PfbDataEvictionPolicy"
       ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
+      "missingQueryParameters": [],
       "missingBodyProperties": [
         "enabled",
         "location",
@@ -10221,48 +8800,11 @@
       "annotations": []
     },
     {
-      "endpoint": "POST /data-eviction-policies/file-systems",
-      "cmdlets": [
-        "Add-PfbDataEvictionPolicyFileSystem"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "POST /directory-services/local/directory-services",
-      "cmdlets": [
-        "New-PfbLocalDirectoryService"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
       "endpoint": "POST /directory-services/local/groups",
       "cmdlets": [
         "New-PfbLocalGroup"
       ],
       "missingQueryParameters": [
-        "context_names",
         "local_directory_service_ids",
         "local_directory_service_names"
       ],
@@ -10282,7 +8824,6 @@
         "New-PfbLocalGroupMember"
       ],
       "missingQueryParameters": [
-        "context_names",
         "group_gids",
         "group_sids",
         "local_directory_service_ids"
@@ -10397,7 +8938,6 @@
         "New-PfbDns"
       ],
       "missingQueryParameters": [
-        "context_names",
         "names"
       ],
       "missingBodyProperties": [
@@ -10432,7 +8972,6 @@
         "New-PfbFileSystemExport"
       ],
       "missingQueryParameters": [
-        "context_names",
         "member_ids",
         "policy_ids"
       ],
@@ -10452,7 +8991,6 @@
         "New-PfbFileSystemReplicaLink"
       ],
       "missingQueryParameters": [
-        "context_names",
         "local_file_system_ids"
       ],
       "missingBodyProperties": [
@@ -10579,30 +9117,11 @@
       "annotations": []
     },
     {
-      "endpoint": "POST /file-system-replica-links/policies",
-      "cmdlets": [
-        "New-PfbFileSystemReplicaLinkPolicy"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
       "endpoint": "POST /file-system-snapshots",
       "cmdlets": [
         "New-PfbFileSystemSnapshot"
       ],
       "missingQueryParameters": [
-        "context_names",
         "source_ids",
         "source_names"
       ],
@@ -10629,7 +9148,6 @@
         "New-PfbFileSystem"
       ],
       "missingQueryParameters": [
-        "context_names",
         "default_exports",
         "discard_non_snapshotted_data",
         "include_snapshot",
@@ -10783,78 +9301,6 @@
       "annotations": []
     },
     {
-      "endpoint": "POST /file-systems/audit-policies",
-      "cmdlets": [
-        "New-PfbFileSystemAuditPolicy"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "POST /file-systems/locks/nlm-reclamations",
-      "cmdlets": [
-        "New-PfbNlmReclamation"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "POST /file-systems/policies",
-      "cmdlets": [
-        "New-PfbFileSystemPolicy"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "POST /file-systems/user-group-quota-policies",
-      "cmdlets": [
-        "New-PfbFileSystemUserGroupQuotaPolicy"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
       "endpoint": "POST /fleets",
       "cmdlets": [
         "New-PfbFleet"
@@ -10997,8 +9443,7 @@
         "New-PfbLifecycleRule"
       ],
       "missingQueryParameters": [
-        "confirm_date",
-        "context_names"
+        "confirm_date"
       ],
       "missingBodyProperties": [
         {
@@ -11154,9 +9599,7 @@
       "cmdlets": [
         "New-PfbLogTargetFileSystem"
       ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
+      "missingQueryParameters": [],
       "missingBodyProperties": [
         {
           "name": "file_system",
@@ -11243,9 +9686,7 @@
       "cmdlets": [
         "New-PfbLogTargetObjectStore"
       ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
+      "missingQueryParameters": [],
       "missingBodyProperties": [
         {
           "name": "bucket",
@@ -11368,9 +9809,7 @@
       "cmdlets": [
         "New-PfbManagementAccessPolicy"
       ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
+      "missingQueryParameters": [],
       "missingBodyProperties": [
         {
           "name": "aggregation_strategy",
@@ -11481,32 +9920,6 @@
       ]
     },
     {
-      "endpoint": "POST /management-access-policies/admins",
-      "cmdlets": [
-        "New-PfbManagementAccessPolicyAdmin"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": [
-        {
-          "matchType": "endpoint",
-          "match": "management-access-policies",
-          "kind": "liveTestingHazard",
-          "note": "POST/PATCH/DELETE return 403 regardless of account; not an implementation bug",
-          "reference": null
-        }
-      ]
-    },
-    {
       "endpoint": "POST /network-access-policies/rules",
       "cmdlets": [
         "New-PfbNetworkAccessRule"
@@ -11568,9 +9981,7 @@
       "cmdlets": [
         "New-PfbNfsExportPolicy"
       ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
+      "missingQueryParameters": [],
       "missingBodyProperties": [
         "enabled",
         "location",
@@ -11605,9 +10016,7 @@
       "cmdlets": [
         "New-PfbNfsExportRule"
       ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
+      "missingQueryParameters": [],
       "missingBodyProperties": [],
       "readOnlyFields": [
         "context",
@@ -11656,7 +10065,6 @@
         "New-PfbObjectStoreAccessKey"
       ],
       "missingQueryParameters": [
-        "context_names",
         "names"
       ],
       "missingBodyProperties": [
@@ -11693,7 +10101,6 @@
         "New-PfbObjectStoreAccessPolicy"
       ],
       "missingQueryParameters": [
-        "context_names",
         "enforce_action_restrictions"
       ],
       "missingBodyProperties": [
@@ -11747,7 +10154,6 @@
         "New-PfbObjectStoreAccessPolicyRole"
       ],
       "missingQueryParameters": [
-        "context_names",
         "member_ids",
         "policy_ids"
       ],
@@ -11767,7 +10173,6 @@
         "New-PfbObjectStoreAccessPolicyUser"
       ],
       "missingQueryParameters": [
-        "context_names",
         "member_ids",
         "policy_ids"
       ],
@@ -11787,7 +10192,6 @@
         "New-PfbObjectStoreAccessPolicyRule"
       ],
       "missingQueryParameters": [
-        "context_names",
         "enforce_action_restrictions",
         "policy_ids"
       ],
@@ -11874,31 +10278,11 @@
       "annotations": []
     },
     {
-      "endpoint": "POST /object-store-account-exports",
-      "cmdlets": [
-        "New-PfbObjectStoreAccountExport"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
       "endpoint": "POST /object-store-accounts",
       "cmdlets": [
         "New-PfbObjectStoreAccount"
       ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
+      "missingQueryParameters": [],
       "missingBodyProperties": [
         {
           "name": "account_exports",
@@ -11983,9 +10367,7 @@
       "cmdlets": [
         "New-PfbObjectStoreRemoteCredential"
       ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
+      "missingQueryParameters": [],
       "missingBodyProperties": [
         {
           "name": "access_key_id",
@@ -12036,9 +10418,7 @@
       "cmdlets": [
         "New-PfbObjectStoreRole"
       ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
+      "missingQueryParameters": [],
       "missingBodyProperties": [
         {
           "name": "max_session_duration",
@@ -12073,7 +10453,6 @@
         "New-PfbObjectStoreRoleAccessPolicy"
       ],
       "missingQueryParameters": [
-        "context_names",
         "member_ids",
         "policy_ids",
         "policy_names"
@@ -12094,7 +10473,6 @@
         "New-PfbObjectStoreTrustPolicyRule"
       ],
       "missingQueryParameters": [
-        "context_names",
         "names",
         "role_ids",
         "role_names"
@@ -12186,7 +10564,6 @@
         "New-PfbObjectStoreUser"
       ],
       "missingQueryParameters": [
-        "context_names",
         "full_access"
       ],
       "missingBodyProperties": [],
@@ -12205,7 +10582,6 @@
         "New-PfbObjectStoreUserAccessPolicy"
       ],
       "missingQueryParameters": [
-        "context_names",
         "member_ids",
         "policy_ids"
       ],
@@ -12224,9 +10600,7 @@
       "cmdlets": [
         "New-PfbObjectStoreVirtualHost"
       ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
+      "missingQueryParameters": [],
       "missingBodyProperties": [
         {
           "name": "attached_servers",
@@ -12265,9 +10639,7 @@
       "cmdlets": [
         "New-PfbPolicy"
       ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
+      "missingQueryParameters": [],
       "missingBodyProperties": [
         "enabled",
         "location",
@@ -12298,49 +10670,11 @@
       "annotations": []
     },
     {
-      "endpoint": "POST /policies/file-system-replica-links",
-      "cmdlets": [
-        "New-PfbPolicyFileSystemReplicaLink"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "POST /policies/file-systems",
-      "cmdlets": [
-        "New-PfbPolicyFileSystem"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
       "endpoint": "POST /presets/workload",
       "cmdlets": [
         "New-PfbPresetWorkload"
       ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
+      "missingQueryParameters": [],
       "missingBodyProperties": [
         {
           "name": "description",
@@ -12634,9 +10968,7 @@
       "cmdlets": [
         "New-PfbQosPolicy"
       ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
+      "missingQueryParameters": [],
       "missingBodyProperties": [
         {
           "name": "enabled",
@@ -12740,30 +11072,11 @@
       "annotations": []
     },
     {
-      "endpoint": "POST /qos-policies/members",
-      "cmdlets": [
-        "New-PfbQosPolicyMember"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
       "endpoint": "POST /quotas/groups",
       "cmdlets": [
         "New-PfbQuotaGroup"
       ],
       "missingQueryParameters": [
-        "context_names",
         "file_system_ids",
         "file_system_names",
         "gids",
@@ -12810,7 +11123,6 @@
         "New-PfbQuotaUser"
       ],
       "missingQueryParameters": [
-        "context_names",
         "file_system_ids",
         "file_system_names",
         "uids",
@@ -12874,9 +11186,7 @@
       "cmdlets": [
         "New-PfbS3ExportPolicy"
       ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
+      "missingQueryParameters": [],
       "missingBodyProperties": [
         "enabled",
         "rules"
@@ -12896,24 +11206,6 @@
           "Enabled"
         ],
         "caveat": "body reachable only via -Attributes; lists reflect typed-parameter coverage, not wire reachability"
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "POST /s3-export-policies/rules",
-      "cmdlets": [
-        "New-PfbS3ExportRule"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
       },
       "annotations": []
     },
@@ -12950,9 +11242,7 @@
       "cmdlets": [
         "New-PfbSmbClientPolicy"
       ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
+      "missingQueryParameters": [],
       "missingBodyProperties": [
         "access_based_enumeration_enabled",
         "enabled",
@@ -12988,9 +11278,7 @@
       "cmdlets": [
         "New-PfbSmbClientRule"
       ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
+      "missingQueryParameters": [],
       "missingBodyProperties": [],
       "readOnlyFields": [
         "id",
@@ -13009,9 +11297,7 @@
       "cmdlets": [
         "New-PfbSmbSharePolicy"
       ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
+      "missingQueryParameters": [],
       "missingBodyProperties": [
         "enabled",
         "location",
@@ -13046,9 +11332,7 @@
       "cmdlets": [
         "New-PfbSmbShareRule"
       ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
+      "missingQueryParameters": [],
       "missingBodyProperties": [],
       "readOnlyFields": [
         "id",
@@ -13149,42 +11433,6 @@
           "Name"
         ],
         "caveat": "body reachable only via -Attributes; lists reflect typed-parameter coverage, not wire reachability"
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "POST /ssh-certificate-authority-policies/admins",
-      "cmdlets": [
-        "New-PfbSshCaPolicyAdmin"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
-      "endpoint": "POST /ssh-certificate-authority-policies/arrays",
-      "cmdlets": [
-        "New-PfbSshCaPolicyArray"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
       },
       "annotations": []
     },
@@ -13583,9 +11831,7 @@
       "cmdlets": [
         "New-PfbUserGroupQuotaPolicy"
       ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
+      "missingQueryParameters": [],
       "missingBodyProperties": [
         "enabled",
         "name"
@@ -13614,31 +11860,11 @@
       "annotations": []
     },
     {
-      "endpoint": "POST /user-group-quota-policies/file-systems",
-      "cmdlets": [
-        "New-PfbUserGroupQuotaPolicyFileSystem"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
       "endpoint": "POST /user-group-quota-policies/rules",
       "cmdlets": [
         "New-PfbUserGroupQuotaPolicyRule"
       ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
+      "missingQueryParameters": [],
       "missingBodyProperties": [
         "enforced"
       ],
@@ -13661,31 +11887,11 @@
       "annotations": []
     },
     {
-      "endpoint": "POST /workloads",
-      "cmdlets": [
-        "New-PfbWorkload"
-      ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
-      "missingBodyProperties": [],
-      "readOnlyFields": [],
-      "confidence": {
-        "level": "high",
-        "unresolvedParameters": [],
-        "escapeHatchOnly": [],
-        "caveat": ""
-      },
-      "annotations": []
-    },
-    {
       "endpoint": "POST /workloads/placement-recommendations",
       "cmdlets": [
         "New-PfbWorkloadPlacementRecommendation"
       ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
+      "missingQueryParameters": [],
       "missingBodyProperties": [
         "additional_constraints",
         "parameters",
@@ -13726,7 +11932,6 @@
         "New-PfbWormPolicy"
       ],
       "missingQueryParameters": [
-        "context_names",
         "names"
       ],
       "missingBodyProperties": [
@@ -13768,9 +11973,7 @@
       "cmdlets": [
         "Set-PfbPresetWorkload"
       ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
+      "missingQueryParameters": [],
       "missingBodyProperties": [
         {
           "name": "description",
@@ -14049,9 +12252,7 @@
       "cmdlets": [
         "Set-PfbWorkloadTag"
       ],
-      "missingQueryParameters": [
-        "context_names"
-      ],
+      "missingQueryParameters": [],
       "missingBodyProperties": [
         "copyable",
         "key",
@@ -14077,291 +12278,6 @@
     }
   ],
   "systemicGaps": [
-    {
-      "name": "context_names",
-      "endpointCount": 268,
-      "queryEndpointCount": 268,
-      "bodyEndpointCount": 0,
-      "endpoints": [
-        "DELETE /admins/api-tokens",
-        "DELETE /admins/cache",
-        "DELETE /admins/management-access-policies",
-        "DELETE /admins/ssh-certificate-authority-policies",
-        "DELETE /array-connections",
-        "DELETE /arrays/ssh-certificate-authority-policies",
-        "DELETE /audit-file-systems-policies",
-        "DELETE /audit-file-systems-policies/members",
-        "DELETE /audit-object-store-policies",
-        "DELETE /audit-object-store-policies/members",
-        "DELETE /buckets/audit-filters",
-        "DELETE /buckets/bucket-access-policies",
-        "DELETE /buckets/bucket-access-policies/rules",
-        "DELETE /buckets/cross-origin-resource-sharing-policies",
-        "DELETE /buckets/cross-origin-resource-sharing-policies/rules",
-        "DELETE /data-eviction-policies",
-        "DELETE /data-eviction-policies/file-systems",
-        "DELETE /directory-services/local/groups",
-        "DELETE /directory-services/local/groups/members",
-        "DELETE /dns",
-        "DELETE /file-system-exports",
-        "DELETE /file-system-replica-links",
-        "DELETE /file-system-replica-links/policies",
-        "DELETE /file-system-snapshots/policies",
-        "DELETE /file-system-snapshots/transfer",
-        "DELETE /file-systems/audit-policies",
-        "DELETE /file-systems/locks",
-        "DELETE /file-systems/policies",
-        "DELETE /file-systems/user-group-quota-policies",
-        "DELETE /lifecycle-rules",
-        "DELETE /log-targets/file-systems",
-        "DELETE /log-targets/object-store",
-        "DELETE /management-access-policies",
-        "DELETE /management-access-policies/admins",
-        "DELETE /nfs-export-policies",
-        "DELETE /nfs-export-policies/rules",
-        "DELETE /object-store-access-keys",
-        "DELETE /object-store-access-policies",
-        "DELETE /object-store-access-policies/object-store-roles",
-        "DELETE /object-store-access-policies/object-store-users",
-        "DELETE /object-store-access-policies/rules",
-        "DELETE /object-store-account-exports",
-        "DELETE /object-store-accounts",
-        "DELETE /object-store-remote-credentials",
-        "DELETE /object-store-roles",
-        "DELETE /object-store-roles/object-store-access-policies",
-        "DELETE /object-store-roles/object-store-trust-policies/rules",
-        "DELETE /object-store-users",
-        "DELETE /object-store-users/object-store-access-policies",
-        "DELETE /object-store-virtual-hosts",
-        "DELETE /policies",
-        "DELETE /policies/file-system-replica-links",
-        "DELETE /policies/file-systems",
-        "DELETE /presets/workload",
-        "DELETE /qos-policies",
-        "DELETE /qos-policies/members",
-        "DELETE /s3-export-policies",
-        "DELETE /s3-export-policies/rules",
-        "DELETE /smb-client-policies",
-        "DELETE /smb-client-policies/rules",
-        "DELETE /smb-share-policies",
-        "DELETE /smb-share-policies/rules",
-        "DELETE /ssh-certificate-authority-policies/admins",
-        "DELETE /ssh-certificate-authority-policies/arrays",
-        "DELETE /user-group-quota-policies",
-        "DELETE /user-group-quota-policies/file-systems",
-        "DELETE /user-group-quota-policies/rules",
-        "DELETE /workloads",
-        "DELETE /workloads/tags",
-        "DELETE /worm-data-policies",
-        "GET /active-directory/test",
-        "GET /admins",
-        "GET /admins/api-tokens",
-        "GET /admins/cache",
-        "GET /admins/management-access-policies",
-        "GET /admins/ssh-certificate-authority-policies",
-        "GET /array-connections",
-        "GET /array-connections/path",
-        "GET /arrays/http-specific-performance",
-        "GET /arrays/nfs-specific-performance",
-        "GET /arrays/performance",
-        "GET /arrays/performance/replication",
-        "GET /arrays/s3-specific-performance",
-        "GET /arrays/space",
-        "GET /arrays/ssh-certificate-authority-policies",
-        "GET /audit-file-systems-policies",
-        "GET /audit-file-systems-policies/members",
-        "GET /audit-file-systems-policy-operations",
-        "GET /audit-object-store-policies",
-        "GET /audit-object-store-policies/members",
-        "GET /audits",
-        "GET /bucket-audit-filter-actions",
-        "GET /bucket-replica-links",
-        "GET /buckets",
-        "GET /buckets/audit-filters",
-        "GET /buckets/bucket-access-policies",
-        "GET /buckets/bucket-access-policies/rules",
-        "GET /buckets/cross-origin-resource-sharing-policies",
-        "GET /buckets/cross-origin-resource-sharing-policies/rules",
-        "GET /data-eviction-policies",
-        "GET /data-eviction-policies/file-systems",
-        "GET /data-eviction-policies/members",
-        "GET /directory-services/local/directory-services",
-        "GET /directory-services/local/groups",
-        "GET /directory-services/local/groups/members",
-        "GET /directory-services/test",
-        "GET /dns",
-        "GET /file-system-exports",
-        "GET /file-system-group-quotas",
-        "GET /file-system-replica-links",
-        "GET /file-system-replica-links/policies",
-        "GET /file-system-replica-links/transfer",
-        "GET /file-system-snapshots",
-        "GET /file-system-snapshots/policies",
-        "GET /file-system-snapshots/transfer",
-        "GET /file-system-user-quotas",
-        "GET /file-systems",
-        "GET /file-systems/audit-policies",
-        "GET /file-systems/groups",
-        "GET /file-systems/locks",
-        "GET /file-systems/locks/clients",
-        "GET /file-systems/policies",
-        "GET /file-systems/sessions",
-        "GET /file-systems/user-group-quota-policies",
-        "GET /file-systems/users",
-        "GET /file-systems/worm-data-policies",
-        "GET /lifecycle-rules",
-        "GET /log-targets/file-systems",
-        "GET /log-targets/object-store",
-        "GET /management-access-policies",
-        "GET /management-access-policies/admins",
-        "GET /management-access-policies/members",
-        "GET /nfs-export-policies",
-        "GET /nfs-export-policies/rules",
-        "GET /object-store-access-keys",
-        "GET /object-store-access-policies",
-        "GET /object-store-access-policies/object-store-roles",
-        "GET /object-store-access-policies/object-store-users",
-        "GET /object-store-access-policies/rules",
-        "GET /object-store-access-policy-actions",
-        "GET /object-store-account-exports",
-        "GET /object-store-accounts",
-        "GET /object-store-remote-credentials",
-        "GET /object-store-roles",
-        "GET /object-store-roles/object-store-access-policies",
-        "GET /object-store-roles/object-store-trust-policies",
-        "GET /object-store-roles/object-store-trust-policies/rules",
-        "GET /object-store-users",
-        "GET /object-store-users/object-store-access-policies",
-        "GET /object-store-virtual-hosts",
-        "GET /policies",
-        "GET /policies-all",
-        "GET /policies-all/members",
-        "GET /policies/file-system-replica-links",
-        "GET /policies/file-system-snapshots",
-        "GET /policies/file-systems",
-        "GET /presets/workload",
-        "GET /qos-policies",
-        "GET /qos-policies/buckets",
-        "GET /qos-policies/file-systems",
-        "GET /qos-policies/members",
-        "GET /quotas/groups",
-        "GET /quotas/users",
-        "GET /realms",
-        "GET /realms/defaults",
-        "GET /s3-export-policies",
-        "GET /s3-export-policies/rules",
-        "GET /servers",
-        "GET /smb-client-policies",
-        "GET /smb-client-policies/rules",
-        "GET /smb-share-policies",
-        "GET /smb-share-policies/rules",
-        "GET /ssh-certificate-authority-policies",
-        "GET /ssh-certificate-authority-policies/admins",
-        "GET /ssh-certificate-authority-policies/arrays",
-        "GET /ssh-certificate-authority-policies/members",
-        "GET /storage-class-tiering-policies/members",
-        "GET /syslog-servers",
-        "GET /targets",
-        "GET /usage/groups",
-        "GET /usage/users",
-        "GET /user-group-quota-policies/file-systems",
-        "GET /user-group-quota-policies/members",
-        "GET /user-group-quota-policies/rules",
-        "GET /workloads",
-        "GET /workloads/placement-recommendations",
-        "GET /workloads/tags",
-        "GET /worm-data-policies",
-        "GET /worm-data-policies/members",
-        "PATCH /admins",
-        "PATCH /array-connections",
-        "PATCH /buckets/audit-filters",
-        "PATCH /dns",
-        "PATCH /file-system-exports",
-        "PATCH /lifecycle-rules",
-        "PATCH /log-targets/file-systems",
-        "PATCH /log-targets/object-store",
-        "PATCH /management-access-policies",
-        "PATCH /nfs-export-policies/rules",
-        "PATCH /object-store-access-policies/rules",
-        "PATCH /object-store-account-exports",
-        "PATCH /object-store-remote-credentials",
-        "PATCH /object-store-roles",
-        "PATCH /object-store-roles/object-store-trust-policies/rules",
-        "PATCH /object-store-virtual-hosts",
-        "PATCH /presets/workload",
-        "PATCH /qos-policies",
-        "PATCH /realms/defaults",
-        "PATCH /s3-export-policies/rules",
-        "PATCH /smb-client-policies/rules",
-        "PATCH /smb-share-policies/rules",
-        "PATCH /user-group-quota-policies/rules",
-        "PATCH /worm-data-policies",
-        "POST /admins/api-tokens",
-        "POST /admins/management-access-policies",
-        "POST /admins/ssh-certificate-authority-policies",
-        "POST /array-connections",
-        "POST /arrays/ssh-certificate-authority-policies",
-        "POST /audit-file-systems-policies/members",
-        "POST /audit-object-store-policies/members",
-        "POST /buckets",
-        "POST /buckets/bucket-access-policies",
-        "POST /buckets/bucket-access-policies/rules",
-        "POST /buckets/cross-origin-resource-sharing-policies",
-        "POST /buckets/cross-origin-resource-sharing-policies/rules",
-        "POST /data-eviction-policies/file-systems",
-        "POST /directory-services/local/directory-services",
-        "POST /directory-services/local/groups",
-        "POST /file-system-exports",
-        "POST /file-system-replica-links",
-        "POST /file-system-replica-links/policies",
-        "POST /file-systems/audit-policies",
-        "POST /file-systems/locks/nlm-reclamations",
-        "POST /file-systems/policies",
-        "POST /file-systems/user-group-quota-policies",
-        "POST /lifecycle-rules",
-        "POST /log-targets/file-systems",
-        "POST /log-targets/object-store",
-        "POST /management-access-policies",
-        "POST /management-access-policies/admins",
-        "POST /nfs-export-policies/rules",
-        "POST /object-store-access-keys",
-        "POST /object-store-access-policies",
-        "POST /object-store-access-policies/object-store-roles",
-        "POST /object-store-access-policies/object-store-users",
-        "POST /object-store-access-policies/rules",
-        "POST /object-store-account-exports",
-        "POST /object-store-accounts",
-        "POST /object-store-remote-credentials",
-        "POST /object-store-roles",
-        "POST /object-store-roles/object-store-access-policies",
-        "POST /object-store-roles/object-store-trust-policies/rules",
-        "POST /object-store-users",
-        "POST /object-store-users/object-store-access-policies",
-        "POST /object-store-virtual-hosts",
-        "POST /policies/file-system-replica-links",
-        "POST /policies/file-systems",
-        "POST /presets/workload",
-        "POST /qos-policies",
-        "POST /qos-policies/members",
-        "POST /s3-export-policies/rules",
-        "POST /smb-client-policies/rules",
-        "POST /smb-share-policies/rules",
-        "POST /ssh-certificate-authority-policies/admins",
-        "POST /ssh-certificate-authority-policies/arrays",
-        "POST /user-group-quota-policies/file-systems",
-        "POST /workloads",
-        "PUT /presets/workload"
-      ],
-      "annotations": [
-        {
-          "matchType": "field",
-          "match": "context_names",
-          "kind": "designDecision",
-          "note": "implemented in Phase 1 via central injection; still listed as a gap because the drift detector does not resolve the variable-keyed injection site (issue #113)",
-          "reference": "docs/design/fusion-context-phase-1-spec.md"
-        }
-      ]
-    },
     {
       "name": "allow_errors",
       "endpointCount": 118,
@@ -19831,11 +17747,6 @@
     },
     {
       "name": "contact",
-      "cmdletCount": 0,
-      "cmdlets": []
-    },
-    {
-      "name": "context_names",
       "cmdletCount": 0,
       "cmdlets": []
     },

--- a/Reports/PfbApiDriftReport.md
+++ b/Reports/PfbApiDriftReport.md
@@ -21,13 +21,13 @@ This report accepts **false positives in order to eliminate false negatives**. A
 ## Summary
 
 - Uncovered endpoints: 95
-- Endpoints with parameter gaps: 439
+- Endpoints with parameter gaps: 358
 - Missing body properties (addable): 424
-- Missing query parameters (addable): 880
+- Missing query parameters (addable): 569
 - Read-only body fields (not addable -- see the Read-only fields section below): 384
 - Phantom fields silently excluded (accumulated in the capability map, absent from the newest analysed spec): 40
-- Partial-confidence endpoints (see `How to read this report` above, and each row's marker in the Parameter gaps table): 61
-- Systemic gaps (distinct field names collapsed across high-confidence endpoints, detailed below): 241
+- Partial-confidence endpoints (see `How to read this report` above, and each row's marker in the Parameter gaps table): 58
+- Systemic gaps (distinct field names collapsed across high-confidence endpoints, detailed below): 240
 - ValidateSet drift: 0
 - New ValidateSet candidates: 2
 - Context cardinality signal disagreements (fb2.28): 9
@@ -39,11 +39,10 @@ This report accepts **false positives in order to eliminate false negatives**. A
 
 One finding per distinct wire field name, collapsed across every endpoint where a high-confidence gap exists (decision 7) -- turns hundreds of per-endpoint rows into a handful of real, actionable decisions. "Cmdlets already using this name" is decision 8's convention-strength ranking: a high count means closing the remaining gaps for this name is a mechanical batch fix; zero means no established convention exists to extend at all -- closing it is an architectural decision, not a mechanical one.
 
-Showing the top 25 of 241 findings by endpoint count -- the full list is in the JSON manifest's `systemicGaps`, nothing is dropped there.
+Showing the top 25 of 240 findings by endpoint count -- the full list is in the JSON manifest's `systemicGaps`, nothing is dropped there.
 
 | Field name | Endpoints | Query | Body | Cmdlets already using this name | Annotation |
 |---|---|---|---|---|---|
-| `context_names` | 268 | 268 | 0 | 0 | implemented in Phase 1 via central injection; still listed as a gap because the drift detector does not resolve the variable-keyed injection site (issue #113) |
 | `allow_errors` | 118 | 118 | 0 | 0 | not yet implemented; deferred to Phase 2 |
 | `ids` | 38 | 38 | 0 | 220 |  |
 | `sort` | 28 | 28 | 0 | 179 |  |
@@ -68,6 +67,7 @@ Showing the top 25 of 241 findings by endpoint count -- the full list is in the 
 | `gids` | 5 | 5 | 0 | 2 |  |
 | `local_file_system_names` | 5 | 5 | 0 | 5 |  |
 | `policy` | 5 | 0 | 5 | 3 |  |
+| `remote_file_system_ids` | 5 | 5 | 0 | 0 |  |
 
 ## Parameter gaps
 
@@ -76,179 +76,126 @@ Endpoints an existing cmdlet already calls, where the capability map knows of a 
 | Endpoint | Cmdlets | Missing query parameters | Missing body properties | Confidence | Notes |
 |---|---|---|---|---|---|
 | `DELETE /active-directory` | Remove-PfbActiveDirectory | local_only |  | `high` |  |
-| `DELETE /admins/api-tokens` | Remove-PfbApiToken | context_names |  | `high` |  |
-| `DELETE /admins/cache` | Remove-PfbAdminCache | context_names |  | `high` |  |
-| `DELETE /admins/management-access-policies` | Remove-PfbAdminManagementAccessPolicy | context_names |  | `high` | POST/PATCH/DELETE return 403 regardless of account; not an implementation bug |
-| `DELETE /admins/ssh-certificate-authority-policies` | Remove-PfbAdminSshCaPolicy | context_names |  | `high` |  |
-| `DELETE /array-connections` | Remove-PfbArrayConnection | context_names |  | `high` |  |
-| `DELETE /arrays/ssh-certificate-authority-policies` | Remove-PfbArraySshCaPolicy | context_names |  | `high` |  |
-| `DELETE /audit-file-systems-policies` | Remove-PfbAuditFileSystemPolicy | context_names |  | `high` |  |
-| `DELETE /audit-file-systems-policies/members` | Remove-PfbAuditFileSystemPolicyMember | context_names |  | `high` |  |
-| `DELETE /audit-object-store-policies` | Remove-PfbAuditObjectStorePolicy | context_names |  | `high` |  |
-| `DELETE /audit-object-store-policies/members` | Remove-PfbAuditObjectStorePolicyMember | context_names |  | `high` |  |
-| `DELETE /buckets` | Remove-PfbBucket | context_names |  | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
-| `DELETE /buckets/audit-filters` | Remove-PfbBucketAuditFilter | context_names |  | `high` |  |
-| `DELETE /buckets/bucket-access-policies` | Remove-PfbBucketAccessPolicy | context_names |  | `high` |  |
-| `DELETE /buckets/bucket-access-policies/rules` | Remove-PfbBucketAccessPolicyRule | bucket_ids, bucket_names, context_names, policy_names |  | `high` |  |
-| `DELETE /buckets/cross-origin-resource-sharing-policies` | Remove-PfbBucketCorsPolicy | context_names |  | `high` |  |
-| `DELETE /buckets/cross-origin-resource-sharing-policies/rules` | Remove-PfbBucketCorsPolicyRule | bucket_ids, bucket_names, context_names, policy_names |  | `high` |  |
+| `DELETE /buckets/bucket-access-policies/rules` | Remove-PfbBucketAccessPolicyRule | bucket_ids, bucket_names, policy_names |  | `high` |  |
+| `DELETE /buckets/cross-origin-resource-sharing-policies/rules` | Remove-PfbBucketCorsPolicyRule | bucket_ids, bucket_names, policy_names |  | `high` |  |
 | `DELETE /certificates/certificate-groups` | Remove-PfbCertificateCertificateGroup | certificate_group_ids, certificate_ids |  | `high` |  |
-| `DELETE /data-eviction-policies` | Remove-PfbDataEvictionPolicy | context_names |  | `high` |  |
-| `DELETE /data-eviction-policies/file-systems` | Remove-PfbDataEvictionPolicyFileSystem | context_names |  | `high` |  |
-| `DELETE /directory-services/local/groups` | Remove-PfbLocalGroup | context_names, gids, local_directory_service_ids, local_directory_service_names, sids |  | `high` |  |
-| `DELETE /directory-services/local/groups/members` | Remove-PfbLocalGroupMember | context_names, group_gids, group_sids, local_directory_service_ids, local_directory_service_names, member_ids, member_sids, member_types |  | `high` |  |
-| `DELETE /dns` | Remove-PfbDns | context_names |  | `high` |  |
-| `DELETE /file-system-exports` | Remove-PfbFileSystemExport | context_names |  | `high` |  |
-| `DELETE /file-system-replica-links` | Remove-PfbFileSystemReplicaLink | context_names, local_file_system_ids, remote_file_system_ids |  | `high` |  |
-| `DELETE /file-system-replica-links/policies` | Remove-PfbFileSystemReplicaLinkPolicy | context_names, local_file_system_ids, local_file_system_names |  | `high` |  |
-| `DELETE /file-system-snapshots` | Remove-PfbFileSystemSnapshot | context_names |  | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
-| `DELETE /file-system-snapshots/policies` | Remove-PfbFileSystemSnapshotPolicy | context_names |  | `high` |  |
-| `DELETE /file-system-snapshots/transfer` | Remove-PfbFileSystemSnapshotTransfer | context_names |  | `high` |  |
-| `DELETE /file-systems` | Remove-PfbFileSystem | context_names |  | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
-| `DELETE /file-systems/audit-policies` | Remove-PfbFileSystemAuditPolicy | context_names |  | `high` |  |
-| `DELETE /file-systems/locks` | Remove-PfbFileLock | client_names, context_names, file_system_ids, file_system_names, inodes, paths, recursive |  | `high` |  |
-| `DELETE /file-systems/policies` | Remove-PfbFileSystemPolicy | context_names |  | `high` |  |
-| `DELETE /file-systems/sessions` | Remove-PfbFileSystemSession | client_names, context_names, disruptive, user_names |  | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
-| `DELETE /file-systems/user-group-quota-policies` | Remove-PfbFileSystemUserGroupQuotaPolicy | context_names |  | `high` |  |
+| `DELETE /directory-services/local/groups` | Remove-PfbLocalGroup | gids, local_directory_service_ids, local_directory_service_names, sids |  | `high` |  |
+| `DELETE /directory-services/local/groups/members` | Remove-PfbLocalGroupMember | group_gids, group_sids, local_directory_service_ids, local_directory_service_names, member_ids, member_sids, member_types |  | `high` |  |
+| `DELETE /file-system-replica-links` | Remove-PfbFileSystemReplicaLink | local_file_system_ids, remote_file_system_ids |  | `high` |  |
+| `DELETE /file-system-replica-links/policies` | Remove-PfbFileSystemReplicaLinkPolicy | local_file_system_ids, local_file_system_names |  | `high` |  |
+| `DELETE /file-systems/locks` | Remove-PfbFileLock | client_names, file_system_ids, file_system_names, inodes, paths, recursive |  | `high` |  |
+| `DELETE /file-systems/sessions` | Remove-PfbFileSystemSession | client_names, disruptive, user_names |  | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
 | `DELETE /fleets/members` | Remove-PfbFleetMember | member_ids, unreachable |  | `high` |  |
-| `DELETE /lifecycle-rules` | Remove-PfbLifecycleRule | bucket_ids, bucket_names, context_names |  | `high` |  |
-| `DELETE /log-targets/file-systems` | Remove-PfbLogTargetFileSystem | context_names |  | `high` |  |
-| `DELETE /log-targets/object-store` | Remove-PfbLogTargetObjectStore | context_names |  | `high` |  |
-| `DELETE /management-access-policies` | Remove-PfbManagementAccessPolicy | context_names |  | `high` | POST/PATCH/DELETE return 403 regardless of account; not an implementation bug |
-| `DELETE /management-access-policies/admins` | Remove-PfbManagementAccessPolicyAdmin | context_names |  | `high` | POST/PATCH/DELETE return 403 regardless of account; not an implementation bug |
+| `DELETE /lifecycle-rules` | Remove-PfbLifecycleRule | bucket_ids, bucket_names |  | `high` |  |
 | `DELETE /network-access-policies/rules` | Remove-PfbNetworkAccessRule | ids, versions |  | `high` |  |
 | `DELETE /network-interfaces/tls-policies` | Remove-PfbNetworkInterfaceTlsPolicy | member_ids, policy_ids |  | `high` |  |
-| `DELETE /nfs-export-policies` | Remove-PfbNfsExportPolicy | context_names, versions |  | `high` |  |
-| `DELETE /nfs-export-policies/rules` | Remove-PfbNfsExportRule | context_names, ids, versions |  | `high` |  |
+| `DELETE /nfs-export-policies` | Remove-PfbNfsExportPolicy | versions |  | `high` |  |
+| `DELETE /nfs-export-policies/rules` | Remove-PfbNfsExportRule | ids, versions |  | `high` |  |
 | `DELETE /node-groups/nodes` | Remove-PfbNodeGroupNode | node_group_ids, node_group_names, node_ids, node_names |  | `high` |  |
-| `DELETE /object-store-access-keys` | Remove-PfbObjectStoreAccessKey | context_names |  | `high` |  |
-| `DELETE /object-store-access-policies` | Remove-PfbObjectStoreAccessPolicy | context_names |  | `high` |  |
-| `DELETE /object-store-access-policies/object-store-roles` | Remove-PfbObjectStoreAccessPolicyRole | context_names, member_ids, policy_ids |  | `high` |  |
-| `DELETE /object-store-access-policies/object-store-users` | Remove-PfbObjectStoreAccessPolicyUser | context_names, member_ids, policy_ids |  | `high` |  |
-| `DELETE /object-store-access-policies/rules` | Remove-PfbObjectStoreAccessPolicyRule | context_names, policy_ids |  | `high` |  |
-| `DELETE /object-store-account-exports` | Remove-PfbObjectStoreAccountExport | context_names |  | `high` |  |
-| `DELETE /object-store-accounts` | Remove-PfbObjectStoreAccount | context_names |  | `high` |  |
-| `DELETE /object-store-remote-credentials` | Remove-PfbObjectStoreRemoteCredential | context_names |  | `high` |  |
-| `DELETE /object-store-roles` | Remove-PfbObjectStoreRole | context_names |  | `high` |  |
-| `DELETE /object-store-roles/object-store-access-policies` | Remove-PfbObjectStoreRoleAccessPolicy | context_names, member_ids, policy_ids, policy_names |  | `high` |  |
-| `DELETE /object-store-roles/object-store-trust-policies/rules` | Remove-PfbObjectStoreTrustPolicyRule | context_names, indices, role_ids, role_names |  | `high` |  |
-| `DELETE /object-store-users` | Remove-PfbObjectStoreUser | context_names |  | `high` |  |
-| `DELETE /object-store-users/object-store-access-policies` | Remove-PfbObjectStoreUserAccessPolicy | context_names, member_ids, policy_ids |  | `high` |  |
-| `DELETE /object-store-virtual-hosts` | Remove-PfbObjectStoreVirtualHost | context_names |  | `high` |  |
-| `DELETE /policies` | Remove-PfbPolicy | context_names |  | `high` |  |
-| `DELETE /policies/file-system-replica-links` | Remove-PfbPolicyFileSystemReplicaLink | context_names, local_file_system_ids, local_file_system_names |  | `high` |  |
-| `DELETE /policies/file-systems` | Remove-PfbPolicyFileSystem | context_names |  | `high` |  |
-| `DELETE /presets/workload` | Remove-PfbPresetWorkload | context_names |  | `high` |  |
-| `DELETE /qos-policies` | Remove-PfbQosPolicy | context_names |  | `high` |  |
-| `DELETE /qos-policies/members` | Remove-PfbQosPolicyMember | context_names, member_types |  | `high` |  |
-| `DELETE /quotas/groups` | Remove-PfbQuotaGroup | context_names, file_system_ids, file_system_names, gids, group_names, names |  | `partial` -- /!\ 3 unresolved params (see Partial-confidence detail below) |  |
-| `DELETE /quotas/users` | Remove-PfbQuotaUser | context_names, file_system_ids, file_system_names, names, uids, user_names |  | `partial` -- /!\ 2 unresolved params (see Partial-confidence detail below) |  |
-| `DELETE /s3-export-policies` | Remove-PfbS3ExportPolicy | context_names |  | `high` |  |
-| `DELETE /s3-export-policies/rules` | Remove-PfbS3ExportRule | context_names |  | `high` |  |
+| `DELETE /object-store-access-policies/object-store-roles` | Remove-PfbObjectStoreAccessPolicyRole | member_ids, policy_ids |  | `high` |  |
+| `DELETE /object-store-access-policies/object-store-users` | Remove-PfbObjectStoreAccessPolicyUser | member_ids, policy_ids |  | `high` |  |
+| `DELETE /object-store-access-policies/rules` | Remove-PfbObjectStoreAccessPolicyRule | policy_ids |  | `high` |  |
+| `DELETE /object-store-roles/object-store-access-policies` | Remove-PfbObjectStoreRoleAccessPolicy | member_ids, policy_ids, policy_names |  | `high` |  |
+| `DELETE /object-store-roles/object-store-trust-policies/rules` | Remove-PfbObjectStoreTrustPolicyRule | indices, role_ids, role_names |  | `high` |  |
+| `DELETE /object-store-users/object-store-access-policies` | Remove-PfbObjectStoreUserAccessPolicy | member_ids, policy_ids |  | `high` |  |
+| `DELETE /policies/file-system-replica-links` | Remove-PfbPolicyFileSystemReplicaLink | local_file_system_ids, local_file_system_names |  | `high` |  |
+| `DELETE /qos-policies/members` | Remove-PfbQosPolicyMember | member_types |  | `high` |  |
+| `DELETE /quotas/groups` | Remove-PfbQuotaGroup | file_system_ids, file_system_names, gids, group_names, names |  | `partial` -- /!\ 3 unresolved params (see Partial-confidence detail below) |  |
+| `DELETE /quotas/users` | Remove-PfbQuotaUser | file_system_ids, file_system_names, names, uids, user_names |  | `partial` -- /!\ 2 unresolved params (see Partial-confidence detail below) |  |
 | `DELETE /servers` | Remove-PfbServer | cascade_delete |  | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
-| `DELETE /smb-client-policies` | Remove-PfbSmbClientPolicy | context_names |  | `high` |  |
-| `DELETE /smb-client-policies/rules` | Remove-PfbSmbClientRule | context_names, ids, versions |  | `high` |  |
-| `DELETE /smb-share-policies` | Remove-PfbSmbSharePolicy | context_names |  | `high` |  |
-| `DELETE /smb-share-policies/rules` | Remove-PfbSmbShareRule | context_names, ids |  | `high` |  |
-| `DELETE /ssh-certificate-authority-policies/admins` | Remove-PfbSshCaPolicyAdmin | context_names |  | `high` |  |
-| `DELETE /ssh-certificate-authority-policies/arrays` | Remove-PfbSshCaPolicyArray | context_names |  | `high` |  |
-| `DELETE /user-group-quota-policies` | Remove-PfbUserGroupQuotaPolicy | context_names |  | `high` |  |
-| `DELETE /user-group-quota-policies/file-systems` | Remove-PfbUserGroupQuotaPolicyFileSystem | context_names |  | `high` |  |
-| `DELETE /user-group-quota-policies/rules` | Remove-PfbUserGroupQuotaPolicyRule | context_names |  | `high` |  |
-| `DELETE /workloads` | Remove-PfbWorkload | context_names |  | `high` |  |
-| `DELETE /workloads/tags` | Remove-PfbWorkloadTag | context_names |  | `high` |  |
-| `DELETE /worm-data-policies` | Remove-PfbWormPolicy | context_names |  | `high` |  |
+| `DELETE /smb-client-policies/rules` | Remove-PfbSmbClientRule | ids, versions |  | `high` |  |
+| `DELETE /smb-share-policies/rules` | Remove-PfbSmbShareRule | ids |  | `high` |  |
 | `GET /active-directory` | Get-PfbActiveDirectory | ids, limit, sort |  | `high` |  |
-| `GET /active-directory/test` | Test-PfbActiveDirectory | allow_errors, context_names, filter, limit, sort |  | `high` |  |
-| `GET /admins` | Get-PfbAdmin, Resolve-PfbAdminLocality | allow_errors, context_names, expose_api_token |  | `high` |  |
-| `GET /admins/api-tokens` | Get-PfbApiToken | allow_errors, context_names |  | `high` |  |
-| `GET /admins/cache` | Get-PfbAdminCache | allow_errors, context_names, refresh |  | `high` |  |
-| `GET /admins/management-access-policies` | Get-PfbAdminManagementAccessPolicy | allow_errors, context_names, sort |  | `high` | POST/PATCH/DELETE return 403 regardless of account; not an implementation bug |
-| `GET /admins/ssh-certificate-authority-policies` | Get-PfbAdminSshCaPolicy | allow_errors, context_names, sort |  | `high` |  |
+| `GET /active-directory/test` | Test-PfbActiveDirectory | allow_errors, filter, limit, sort |  | `high` |  |
+| `GET /admins` | Get-PfbAdmin | allow_errors, expose_api_token |  | `high` |  |
+| `GET /admins/api-tokens` | Get-PfbApiToken | allow_errors |  | `high` |  |
+| `GET /admins/cache` | Get-PfbAdminCache | allow_errors, refresh |  | `high` |  |
+| `GET /admins/management-access-policies` | Get-PfbAdminManagementAccessPolicy | allow_errors, sort |  | `high` | POST/PATCH/DELETE return 403 regardless of account; not an implementation bug |
+| `GET /admins/ssh-certificate-authority-policies` | Get-PfbAdminSshCaPolicy | allow_errors, sort |  | `high` |  |
 | `GET /alert-watchers/test` | Test-PfbAlertWatcher | filter, sort |  | `high` |  |
-| `GET /array-connections` | Get-PfbArrayConnection | allow_errors, context_names |  | `high` |  |
+| `GET /array-connections` | Get-PfbArrayConnection | allow_errors |  | `high` |  |
 | `GET /array-connections/connection-key` | Get-PfbArrayConnectionKey | ids |  | `high` |  |
-| `GET /array-connections/path` | Get-PfbArrayConnectionPath | allow_errors, context_names |  | `high` |  |
+| `GET /array-connections/path` | Get-PfbArrayConnectionPath | allow_errors |  | `high` |  |
 | `GET /array-connections/performance/replication` | Get-PfbArrayConnectionPerformanceReplication | total_only |  | `high` |  |
-| `GET /arrays` | Get-PfbArray, Test-PfbConnection | allow_errors, context_names |  | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
+| `GET /arrays` | Get-PfbArray, Test-PfbConnection | allow_errors |  | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
 | `GET /arrays/clients/performance` | Get-PfbArrayClientPerformance | names, protocol, total_only |  | `high` |  |
 | `GET /arrays/clients/s3-specific-performance` | Get-PfbArrayClientS3Performance | names, total_only |  | `high` |  |
-| `GET /arrays/http-specific-performance` | Get-PfbArrayHttpPerformance | allow_errors, context_names |  | `high` |  |
-| `GET /arrays/nfs-specific-performance` | Get-PfbArrayNfsPerformance | allow_errors, context_names |  | `high` |  |
-| `GET /arrays/performance` | Get-PfbArrayPerformance | allow_errors, context_names |  | `high` |  |
-| `GET /arrays/performance/replication` | Get-PfbArrayPerformanceReplication | allow_errors, context_names |  | `high` |  |
-| `GET /arrays/s3-specific-performance` | Get-PfbArrayS3Performance | allow_errors, context_names |  | `high` |  |
-| `GET /arrays/space` | Get-PfbArraySpace | allow_errors, context_names, end_time, resolution, start_time |  | `high` |  |
+| `GET /arrays/http-specific-performance` | Get-PfbArrayHttpPerformance | allow_errors |  | `high` |  |
+| `GET /arrays/nfs-specific-performance` | Get-PfbArrayNfsPerformance | allow_errors |  | `high` |  |
+| `GET /arrays/performance` | Get-PfbArrayPerformance | allow_errors |  | `high` |  |
+| `GET /arrays/performance/replication` | Get-PfbArrayPerformanceReplication | allow_errors |  | `high` |  |
+| `GET /arrays/s3-specific-performance` | Get-PfbArrayS3Performance | allow_errors |  | `high` |  |
+| `GET /arrays/space` | Get-PfbArraySpace | allow_errors, end_time, resolution, start_time |  | `high` |  |
 | `GET /arrays/space/storage-classes` | Get-PfbArrayStorageClass | end_time, resolution, start_time, storage_class_names, total_only |  | `high` |  |
-| `GET /arrays/ssh-certificate-authority-policies` | Get-PfbArraySshCaPolicy | allow_errors, context_names, sort |  | `high` |  |
+| `GET /arrays/ssh-certificate-authority-policies` | Get-PfbArraySshCaPolicy | allow_errors, sort |  | `high` |  |
 | `GET /arrays/supported-time-zones` | Get-PfbArraySupportedTimeZone | names |  | `high` |  |
-| `GET /audit-file-systems-policies` | Get-PfbAuditFileSystemPolicy | allow_errors, context_names |  | `high` |  |
-| `GET /audit-file-systems-policies/members` | Get-PfbAuditFileSystemPolicyMember | allow_errors, context_names |  | `high` |  |
-| `GET /audit-file-systems-policy-operations` | Get-PfbAuditFileSystemPolicyOperation | allow_errors, context_names, names |  | `high` |  |
-| `GET /audit-object-store-policies` | Get-PfbAuditObjectStorePolicy | allow_errors, context_names |  | `high` |  |
-| `GET /audit-object-store-policies/members` | Get-PfbAuditObjectStorePolicyMember | allow_errors, context_names |  | `high` |  |
-| `GET /audits` | Get-PfbAudit | allow_errors, context_names |  | `high` |  |
+| `GET /audit-file-systems-policies` | Get-PfbAuditFileSystemPolicy | allow_errors |  | `high` |  |
+| `GET /audit-file-systems-policies/members` | Get-PfbAuditFileSystemPolicyMember | allow_errors |  | `high` |  |
+| `GET /audit-file-systems-policy-operations` | Get-PfbAuditFileSystemPolicyOperation | allow_errors, names |  | `high` |  |
+| `GET /audit-object-store-policies` | Get-PfbAuditObjectStorePolicy | allow_errors |  | `high` |  |
+| `GET /audit-object-store-policies/members` | Get-PfbAuditObjectStorePolicyMember | allow_errors |  | `high` |  |
+| `GET /audits` | Get-PfbAudit | allow_errors |  | `high` |  |
 | `GET /blades` | Get-PfbBlade, Get-PfbNode | total_only |  | `high` |  |
-| `GET /bucket-audit-filter-actions` | Get-PfbBucketAuditFilterAction | allow_errors, context_names, names |  | `high` |  |
-| `GET /bucket-replica-links` | Get-PfbBucketReplicaLink | allow_errors, context_names, local_bucket_ids, total_only |  | `high` |  |
-| `GET /buckets` | Get-PfbBucket | allow_errors, context_names |  | `high` |  |
-| `GET /buckets/audit-filters` | Get-PfbBucketAuditFilter | allow_errors, context_names |  | `high` |  |
-| `GET /buckets/bucket-access-policies` | Get-PfbBucketAccessPolicy | allow_errors, context_names |  | `high` |  |
-| `GET /buckets/bucket-access-policies/rules` | Get-PfbBucketAccessPolicyRule | allow_errors, bucket_ids, context_names |  | `high` |  |
-| `GET /buckets/cross-origin-resource-sharing-policies` | Get-PfbBucketCorsPolicy | allow_errors, context_names |  | `high` |  |
-| `GET /buckets/cross-origin-resource-sharing-policies/rules` | Get-PfbBucketCorsPolicyRule | allow_errors, bucket_ids, context_names |  | `high` |  |
+| `GET /bucket-audit-filter-actions` | Get-PfbBucketAuditFilterAction | allow_errors, names |  | `high` |  |
+| `GET /bucket-replica-links` | Get-PfbBucketReplicaLink | allow_errors, local_bucket_ids, total_only |  | `high` |  |
+| `GET /buckets` | Get-PfbBucket | allow_errors |  | `high` |  |
+| `GET /buckets/audit-filters` | Get-PfbBucketAuditFilter | allow_errors |  | `high` |  |
+| `GET /buckets/bucket-access-policies` | Get-PfbBucketAccessPolicy | allow_errors |  | `high` |  |
+| `GET /buckets/bucket-access-policies/rules` | Get-PfbBucketAccessPolicyRule | allow_errors, bucket_ids |  | `high` |  |
+| `GET /buckets/cross-origin-resource-sharing-policies` | Get-PfbBucketCorsPolicy | allow_errors |  | `high` |  |
+| `GET /buckets/cross-origin-resource-sharing-policies/rules` | Get-PfbBucketCorsPolicyRule | allow_errors, bucket_ids |  | `high` |  |
 | `GET /certificate-groups/certificates` | Get-PfbCertificateGroupCertificate | certificate_group_names, certificate_ids |  | `high` |  |
 | `GET /certificate-groups/uses` | Get-PfbCertificateGroupUse | ids |  | `high` |  |
 | `GET /certificates/certificate-groups` | Get-PfbCertificateCertificateGroup | certificate_group_ids, certificate_ids, sort |  | `high` |  |
 | `GET /certificates/uses` | Get-PfbCertificateUse | ids |  | `high` |  |
-| `GET /data-eviction-policies` | Get-PfbDataEvictionPolicy | allow_errors, context_names |  | `high` |  |
-| `GET /data-eviction-policies/file-systems` | Get-PfbDataEvictionPolicyFileSystem | allow_errors, context_names |  | `high` |  |
-| `GET /data-eviction-policies/members` | Get-PfbDataEvictionPolicyMember | allow_errors, context_names |  | `high` |  |
+| `GET /data-eviction-policies` | Get-PfbDataEvictionPolicy | allow_errors |  | `high` |  |
+| `GET /data-eviction-policies/file-systems` | Get-PfbDataEvictionPolicyFileSystem | allow_errors |  | `high` |  |
+| `GET /data-eviction-policies/members` | Get-PfbDataEvictionPolicyMember | allow_errors |  | `high` |  |
 | `GET /directory-services` | Get-PfbDirectoryService | ids, limit, sort |  | `high` |  |
-| `GET /directory-services/local/directory-services` | Get-PfbLocalDirectoryService | allow_errors, context_names, destroyed, total_item_count |  | `high` |  |
-| `GET /directory-services/local/groups` | Get-PfbLocalGroup | allow_errors, context_names, gids, sids, total_item_count |  | `high` |  |
-| `GET /directory-services/local/groups/members` | Get-PfbLocalGroupMember | allow_errors, context_names, group_gids, group_sids, member_ids, member_sids, member_types, total_item_count |  | `high` |  |
+| `GET /directory-services/local/directory-services` | Get-PfbLocalDirectoryService | allow_errors, destroyed, total_item_count |  | `high` |  |
+| `GET /directory-services/local/groups` | Get-PfbLocalGroup | allow_errors, gids, sids, total_item_count |  | `high` |  |
+| `GET /directory-services/local/groups/members` | Get-PfbLocalGroupMember | allow_errors, group_gids, group_sids, member_ids, member_sids, member_types, total_item_count |  | `high` |  |
 | `GET /directory-services/roles` | Get-PfbDirectoryServiceRole | role_ids, role_names |  | `high` |  |
 | `GET /directory-services/roles/management-access-policies` | Get-PfbDirectoryServiceRoleManagementPolicy | sort |  | `high` | POST/PATCH/DELETE return 403 regardless of account; not an implementation bug |
-| `GET /directory-services/test` | Test-PfbDirectoryService | allow_errors, context_names, filter, ids, limit, names, sort |  | `high` |  |
-| `GET /dns` | Get-PfbDns | allow_errors, context_names, ids, names |  | `high` |  |
+| `GET /directory-services/test` | Test-PfbDirectoryService | allow_errors, filter, ids, limit, names, sort |  | `high` |  |
+| `GET /dns` | Get-PfbDns | allow_errors, ids, names |  | `high` |  |
 | `GET /drives` | Get-PfbDrive | total_only |  | `high` |  |
-| `GET /file-system-exports` | Get-PfbFileSystemExport | allow_errors, context_names, workload_ids, workload_names |  | `high` |  |
-| `GET /file-system-group-quotas` | Get-PfbFileSystemGroupQuota | allow_errors, context_names |  | `high` |  |
-| `GET /file-system-replica-links` | Get-PfbFileSystemReplicaLink | allow_errors, context_names, local_file_system_ids, remote_file_system_ids |  | `high` |  |
-| `GET /file-system-replica-links/policies` | Get-PfbFileSystemReplicaLinkPolicy | allow_errors, context_names, local_file_system_ids, local_file_system_names, remote_file_system_ids, remote_file_system_names |  | `high` |  |
-| `GET /file-system-replica-links/transfer` | Get-PfbFileSystemReplicaLinkTransfer | allow_errors, context_names |  | `high` |  |
-| `GET /file-system-snapshots` | Get-PfbFileSystemSnapshot | allow_errors, context_names, names_or_owner_names, owner_ids |  | `high` |  |
-| `GET /file-system-snapshots/policies` | Get-PfbFileSystemSnapshotPolicy | allow_errors, context_names |  | `high` |  |
-| `GET /file-system-snapshots/transfer` | Get-PfbFileSystemSnapshotTransfer | allow_errors, context_names, names_or_owner_names |  | `high` |  |
-| `GET /file-system-user-quotas` | Get-PfbFileSystemUserQuota | allow_errors, context_names |  | `high` |  |
-| `GET /file-systems` | Get-PfbFileSystem | allow_errors, context_names, workload_ids, workload_names |  | `high` |  |
-| `GET /file-systems/audit-policies` | Get-PfbFileSystemAuditPolicy | allow_errors, context_names |  | `high` |  |
-| `GET /file-systems/groups` | Get-PfbFileSystemGroup | allow_errors, context_names |  | `high` |  |
+| `GET /file-system-exports` | Get-PfbFileSystemExport | allow_errors, workload_ids, workload_names |  | `high` |  |
+| `GET /file-system-group-quotas` | Get-PfbFileSystemGroupQuota | allow_errors |  | `high` |  |
+| `GET /file-system-replica-links` | Get-PfbFileSystemReplicaLink | allow_errors, local_file_system_ids, remote_file_system_ids |  | `high` |  |
+| `GET /file-system-replica-links/policies` | Get-PfbFileSystemReplicaLinkPolicy | allow_errors, local_file_system_ids, local_file_system_names, remote_file_system_ids, remote_file_system_names |  | `high` |  |
+| `GET /file-system-replica-links/transfer` | Get-PfbFileSystemReplicaLinkTransfer | allow_errors |  | `high` |  |
+| `GET /file-system-snapshots` | Get-PfbFileSystemSnapshot | allow_errors, names_or_owner_names, owner_ids |  | `high` |  |
+| `GET /file-system-snapshots/policies` | Get-PfbFileSystemSnapshotPolicy | allow_errors |  | `high` |  |
+| `GET /file-system-snapshots/transfer` | Get-PfbFileSystemSnapshotTransfer | allow_errors, names_or_owner_names |  | `high` |  |
+| `GET /file-system-user-quotas` | Get-PfbFileSystemUserQuota | allow_errors |  | `high` |  |
+| `GET /file-systems` | Get-PfbFileSystem | allow_errors, workload_ids, workload_names |  | `high` |  |
+| `GET /file-systems/audit-policies` | Get-PfbFileSystemAuditPolicy | allow_errors |  | `high` |  |
+| `GET /file-systems/groups` | Get-PfbFileSystemGroup | allow_errors |  | `high` |  |
 | `GET /file-systems/groups/performance` | Get-PfbFileSystemGroupPerformance | gids, group_names, names |  | `high` |  |
-| `GET /file-systems/locks` | Get-PfbFileLock | allow_errors, client_names, context_names, file_system_ids, file_system_names, inodes, paths |  | `high` |  |
-| `GET /file-systems/locks/clients` | Get-PfbFileLockClient | allow_errors, context_names |  | `high` |  |
+| `GET /file-systems/locks` | Get-PfbFileLock | allow_errors, client_names, file_system_ids, file_system_names, inodes, paths |  | `high` |  |
+| `GET /file-systems/locks/clients` | Get-PfbFileLockClient | allow_errors |  | `high` |  |
 | `GET /file-systems/open-files` | Get-PfbOpenFile | client_names, file_system_ids, file_system_names, paths, protocols, session_names, user_names |  | `high` |  |
-| `GET /file-systems/policies` | Get-PfbFileSystemPolicy | allow_errors, context_names |  | `high` |  |
-| `GET /file-systems/sessions` | Get-PfbFileSystemSession | allow_errors, client_names, context_names, user_names |  | `high` |  |
+| `GET /file-systems/policies` | Get-PfbFileSystemPolicy | allow_errors |  | `high` |  |
+| `GET /file-systems/sessions` | Get-PfbFileSystemSession | allow_errors, client_names, user_names |  | `high` |  |
 | `GET /file-systems/space/storage-classes` | Get-PfbFileSystemStorageClass | storage_class_names |  | `high` |  |
-| `GET /file-systems/user-group-quota-policies` | Get-PfbFileSystemUserGroupQuotaPolicy | allow_errors, context_names |  | `high` |  |
-| `GET /file-systems/users` | Get-PfbFileSystemUser | allow_errors, context_names |  | `high` |  |
+| `GET /file-systems/user-group-quota-policies` | Get-PfbFileSystemUserGroupQuotaPolicy | allow_errors |  | `high` |  |
+| `GET /file-systems/users` | Get-PfbFileSystemUser | allow_errors |  | `high` |  |
 | `GET /file-systems/users/performance` | Get-PfbFileSystemUserPerformance | names, uids, user_names |  | `high` |  |
-| `GET /file-systems/worm-data-policies` | Get-PfbFileSystemWormPolicy | allow_errors, context_names |  | `high` |  |
+| `GET /file-systems/worm-data-policies` | Get-PfbFileSystemWormPolicy | allow_errors |  | `high` |  |
 | `GET /fleets` | Get-PfbFleet | total_only |  | `high` |  |
 | `GET /fleets/fleet-key` | Get-PfbFleetKey | total_only |  | `high` |  |
 | `GET /fleets/members` | Get-PfbFleetMember | fleet_ids, member_ids, total_only |  | `high` |  |
 | `GET /hardware-connectors/performance` | Get-PfbHardwareConnectorPerformance | ids, total_only |  | `high` |  |
 | `GET /keytabs/download` | Get-PfbKeytabDownload | keytab_ids, keytab_names |  | `high` |  |
 | `GET /legal-holds/held-entities` | Get-PfbLegalHoldEntity | file_system_ids, file_system_names, ids, names, paths |  | `high` |  |
-| `GET /lifecycle-rules` | Get-PfbLifecycleRule | allow_errors, bucket_ids, context_names |  | `high` |  |
-| `GET /log-targets/file-systems` | Get-PfbLogTargetFileSystem | allow_errors, context_names |  | `high` |  |
-| `GET /log-targets/object-store` | Get-PfbLogTargetObjectStore | allow_errors, context_names |  | `high` |  |
-| `GET /management-access-policies` | Get-PfbManagementAccessPolicy | allow_errors, context_names |  | `high` | POST/PATCH/DELETE return 403 regardless of account; not an implementation bug |
-| `GET /management-access-policies/admins` | Get-PfbManagementAccessPolicyAdmin | allow_errors, context_names, sort |  | `high` | POST/PATCH/DELETE return 403 regardless of account; not an implementation bug |
+| `GET /lifecycle-rules` | Get-PfbLifecycleRule | allow_errors, bucket_ids |  | `high` |  |
+| `GET /log-targets/file-systems` | Get-PfbLogTargetFileSystem | allow_errors |  | `high` |  |
+| `GET /log-targets/object-store` | Get-PfbLogTargetObjectStore | allow_errors |  | `high` |  |
+| `GET /management-access-policies` | Get-PfbManagementAccessPolicy | allow_errors |  | `high` | POST/PATCH/DELETE return 403 regardless of account; not an implementation bug |
+| `GET /management-access-policies/admins` | Get-PfbManagementAccessPolicyAdmin | allow_errors, sort |  | `high` | POST/PATCH/DELETE return 403 regardless of account; not an implementation bug |
 | `GET /management-access-policies/directory-services/roles` | Get-PfbManagementAccessPolicyDirectoryRole | sort |  | `high` | POST/PATCH/DELETE return 403 regardless of account; not an implementation bug |
-| `GET /management-access-policies/members` | Get-PfbManagementAccessPolicyMember | allow_errors, context_names, sort |  | `high` | POST/PATCH/DELETE return 403 regardless of account; not an implementation bug |
+| `GET /management-access-policies/members` | Get-PfbManagementAccessPolicyMember | allow_errors, sort |  | `high` | POST/PATCH/DELETE return 403 regardless of account; not an implementation bug |
 | `GET /network-access-policies/rules` | Get-PfbNetworkAccessRule | ids |  | `high` |  |
 | `GET /network-interfaces/connectors/performance` | Get-PfbNetworkInterfaceConnectorPerformance | ids, total_only |  | `high` |  |
 | `GET /network-interfaces/connectors/settings` | Get-PfbNetworkInterfaceConnectorSettings | ids |  | `high` |  |
@@ -256,143 +203,138 @@ Endpoints an existing cmdlet already calls, where the capability map knows of a 
 | `GET /network-interfaces/network-connection-statistics` | Get-PfbNetworkConnectionStatistics | current_state, local_host, local_port, remote_host, remote_port |  | `high` |  |
 | `GET /network-interfaces/ping` | Invoke-PfbNetworkPing | component_name, print_latency, resolve_hostname |  | `high` |  |
 | `GET /network-interfaces/trace` | Invoke-PfbNetworkTrace | component_name, discover_mtu, fragment_packet, port, resolve_hostname |  | `high` |  |
-| `GET /nfs-export-policies` | Get-PfbNfsExportPolicy | allow_errors, context_names, workload_ids, workload_names |  | `high` |  |
-| `GET /nfs-export-policies/rules` | Get-PfbNfsExportRule | allow_errors, context_names, ids |  | `high` |  |
+| `GET /nfs-export-policies` | Get-PfbNfsExportPolicy | allow_errors, workload_ids, workload_names |  | `high` |  |
+| `GET /nfs-export-policies/rules` | Get-PfbNfsExportRule | allow_errors, ids |  | `high` |  |
 | `GET /node-groups/nodes` | Get-PfbNodeGroupNode | node_group_ids, node_group_names, node_ids, node_names |  | `high` |  |
 | `GET /node-groups/uses` | Get-PfbNodeGroupUse | ids |  | `high` |  |
 | `GET /nodes` | Get-PfbNode | total_only |  | `high` |  |
-| `GET /object-store-access-keys` | Get-PfbObjectStoreAccessKey | allow_errors, context_names |  | `high` |  |
-| `GET /object-store-access-policies` | Get-PfbObjectStoreAccessPolicy | allow_errors, context_names, exclude_rules |  | `high` |  |
-| `GET /object-store-access-policies/object-store-roles` | Get-PfbObjectStoreAccessPolicyRole | allow_errors, context_names |  | `high` |  |
-| `GET /object-store-access-policies/object-store-users` | Get-PfbObjectStoreAccessPolicyUser | allow_errors, context_names |  | `high` |  |
-| `GET /object-store-access-policies/rules` | Get-PfbObjectStoreAccessPolicyRule | allow_errors, context_names |  | `high` |  |
-| `GET /object-store-access-policy-actions` | Get-PfbObjectStoreAccessPolicyAction | allow_errors, context_names, names |  | `high` |  |
-| `GET /object-store-account-exports` | Get-PfbObjectStoreAccountExport | allow_errors, context_names |  | `high` |  |
-| `GET /object-store-accounts` | Get-PfbObjectStoreAccount | allow_errors, context_names |  | `high` |  |
-| `GET /object-store-remote-credentials` | Get-PfbObjectStoreRemoteCredential | allow_errors, context_names |  | `high` |  |
-| `GET /object-store-roles` | Get-PfbObjectStoreRole | allow_errors, context_names |  | `high` |  |
-| `GET /object-store-roles/object-store-access-policies` | Get-PfbObjectStoreRoleAccessPolicy | allow_errors, context_names, policy_ids, policy_names |  | `high` |  |
-| `GET /object-store-roles/object-store-trust-policies` | Get-PfbObjectStoreTrustPolicy | allow_errors, context_names, names |  | `high` |  |
-| `GET /object-store-roles/object-store-trust-policies/rules` | Get-PfbObjectStoreTrustPolicyRule | allow_errors, context_names, indices, role_ids, role_names |  | `high` |  |
-| `GET /object-store-users` | Get-PfbObjectStoreUser | allow_errors, context_names |  | `high` |  |
-| `GET /object-store-users/object-store-access-policies` | Get-PfbObjectStoreUserAccessPolicy | allow_errors, context_names |  | `high` |  |
-| `GET /object-store-virtual-hosts` | Get-PfbObjectStoreVirtualHost | allow_errors, context_names |  | `high` |  |
+| `GET /object-store-access-keys` | Get-PfbObjectStoreAccessKey | allow_errors |  | `high` |  |
+| `GET /object-store-access-policies` | Get-PfbObjectStoreAccessPolicy | allow_errors, exclude_rules |  | `high` |  |
+| `GET /object-store-access-policies/object-store-roles` | Get-PfbObjectStoreAccessPolicyRole | allow_errors |  | `high` |  |
+| `GET /object-store-access-policies/object-store-users` | Get-PfbObjectStoreAccessPolicyUser | allow_errors |  | `high` |  |
+| `GET /object-store-access-policies/rules` | Get-PfbObjectStoreAccessPolicyRule | allow_errors |  | `high` |  |
+| `GET /object-store-access-policy-actions` | Get-PfbObjectStoreAccessPolicyAction | allow_errors, names |  | `high` |  |
+| `GET /object-store-account-exports` | Get-PfbObjectStoreAccountExport | allow_errors |  | `high` |  |
+| `GET /object-store-accounts` | Get-PfbObjectStoreAccount | allow_errors |  | `high` |  |
+| `GET /object-store-remote-credentials` | Get-PfbObjectStoreRemoteCredential | allow_errors |  | `high` |  |
+| `GET /object-store-roles` | Get-PfbObjectStoreRole | allow_errors |  | `high` |  |
+| `GET /object-store-roles/object-store-access-policies` | Get-PfbObjectStoreRoleAccessPolicy | allow_errors, policy_ids, policy_names |  | `high` |  |
+| `GET /object-store-roles/object-store-trust-policies` | Get-PfbObjectStoreTrustPolicy | allow_errors, names |  | `high` |  |
+| `GET /object-store-roles/object-store-trust-policies/rules` | Get-PfbObjectStoreTrustPolicyRule | allow_errors, indices, role_ids, role_names |  | `high` |  |
+| `GET /object-store-users` | Get-PfbObjectStoreUser | allow_errors |  | `high` |  |
+| `GET /object-store-users/object-store-access-policies` | Get-PfbObjectStoreUserAccessPolicy | allow_errors |  | `high` |  |
+| `GET /object-store-virtual-hosts` | Get-PfbObjectStoreVirtualHost | allow_errors |  | `high` |  |
 | `GET /password-policies` | Get-PfbPasswordPolicy | ids, names |  | `high` |  |
-| `GET /policies` | Get-PfbPolicy | allow_errors, context_names, workload_ids, workload_names |  | `high` |  |
-| `GET /policies-all` | Get-PfbPolicyAll | allow_errors, context_names |  | `high` |  |
-| `GET /policies-all/members` | Get-PfbPolicyAllMember | allow_errors, context_names, local_file_system_ids, local_file_system_names, remote_file_system_ids, remote_file_system_names, sort |  | `high` |  |
-| `GET /policies/file-system-replica-links` | Get-PfbPolicyFileSystemReplicaLink | allow_errors, context_names, local_file_system_ids, local_file_system_names, remote_file_system_ids, remote_file_system_names, sort |  | `high` |  |
-| `GET /policies/file-system-snapshots` | Get-PfbPolicyFileSystemSnapshot | allow_errors, context_names |  | `high` |  |
-| `GET /policies/file-systems` | Get-PfbPolicyFileSystem | allow_errors, context_names |  | `high` |  |
-| `GET /presets/workload` | Get-PfbPresetWorkload | context_names |  | `high` |  |
+| `GET /policies` | Get-PfbPolicy | allow_errors, workload_ids, workload_names |  | `high` |  |
+| `GET /policies-all` | Get-PfbPolicyAll | allow_errors |  | `high` |  |
+| `GET /policies-all/members` | Get-PfbPolicyAllMember | allow_errors, local_file_system_ids, local_file_system_names, remote_file_system_ids, remote_file_system_names, sort |  | `high` |  |
+| `GET /policies/file-system-replica-links` | Get-PfbPolicyFileSystemReplicaLink | allow_errors, local_file_system_ids, local_file_system_names, remote_file_system_ids, remote_file_system_names, sort |  | `high` |  |
+| `GET /policies/file-system-snapshots` | Get-PfbPolicyFileSystemSnapshot | allow_errors |  | `high` |  |
+| `GET /policies/file-systems` | Get-PfbPolicyFileSystem | allow_errors |  | `high` |  |
 | `GET /public-keys/uses` | Get-PfbPublicKeyUse | ids |  | `high` |  |
-| `GET /qos-policies` | Get-PfbQosPolicy | allow_errors, context_names |  | `high` |  |
-| `GET /qos-policies/buckets` | Get-PfbQosPolicyBucket | allow_errors, context_names, sort |  | `high` |  |
-| `GET /qos-policies/file-systems` | Get-PfbQosPolicyFileSystem | allow_errors, context_names, sort |  | `high` |  |
-| `GET /qos-policies/members` | Get-PfbQosPolicyMember | allow_errors, context_names, member_types, sort |  | `high` |  |
-| `GET /quotas/groups` | Get-PfbQuotaGroup | allow_errors, context_names, file_system_ids, gids, group_names |  | `high` |  |
+| `GET /qos-policies` | Get-PfbQosPolicy | allow_errors |  | `high` |  |
+| `GET /qos-policies/buckets` | Get-PfbQosPolicyBucket | allow_errors, sort |  | `high` |  |
+| `GET /qos-policies/file-systems` | Get-PfbQosPolicyFileSystem | allow_errors, sort |  | `high` |  |
+| `GET /qos-policies/members` | Get-PfbQosPolicyMember | allow_errors, member_types, sort |  | `high` |  |
+| `GET /quotas/groups` | Get-PfbQuotaGroup | allow_errors, file_system_ids, gids, group_names |  | `high` |  |
 | `GET /quotas/settings` | Get-PfbQuotaSettings | ids, names |  | `high` |  |
-| `GET /quotas/users` | Get-PfbQuotaUser | allow_errors, context_names, file_system_ids, uids, user_names |  | `high` |  |
-| `GET /realms` | Get-PfbRealm | allow_errors, context_names |  | `high` |  |
-| `GET /realms/defaults` | Get-PfbRealmDefaults | allow_errors, context_names, realm_ids |  | `high` |  |
+| `GET /quotas/users` | Get-PfbQuotaUser | allow_errors, file_system_ids, uids, user_names |  | `high` |  |
+| `GET /realms` | Get-PfbRealm | allow_errors |  | `high` |  |
+| `GET /realms/defaults` | Get-PfbRealmDefaults | allow_errors, realm_ids |  | `high` |  |
 | `GET /realms/space` | Get-PfbRealmSpace | end_time, ids, resolution, start_time, total_only, type |  | `high` |  |
 | `GET /realms/space/storage-classes` | Get-PfbRealmStorageClass | end_time, ids, resolution, start_time, storage_class_names, total_only |  | `high` |  |
 | `GET /remote-arrays` | Get-PfbRemoteArray | total_only |  | `high` |  |
 | `GET /roles` | Get-PfbRole | ids |  | `high` |  |
-| `GET /s3-export-policies` | Get-PfbS3ExportPolicy | allow_errors, context_names |  | `high` |  |
-| `GET /s3-export-policies/rules` | Get-PfbS3ExportRule | allow_errors, context_names |  | `high` |  |
-| `GET /servers` | Get-PfbServer | allow_errors, context_names |  | `high` |  |
-| `GET /smb-client-policies` | Get-PfbSmbClientPolicy | allow_errors, context_names, workload_ids, workload_names |  | `high` |  |
-| `GET /smb-client-policies/rules` | Get-PfbSmbClientRule | allow_errors, context_names, ids |  | `high` |  |
-| `GET /smb-share-policies` | Get-PfbSmbSharePolicy | allow_errors, context_names, workload_ids, workload_names |  | `high` |  |
-| `GET /smb-share-policies/rules` | Get-PfbSmbShareRule | allow_errors, context_names, ids |  | `high` |  |
+| `GET /s3-export-policies` | Get-PfbS3ExportPolicy | allow_errors |  | `high` |  |
+| `GET /s3-export-policies/rules` | Get-PfbS3ExportRule | allow_errors |  | `high` |  |
+| `GET /servers` | Get-PfbServer | allow_errors |  | `high` |  |
+| `GET /smb-client-policies` | Get-PfbSmbClientPolicy | allow_errors, workload_ids, workload_names |  | `high` |  |
+| `GET /smb-client-policies/rules` | Get-PfbSmbClientRule | allow_errors, ids |  | `high` |  |
+| `GET /smb-share-policies` | Get-PfbSmbSharePolicy | allow_errors, workload_ids, workload_names |  | `high` |  |
+| `GET /smb-share-policies/rules` | Get-PfbSmbShareRule | allow_errors, ids |  | `high` |  |
 | `GET /smtp-servers` | Get-PfbSmtpServer | ids, names |  | `high` |  |
 | `GET /snmp-agents` | Get-PfbSnmpAgent | ids, limit, names, sort |  | `high` |  |
 | `GET /snmp-managers/test` | Test-PfbSnmpManager | filter, limit, sort |  | `high` |  |
 | `GET /software-check` | Get-PfbSoftwareCheck | ids, names, software_names, software_versions, total_item_count |  | `high` |  |
-| `GET /ssh-certificate-authority-policies` | Get-PfbSshCaPolicy | allow_errors, context_names |  | `high` |  |
-| `GET /ssh-certificate-authority-policies/admins` | Get-PfbSshCaPolicyAdmin | allow_errors, context_names, sort |  | `high` |  |
-| `GET /ssh-certificate-authority-policies/arrays` | Get-PfbSshCaPolicyArray | allow_errors, context_names, sort |  | `high` |  |
-| `GET /ssh-certificate-authority-policies/members` | Get-PfbSshCaPolicyMember | allow_errors, context_names, sort |  | `high` |  |
+| `GET /ssh-certificate-authority-policies` | Get-PfbSshCaPolicy | allow_errors |  | `high` |  |
+| `GET /ssh-certificate-authority-policies/admins` | Get-PfbSshCaPolicyAdmin | allow_errors, sort |  | `high` |  |
+| `GET /ssh-certificate-authority-policies/arrays` | Get-PfbSshCaPolicyArray | allow_errors, sort |  | `high` |  |
+| `GET /ssh-certificate-authority-policies/members` | Get-PfbSshCaPolicyMember | allow_errors, sort |  | `high` |  |
 | `GET /sso/saml2/idps/test` | Test-PfbSaml2Idp | filter, limit, sort |  | `high` |  |
-| `GET /storage-class-tiering-policies/members` | Get-PfbStorageClassTieringPolicyMember | allow_errors, context_names, sort |  | `high` |  |
+| `GET /storage-class-tiering-policies/members` | Get-PfbStorageClassTieringPolicyMember | allow_errors, sort |  | `high` |  |
 | `GET /support` | Get-PfbSupport | ids |  | `high` |  |
 | `GET /support/test` | Test-PfbSupport | filter, sort |  | `high` |  |
-| `GET /syslog-servers` | Get-PfbSyslogServer | allow_errors, context_names |  | `high` |  |
+| `GET /syslog-servers` | Get-PfbSyslogServer | allow_errors |  | `high` |  |
 | `GET /syslog-servers/settings` | Get-PfbSyslogServerSettings | ids, names |  | `high` |  |
-| `GET /targets` | Get-PfbTarget | allow_errors, context_names |  | `high` |  |
+| `GET /targets` | Get-PfbTarget | allow_errors |  | `high` |  |
 | `GET /targets/performance/replication` | Get-PfbTargetPerformanceReplication | ids, total_only |  | `high` |  |
 | `GET /tls-policies` | Get-PfbTlsPolicy | effective, purity_defined |  | `high` |  |
 | `GET /tls-policies/members` | Get-PfbTlsPolicyMember | sort |  | `high` |  |
-| `GET /usage/groups` | Get-PfbUsageGroup | allow_errors, context_names, file_system_ids, gids, group_names |  | `high` |  |
-| `GET /usage/users` | Get-PfbUsageUser | allow_errors, context_names, file_system_ids, uids, user_names |  | `high` |  |
-| `GET /user-group-quota-policies` | Get-PfbUserGroupQuotaPolicy | allow_errors, context_names, ids, names |  | `partial` -- /!\ 2 unresolved params (see Partial-confidence detail below) |  |
-| `GET /user-group-quota-policies/file-systems` | Get-PfbUserGroupQuotaPolicyFileSystem | allow_errors, context_names |  | `high` |  |
-| `GET /user-group-quota-policies/members` | Get-PfbUserGroupQuotaPolicyMember | allow_errors, context_names |  | `high` |  |
-| `GET /user-group-quota-policies/rules` | Get-PfbUserGroupQuotaPolicyRule | allow_errors, context_names |  | `high` |  |
-| `GET /workloads` | Get-PfbWorkload | allow_errors, context_names |  | `high` |  |
-| `GET /workloads/placement-recommendations` | Get-PfbWorkloadPlacementRecommendation | allow_errors, context_names |  | `high` |  |
-| `GET /workloads/tags` | Get-PfbWorkloadTag | allow_errors, context_names |  | `high` |  |
-| `GET /worm-data-policies` | Get-PfbWormPolicy | allow_errors, context_names |  | `high` |  |
-| `GET /worm-data-policies/members` | Get-PfbWormPolicyMember | allow_errors, context_names, sort |  | `high` |  |
-| `PATCH /admins` | Update-PfbAdmin | context_names | role | `high` |  |
+| `GET /usage/groups` | Get-PfbUsageGroup | allow_errors, file_system_ids, gids, group_names |  | `high` |  |
+| `GET /usage/users` | Get-PfbUsageUser | allow_errors, file_system_ids, uids, user_names |  | `high` |  |
+| `GET /user-group-quota-policies` | Get-PfbUserGroupQuotaPolicy | allow_errors, ids, names |  | `partial` -- /!\ 2 unresolved params (see Partial-confidence detail below) |  |
+| `GET /user-group-quota-policies/file-systems` | Get-PfbUserGroupQuotaPolicyFileSystem | allow_errors |  | `high` |  |
+| `GET /user-group-quota-policies/members` | Get-PfbUserGroupQuotaPolicyMember | allow_errors |  | `high` |  |
+| `GET /user-group-quota-policies/rules` | Get-PfbUserGroupQuotaPolicyRule | allow_errors |  | `high` |  |
+| `GET /workloads` | Get-PfbWorkload | allow_errors |  | `high` |  |
+| `GET /workloads/placement-recommendations` | Get-PfbWorkloadPlacementRecommendation | allow_errors |  | `high` |  |
+| `GET /workloads/tags` | Get-PfbWorkloadTag | allow_errors |  | `high` |  |
+| `GET /worm-data-policies` | Get-PfbWormPolicy | allow_errors |  | `high` |  |
+| `GET /worm-data-policies/members` | Get-PfbWormPolicyMember | allow_errors, sort |  | `high` |  |
+| `PATCH /admins` | Update-PfbAdmin |  | role | `high` |  |
 | `PATCH /admins/settings` | Update-PfbAdminSetting |  | lockout_duration, max_login_attempts, min_password_length | `high` |  |
 | `PATCH /alert-watchers` | Update-PfbAlertWatcher |  | enabled | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
 | `PATCH /alerts` | Update-PfbAlert |  | flagged | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
 | `PATCH /api-clients` | Update-PfbApiClient |  | max_role | `high` |  |
-| `PATCH /array-connections` | Update-PfbArrayConnection | context_names |  | `high` |  |
+| `PATCH /array-connections` | Update-PfbArrayConnection |  |  | `high` |  |
 | `PATCH /arrays` | Update-PfbArray |  | banner, default_inbound_tls_policy, eradication_config, idle_timeout, name, network_access_policy, ntp_servers, time_zone | `high` |  |
 | `PATCH /arrays/erasures` | Update-PfbArrayErasure | delete_sanitization_certificate, eradicate_all_data, finalize |  | `high` |  |
 | `PATCH /arrays/eula` | Update-PfbArrayEula |  | signature | `high` |  |
-| `PATCH /audit-file-systems-policies` | Update-PfbAuditFileSystemPolicy | context_names | add_log_targets, control_type, enabled, location, log_targets, name, remove_log_targets, rules | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
-| `PATCH /audit-object-store-policies` | Update-PfbAuditObjectStorePolicy | context_names | add_log_targets, enabled, location, log_targets, name, remove_log_targets | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
-| `PATCH /buckets` | Remove-PfbBucket, Update-PfbBucket | cancel_in_progress_storage_class_transition, context_names, ignore_usage | destroyed, eradication_config, hard_limit_enabled, object_lock_config, public_access_config, qos_policy, retention_lock, storage_class | `partial` -- /!\ 2 unresolved params (see Partial-confidence detail below) |  |
-| `PATCH /buckets/audit-filters` | Update-PfbBucketAuditFilter | context_names |  | `high` |  |
+| `PATCH /audit-file-systems-policies` | Update-PfbAuditFileSystemPolicy |  | add_log_targets, control_type, enabled, location, log_targets, name, remove_log_targets, rules | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
+| `PATCH /audit-object-store-policies` | Update-PfbAuditObjectStorePolicy |  | add_log_targets, enabled, location, log_targets, name, remove_log_targets | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
+| `PATCH /buckets` | Remove-PfbBucket, Update-PfbBucket | cancel_in_progress_storage_class_transition, ignore_usage | destroyed, eradication_config, hard_limit_enabled, object_lock_config, public_access_config, qos_policy, retention_lock, storage_class | `partial` -- /!\ 2 unresolved params (see Partial-confidence detail below) |  |
 | `PATCH /certificates` | Update-PfbCertificate |  |  | `high` |  |
-| `PATCH /data-eviction-policies` | Update-PfbDataEvictionPolicy | context_names | enabled, location | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
+| `PATCH /data-eviction-policies` | Update-PfbDataEvictionPolicy |  | enabled, location | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
 | `PATCH /directory-services` | Update-PfbDirectoryService | ids, names | base_dn, bind_password, bind_user, ca_certificate, ca_certificate_group, enabled, management, nfs, smb, uris | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
 | `PATCH /directory-services/roles` | Update-PfbDirectoryServiceRole | role_ids, role_names | role | `high` |  |
-| `PATCH /dns` | Update-PfbDns | context_names |  | `high` |  |
-| `PATCH /file-system-exports` | Update-PfbFileSystemExport | context_names |  | `high` |  |
-| `PATCH /file-system-snapshots` | Remove-PfbFileSystemSnapshot | context_names, latest_replica | destroyed, name, owner, policy, source | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
-| `PATCH /file-systems` | Remove-PfbFileSystem, Update-PfbFileSystem | cancel_in_progress_storage_class_transition, context_names, discard_detailed_permissions, ignore_usage | abort_quiesce, default_group_quota, default_user_quota, destroyed, fast_remove_directory_enabled, group_ownership, hard_limit_enabled, http, multi_protocol, name, nfs, qos_policy, quiesce, skip_quiesce, smb, snapshot_directory_enabled, source, storage_class, workload, writable | `partial` -- /!\ 10 unresolved params (see Partial-confidence detail below) |  |
+| `PATCH /dns` | Update-PfbDns |  |  | `high` |  |
+| `PATCH /file-system-exports` | Update-PfbFileSystemExport |  |  | `high` |  |
+| `PATCH /file-system-snapshots` | Remove-PfbFileSystemSnapshot | latest_replica | destroyed, name, owner, policy, source | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
+| `PATCH /file-systems` | Remove-PfbFileSystem, Update-PfbFileSystem | cancel_in_progress_storage_class_transition, discard_detailed_permissions, ignore_usage | abort_quiesce, default_group_quota, default_user_quota, destroyed, fast_remove_directory_enabled, group_ownership, hard_limit_enabled, http, multi_protocol, name, nfs, qos_policy, quiesce, skip_quiesce, smb, snapshot_directory_enabled, source, storage_class, workload, writable | `partial` -- /!\ 10 unresolved params (see Partial-confidence detail below) |  |
 | `PATCH /hardware` | Update-PfbHardware |  |  | `high` |  |
 | `PATCH /hardware-connectors` | Update-PfbHardwareConnector |  |  | `high` |  |
 | `PATCH /kmip` | Update-PfbKmip |  |  | `high` |  |
 | `PATCH /legal-holds` | Update-PfbLegalHold |  |  | `high` |  |
-| `PATCH /lifecycle-rules` | Update-PfbLifecycleRule | context_names |  | `high` |  |
-| `PATCH /log-targets/file-systems` | Update-PfbLogTargetFileSystem | context_names |  | `high` |  |
-| `PATCH /log-targets/object-store` | Update-PfbLogTargetObjectStore | context_names |  | `high` |  |
+| `PATCH /log-targets/file-systems` | Update-PfbLogTargetFileSystem |  |  | `high` |  |
+| `PATCH /log-targets/object-store` | Update-PfbLogTargetObjectStore |  |  | `high` |  |
 | `PATCH /logs-async` | Update-PfbAsyncLog |  |  | `high` |  |
-| `PATCH /management-access-policies` | Update-PfbManagementAccessPolicy | context_names |  | `high` | POST/PATCH/DELETE return 403 regardless of account; not an implementation bug |
+| `PATCH /management-access-policies` | Update-PfbManagementAccessPolicy |  |  | `high` | POST/PATCH/DELETE return 403 regardless of account; not an implementation bug |
 | `PATCH /network-access-policies` | Update-PfbNetworkAccessPolicy | versions | enabled, location, name, rules | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
 | `PATCH /network-access-policies/rules` | Update-PfbNetworkAccessRule | before_rule_id, before_rule_name, ids, versions | client, effect, index, interfaces, policy | `high` |  |
 | `PATCH /network-interfaces/connectors` | Update-PfbNetworkInterfaceConnector |  |  | `high` |  |
-| `PATCH /nfs-export-policies` | Update-PfbNfsExportPolicy | context_names, versions | enabled, location, name, rules | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
-| `PATCH /nfs-export-policies/rules` | Update-PfbNfsExportRule | before_rule_id, before_rule_name, context_names, ids, versions | access, anongid, anonuid, atime, client, fileid_32bit, index, permission, required_transport_security, secure, security | `high` |  |
+| `PATCH /nfs-export-policies` | Update-PfbNfsExportPolicy | versions | enabled, location, name, rules | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
+| `PATCH /nfs-export-policies/rules` | Update-PfbNfsExportRule | before_rule_id, before_rule_name, ids, versions | access, anongid, anonuid, atime, client, fileid_32bit, index, permission, required_transport_security, secure, security | `high` |  |
 | `PATCH /nodes` | Update-PfbNode |  |  | `high` |  |
-| `PATCH /object-store-access-policies/rules` | Update-PfbObjectStoreAccessPolicyRule | context_names, enforce_action_restrictions, policy_ids, policy_names | actions, conditions, effect, resources | `high` |  |
-| `PATCH /object-store-account-exports` | Update-PfbObjectStoreAccountExport | context_names |  | `high` |  |
-| `PATCH /object-store-remote-credentials` | Update-PfbObjectStoreRemoteCredential | context_names |  | `high` |  |
-| `PATCH /object-store-roles` | Update-PfbObjectStoreRole | context_names |  | `high` |  |
-| `PATCH /object-store-roles/object-store-trust-policies/rules` | Update-PfbObjectStoreTrustPolicyRule | context_names, indices, policy_names, role_ids, role_names | actions, conditions, policy, principals | `high` |  |
-| `PATCH /object-store-virtual-hosts` | Update-PfbObjectStoreVirtualHost | context_names |  | `high` |  |
+| `PATCH /object-store-access-policies/rules` | Update-PfbObjectStoreAccessPolicyRule | enforce_action_restrictions, policy_ids, policy_names | actions, conditions, effect, resources | `high` |  |
+| `PATCH /object-store-remote-credentials` | Update-PfbObjectStoreRemoteCredential |  |  | `high` |  |
+| `PATCH /object-store-roles` | Update-PfbObjectStoreRole |  |  | `high` |  |
+| `PATCH /object-store-roles/object-store-trust-policies/rules` | Update-PfbObjectStoreTrustPolicyRule | indices, policy_names, role_ids, role_names | actions, conditions, policy, principals | `high` |  |
+| `PATCH /object-store-virtual-hosts` | Update-PfbObjectStoreVirtualHost |  |  | `high` |  |
 | `PATCH /password-policies` | Update-PfbPasswordPolicy | ids, names | enabled, enforce_dictionary_check, enforce_username_check, location, lockout_duration, max_login_attempts, max_password_age, min_character_groups, min_characters_per_group, min_password_age, min_password_length, name, password_history | `high` |  |
-| `PATCH /policies` | Update-PfbPolicy | context_names, destroy_snapshots | add_rules, enabled, location, remove_rules | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
-| `PATCH /presets/workload` | Update-PfbPresetWorkload | context_names |  | `high` |  |
-| `PATCH /qos-policies` | Update-PfbQosPolicy | context_names |  | `high` |  |
-| `PATCH /quotas/groups` | Update-PfbQuotaGroup | context_names, file_system_ids, file_system_names, gids, group_names, names |  | `partial` -- /!\ 3 unresolved params (see Partial-confidence detail below) |  |
+| `PATCH /policies` | Update-PfbPolicy | destroy_snapshots | add_rules, enabled, location, remove_rules | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
+| `PATCH /qos-policies` | Update-PfbQosPolicy |  |  | `high` |  |
+| `PATCH /quotas/groups` | Update-PfbQuotaGroup | file_system_ids, file_system_names, gids, group_names, names |  | `partial` -- /!\ 3 unresolved params (see Partial-confidence detail below) |  |
 | `PATCH /quotas/settings` | Update-PfbQuotaSettings |  | contact, direct_notifications_enabled | `high` |  |
-| `PATCH /quotas/users` | Update-PfbQuotaUser | context_names, file_system_ids, file_system_names, names, uids, user_names |  | `partial` -- /!\ 2 unresolved params (see Partial-confidence detail below) |  |
+| `PATCH /quotas/users` | Update-PfbQuotaUser | file_system_ids, file_system_names, names, uids, user_names |  | `partial` -- /!\ 2 unresolved params (see Partial-confidence detail below) |  |
 | `PATCH /rapid-data-locking` | Update-PfbRapidDataLocking |  | enabled, kmip_server | `high` |  |
 | `PATCH /realms` | Remove-PfbRealm, Update-PfbRealm |  | default_inbound_tls_policy, destroyed, name | `partial` -- /!\ 2 unresolved params (see Partial-confidence detail below) |  |
-| `PATCH /realms/defaults` | Update-PfbRealmDefaults | context_names |  | `high` |  |
-| `PATCH /s3-export-policies` | Update-PfbS3ExportPolicy | context_names | enabled, name, rules | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
-| `PATCH /s3-export-policies/rules` | Update-PfbS3ExportRule | context_names, policy_ids, policy_names | actions, effect, resources | `high` |  |
-| `PATCH /smb-client-policies` | Update-PfbSmbClientPolicy | context_names | access_based_enumeration_enabled, enabled, location, name, rules | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
-| `PATCH /smb-client-policies/rules` | Update-PfbSmbClientRule | before_rule_id, before_rule_name, context_names, ids, versions | client, encryption, index, permission, policy | `high` |  |
-| `PATCH /smb-share-policies` | Update-PfbSmbSharePolicy | context_names | enabled, location, name, rules | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
-| `PATCH /smb-share-policies/rules` | Update-PfbSmbShareRule | context_names, ids, policy_ids, policy_names | change, full_control, policy, principal, read | `high` |  |
+| `PATCH /realms/defaults` | Update-PfbRealmDefaults |  |  | `high` |  |
+| `PATCH /s3-export-policies` | Update-PfbS3ExportPolicy |  | enabled, name, rules | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
+| `PATCH /s3-export-policies/rules` | Update-PfbS3ExportRule | policy_ids, policy_names | actions, effect, resources | `high` |  |
+| `PATCH /smb-client-policies` | Update-PfbSmbClientPolicy |  | access_based_enumeration_enabled, enabled, location, name, rules | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
+| `PATCH /smb-client-policies/rules` | Update-PfbSmbClientRule | before_rule_id, before_rule_name, ids, versions | client, encryption, index, permission, policy | `high` |  |
+| `PATCH /smb-share-policies` | Update-PfbSmbSharePolicy |  | enabled, location, name, rules | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
+| `PATCH /smb-share-policies/rules` | Update-PfbSmbShareRule | ids, policy_ids, policy_names | change, full_control, policy, principal, read | `high` |  |
 | `PATCH /smtp-servers` | Update-PfbSmtpServer |  |  | `high` |  |
 | `PATCH /snmp-agents` | Update-PfbSnmpAgent |  | v2c, v3, version | `high` |  |
 | `PATCH /snmp-managers` | Update-PfbSnmpManager |  |  | `high` |  |
@@ -406,98 +348,77 @@ Endpoints an existing cmdlet already calls, where the capability map knows of a 
 | `PATCH /syslog-servers/settings` | Update-PfbSyslogServerSettings | ids, names | ca_certificate, ca_certificate_group | `high` |  |
 | `PATCH /targets` | Update-PfbTarget |  |  | `high` |  |
 | `PATCH /tls-policies` | Update-PfbTlsPolicy |  |  | `high` |  |
-| `PATCH /user-group-quota-policies` | Update-PfbUserGroupQuotaPolicy | context_names | enabled, name | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
-| `PATCH /user-group-quota-policies/rules` | Update-PfbUserGroupQuotaPolicyRule | context_names |  | `high` |  |
-| `PATCH /workloads` | Update-PfbWorkload | context_names | destroyed | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
-| `PATCH /worm-data-policies` | Update-PfbWormPolicy | context_names |  | `high` |  |
+| `PATCH /user-group-quota-policies` | Update-PfbUserGroupQuotaPolicy |  | enabled, name | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
+| `PATCH /user-group-quota-policies/rules` | Update-PfbUserGroupQuotaPolicyRule |  |  | `high` |  |
+| `PATCH /workloads` | Update-PfbWorkload |  | destroyed | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
+| `PATCH /worm-data-policies` | Update-PfbWormPolicy |  |  | `high` |  |
 | `POST /active-directory` | New-PfbActiveDirectory | join_existing_account, names | ca_certificate, ca_certificate_group, computer_name, directory_servers, domain, encryption_types, fqdns, global_catalog_servers, join_ou, kerberos_servers, password, service_principal_names, user | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
-| `POST /admins/api-tokens` | New-PfbApiToken | context_names |  | `high` |  |
-| `POST /admins/management-access-policies` | New-PfbAdminManagementAccessPolicy | context_names |  | `high` | POST/PATCH/DELETE return 403 regardless of account; not an implementation bug |
-| `POST /admins/ssh-certificate-authority-policies` | New-PfbAdminSshCaPolicy | context_names |  | `high` |  |
 | `POST /api-clients` | New-PfbApiClient |  | access_policies, access_token_ttl_in_ms, issuer | `high` |  |
-| `POST /array-connections` | New-PfbArrayConnection | context_names |  | `high` |  |
+| `POST /array-connections` | New-PfbArrayConnection |  |  | `high` |  |
 | `POST /arrays/erasures` | New-PfbArrayErasure | eradicate_all_data, preserve_configuration_data, skip_phonehome_check |  | `high` |  |
-| `POST /arrays/ssh-certificate-authority-policies` | New-PfbArraySshCaPolicy | context_names |  | `high` |  |
-| `POST /audit-file-systems-policies` | New-PfbAuditFileSystemPolicy | context_names | control_type, enabled, location, log_targets, name, rules | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
-| `POST /audit-file-systems-policies/members` | New-PfbAuditFileSystemPolicyMember | context_names |  | `high` |  |
-| `POST /audit-object-store-policies` | New-PfbAuditObjectStorePolicy | context_names | enabled, location, log_targets, name | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
-| `POST /audit-object-store-policies/members` | New-PfbAuditObjectStorePolicyMember | context_names |  | `high` |  |
-| `POST /buckets` | New-PfbBucket | context_names | bucket_type, eradication_config, hard_limit_enabled, object_lock_config, retention_lock | `high` |  |
-| `POST /buckets/audit-filters` | New-PfbBucketAuditFilter | bucket_ids, context_names, names | actions, s3_prefixes | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
-| `POST /buckets/bucket-access-policies` | New-PfbBucketAccessPolicy | bucket_ids, context_names | rules | `high` |  |
-| `POST /buckets/bucket-access-policies/rules` | New-PfbBucketAccessPolicyRule | bucket_ids, context_names | actions, principals, resources | `high` |  |
-| `POST /buckets/cross-origin-resource-sharing-policies` | New-PfbBucketCorsPolicy | bucket_ids, context_names | rules | `high` |  |
-| `POST /buckets/cross-origin-resource-sharing-policies/rules` | New-PfbBucketCorsPolicyRule | bucket_ids, context_names | allowed_headers, allowed_methods, allowed_origins | `high` |  |
+| `POST /audit-file-systems-policies` | New-PfbAuditFileSystemPolicy |  | control_type, enabled, location, log_targets, name, rules | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
+| `POST /audit-object-store-policies` | New-PfbAuditObjectStorePolicy |  | enabled, location, log_targets, name | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
+| `POST /buckets` | New-PfbBucket |  | bucket_type, eradication_config, hard_limit_enabled, object_lock_config, retention_lock | `high` |  |
+| `POST /buckets/audit-filters` | New-PfbBucketAuditFilter | bucket_ids, names | actions, s3_prefixes | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
+| `POST /buckets/bucket-access-policies` | New-PfbBucketAccessPolicy | bucket_ids | rules | `high` |  |
+| `POST /buckets/bucket-access-policies/rules` | New-PfbBucketAccessPolicyRule | bucket_ids | actions, principals, resources | `high` |  |
+| `POST /buckets/cross-origin-resource-sharing-policies` | New-PfbBucketCorsPolicy | bucket_ids | rules | `high` |  |
+| `POST /buckets/cross-origin-resource-sharing-policies/rules` | New-PfbBucketCorsPolicyRule | bucket_ids | allowed_headers, allowed_methods, allowed_origins | `high` |  |
 | `POST /certificates` | New-PfbCertificate |  | certificate, certificate_type, common_name, country, days, email, intermediate_certificate, key_algorithm, key_size, locality, organization, organizational_unit, passphrase, private_key, state, subject_alternative_names | `high` |  |
 | `POST /certificates/certificate-signing-requests` | New-PfbCertificateSigningRequest |  | certificate, common_name, country, email, locality, organization, organizational_unit, state, subject_alternative_names | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
-| `POST /data-eviction-policies` | New-PfbDataEvictionPolicy | context_names | enabled, location, name | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
-| `POST /data-eviction-policies/file-systems` | Add-PfbDataEvictionPolicyFileSystem | context_names |  | `high` |  |
-| `POST /directory-services/local/directory-services` | New-PfbLocalDirectoryService | context_names |  | `high` |  |
-| `POST /directory-services/local/groups` | New-PfbLocalGroup | context_names, local_directory_service_ids, local_directory_service_names |  | `high` |  |
-| `POST /directory-services/local/groups/members` | New-PfbLocalGroupMember | context_names, group_gids, group_sids, local_directory_service_ids | members | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
+| `POST /data-eviction-policies` | New-PfbDataEvictionPolicy |  | enabled, location, name | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
+| `POST /directory-services/local/groups` | New-PfbLocalGroup | local_directory_service_ids, local_directory_service_names |  | `high` |  |
+| `POST /directory-services/local/groups/members` | New-PfbLocalGroupMember | group_gids, group_sids, local_directory_service_ids | members | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
 | `POST /directory-services/roles` | New-PfbDirectoryServiceRole |  | group, group_base, management_access_policies, role | `high` |  |
-| `POST /dns` | New-PfbDns | context_names, names | ca_certificate, ca_certificate_group, domain, nameservers, services, sources | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
-| `POST /file-system-exports` | New-PfbFileSystemExport | context_names, member_ids, policy_ids |  | `high` |  |
-| `POST /file-system-replica-links` | New-PfbFileSystemReplicaLink | context_names, local_file_system_ids | direction, link_type, local_file_system, policies, remote, remote_file_system | `high` |  |
-| `POST /file-system-replica-links/policies` | New-PfbFileSystemReplicaLinkPolicy | context_names |  | `high` |  |
-| `POST /file-system-snapshots` | New-PfbFileSystemSnapshot | context_names, source_ids, source_names |  | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
-| `POST /file-systems` | New-PfbFileSystem | context_names, default_exports, discard_non_snapshotted_data, include_snapshot, overwrite, policy_ids, policy_names | eradication_config, fast_remove_directory_enabled, hard_limit_enabled, http, multi_protocol, nfs, node_group, smb, snapshot_directory_enabled, workload, writable | `partial` -- /!\ 17 unresolved params (see Partial-confidence detail below) |  |
-| `POST /file-systems/audit-policies` | New-PfbFileSystemAuditPolicy | context_names |  | `high` |  |
-| `POST /file-systems/locks/nlm-reclamations` | New-PfbNlmReclamation | context_names |  | `high` |  |
-| `POST /file-systems/policies` | New-PfbFileSystemPolicy | context_names |  | `high` |  |
-| `POST /file-systems/user-group-quota-policies` | New-PfbFileSystemUserGroupQuotaPolicy | context_names |  | `high` |  |
+| `POST /dns` | New-PfbDns | names | ca_certificate, ca_certificate_group, domain, nameservers, services, sources | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
+| `POST /file-system-exports` | New-PfbFileSystemExport | member_ids, policy_ids |  | `high` |  |
+| `POST /file-system-replica-links` | New-PfbFileSystemReplicaLink | local_file_system_ids | direction, link_type, local_file_system, policies, remote, remote_file_system | `high` |  |
+| `POST /file-system-snapshots` | New-PfbFileSystemSnapshot | source_ids, source_names |  | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
+| `POST /file-systems` | New-PfbFileSystem | default_exports, discard_non_snapshotted_data, include_snapshot, overwrite, policy_ids, policy_names | eradication_config, fast_remove_directory_enabled, hard_limit_enabled, http, multi_protocol, nfs, node_group, smb, snapshot_directory_enabled, workload, writable | `partial` -- /!\ 17 unresolved params (see Partial-confidence detail below) |  |
 | `POST /fleets` | New-PfbFleet | names |  | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
 | `POST /keytabs` | New-PfbKeytab | name_prefixes | source | `high` |  |
 | `POST /keytabs/upload` | New-PfbKeytabUpload | name_prefixes | keytab_file | `high` |  |
 | `POST /legal-holds` | New-PfbLegalHold |  | description | `high` |  |
-| `POST /lifecycle-rules` | New-PfbLifecycleRule | confirm_date, context_names | abort_incomplete_multipart_uploads_after, keep_current_version_for, keep_current_version_until, keep_previous_version_for, prefix, rule_id | `high` |  |
+| `POST /lifecycle-rules` | New-PfbLifecycleRule | confirm_date | abort_incomplete_multipart_uploads_after, keep_current_version_for, keep_current_version_until, keep_previous_version_for, prefix, rule_id | `high` |  |
 | `POST /link-aggregation-groups` | New-PfbLag | names | ports | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
-| `POST /log-targets/file-systems` | New-PfbLogTargetFileSystem | context_names | file_system, keep_for, keep_size, name | `high` |  |
-| `POST /log-targets/object-store` | New-PfbLogTargetObjectStore | context_names | bucket, log_name_prefix, log_rotate, name | `high` |  |
+| `POST /log-targets/file-systems` | New-PfbLogTargetFileSystem |  | file_system, keep_for, keep_size, name | `high` |  |
+| `POST /log-targets/object-store` | New-PfbLogTargetObjectStore |  | bucket, log_name_prefix, log_rotate, name | `high` |  |
 | `POST /maintenance-windows` | New-PfbMaintenanceWindow | names | timeout | `high` |  |
-| `POST /management-access-policies` | New-PfbManagementAccessPolicy | context_names | aggregation_strategy, enabled, location, name, rules | `high` | POST/PATCH/DELETE return 403 regardless of account; not an implementation bug |
-| `POST /management-access-policies/admins` | New-PfbManagementAccessPolicyAdmin | context_names |  | `high` | POST/PATCH/DELETE return 403 regardless of account; not an implementation bug |
+| `POST /management-access-policies` | New-PfbManagementAccessPolicy |  | aggregation_strategy, enabled, location, name, rules | `high` | POST/PATCH/DELETE return 403 regardless of account; not an implementation bug |
 | `POST /network-access-policies/rules` | New-PfbNetworkAccessRule |  |  | `high` |  |
 | `POST /network-interfaces` | New-PfbNetworkInterface |  | rdma_enabled | `high` |  |
-| `POST /nfs-export-policies` | New-PfbNfsExportPolicy | context_names | enabled, location, name, rules | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
-| `POST /nfs-export-policies/rules` | New-PfbNfsExportRule | context_names |  | `high` |  |
+| `POST /nfs-export-policies` | New-PfbNfsExportPolicy |  | enabled, location, name, rules | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
+| `POST /nfs-export-policies/rules` | New-PfbNfsExportRule |  |  | `high` |  |
 | `POST /node-groups` | New-PfbNodeGroup | names |  | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
-| `POST /object-store-access-keys` | New-PfbObjectStoreAccessKey | context_names, names | secret_access_key | `high` |  |
-| `POST /object-store-access-policies` | New-PfbObjectStoreAccessPolicy | context_names, enforce_action_restrictions | description, rules | `high` |  |
-| `POST /object-store-access-policies/object-store-roles` | New-PfbObjectStoreAccessPolicyRole | context_names, member_ids, policy_ids |  | `high` |  |
-| `POST /object-store-access-policies/object-store-users` | New-PfbObjectStoreAccessPolicyUser | context_names, member_ids, policy_ids |  | `high` |  |
-| `POST /object-store-access-policies/rules` | New-PfbObjectStoreAccessPolicyRule | context_names, enforce_action_restrictions, policy_ids | actions, conditions, effect, resources | `high` |  |
-| `POST /object-store-account-exports` | New-PfbObjectStoreAccountExport | context_names |  | `high` |  |
-| `POST /object-store-accounts` | New-PfbObjectStoreAccount | context_names | account_exports, bucket_defaults, hard_limit_enabled, quota_limit | `high` |  |
-| `POST /object-store-remote-credentials` | New-PfbObjectStoreRemoteCredential | context_names | access_key_id, secret_access_key | `high` |  |
-| `POST /object-store-roles` | New-PfbObjectStoreRole | context_names | max_session_duration | `high` |  |
-| `POST /object-store-roles/object-store-access-policies` | New-PfbObjectStoreRoleAccessPolicy | context_names, member_ids, policy_ids, policy_names |  | `high` |  |
-| `POST /object-store-roles/object-store-trust-policies/rules` | New-PfbObjectStoreTrustPolicyRule | context_names, names, role_ids, role_names | actions, conditions, policy, principals | `high` |  |
-| `POST /object-store-users` | New-PfbObjectStoreUser | context_names, full_access |  | `high` |  |
-| `POST /object-store-users/object-store-access-policies` | New-PfbObjectStoreUserAccessPolicy | context_names, member_ids, policy_ids |  | `high` |  |
-| `POST /object-store-virtual-hosts` | New-PfbObjectStoreVirtualHost | context_names | attached_servers | `high` |  |
-| `POST /policies` | New-PfbPolicy | context_names | enabled, location, name | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
-| `POST /policies/file-system-replica-links` | New-PfbPolicyFileSystemReplicaLink | context_names |  | `high` |  |
-| `POST /policies/file-systems` | New-PfbPolicyFileSystem | context_names |  | `high` |  |
-| `POST /presets/workload` | New-PfbPresetWorkload | context_names | description, directory_configurations, export_configurations, parameters, periodic_replication_configurations, placement_configurations, platform_features, qos_configurations, quota_configurations, snapshot_configurations, volume_configurations, workload_tags, workload_type | `high` |  |
+| `POST /object-store-access-keys` | New-PfbObjectStoreAccessKey | names | secret_access_key | `high` |  |
+| `POST /object-store-access-policies` | New-PfbObjectStoreAccessPolicy | enforce_action_restrictions | description, rules | `high` |  |
+| `POST /object-store-access-policies/object-store-roles` | New-PfbObjectStoreAccessPolicyRole | member_ids, policy_ids |  | `high` |  |
+| `POST /object-store-access-policies/object-store-users` | New-PfbObjectStoreAccessPolicyUser | member_ids, policy_ids |  | `high` |  |
+| `POST /object-store-access-policies/rules` | New-PfbObjectStoreAccessPolicyRule | enforce_action_restrictions, policy_ids | actions, conditions, effect, resources | `high` |  |
+| `POST /object-store-accounts` | New-PfbObjectStoreAccount |  | account_exports, bucket_defaults, hard_limit_enabled, quota_limit | `high` |  |
+| `POST /object-store-remote-credentials` | New-PfbObjectStoreRemoteCredential |  | access_key_id, secret_access_key | `high` |  |
+| `POST /object-store-roles` | New-PfbObjectStoreRole |  | max_session_duration | `high` |  |
+| `POST /object-store-roles/object-store-access-policies` | New-PfbObjectStoreRoleAccessPolicy | member_ids, policy_ids, policy_names |  | `high` |  |
+| `POST /object-store-roles/object-store-trust-policies/rules` | New-PfbObjectStoreTrustPolicyRule | names, role_ids, role_names | actions, conditions, policy, principals | `high` |  |
+| `POST /object-store-users` | New-PfbObjectStoreUser | full_access |  | `high` |  |
+| `POST /object-store-users/object-store-access-policies` | New-PfbObjectStoreUserAccessPolicy | member_ids, policy_ids |  | `high` |  |
+| `POST /object-store-virtual-hosts` | New-PfbObjectStoreVirtualHost |  | attached_servers | `high` |  |
+| `POST /policies` | New-PfbPolicy |  | enabled, location, name | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
+| `POST /presets/workload` | New-PfbPresetWorkload |  | description, directory_configurations, export_configurations, parameters, periodic_replication_configurations, placement_configurations, platform_features, qos_configurations, quota_configurations, snapshot_configurations, volume_configurations, workload_tags, workload_type | `high` |  |
 | `POST /public-keys` | New-PfbPublicKey |  | public_key | `high` |  |
-| `POST /qos-policies` | New-PfbQosPolicy | context_names | enabled, location, max_total_bytes_per_sec, max_total_ops_per_sec, name | `high` |  |
-| `POST /qos-policies/members` | New-PfbQosPolicyMember | context_names |  | `high` |  |
-| `POST /quotas/groups` | New-PfbQuotaGroup | context_names, file_system_ids, file_system_names, gids, group_names |  | `partial` -- /!\ 3 unresolved params (see Partial-confidence detail below) |  |
-| `POST /quotas/users` | New-PfbQuotaUser | context_names, file_system_ids, file_system_names, uids, user_names |  | `partial` -- /!\ 3 unresolved params (see Partial-confidence detail below) |  |
+| `POST /qos-policies` | New-PfbQosPolicy |  | enabled, location, max_total_bytes_per_sec, max_total_ops_per_sec, name | `high` |  |
+| `POST /quotas/groups` | New-PfbQuotaGroup | file_system_ids, file_system_names, gids, group_names |  | `partial` -- /!\ 3 unresolved params (see Partial-confidence detail below) |  |
+| `POST /quotas/users` | New-PfbQuotaUser | file_system_ids, file_system_names, uids, user_names |  | `partial` -- /!\ 3 unresolved params (see Partial-confidence detail below) |  |
 | `POST /realms` | New-PfbRealm | without_default_access_list |  | `high` |  |
-| `POST /s3-export-policies` | New-PfbS3ExportPolicy | context_names | enabled, rules | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
-| `POST /s3-export-policies/rules` | New-PfbS3ExportRule | context_names |  | `high` |  |
+| `POST /s3-export-policies` | New-PfbS3ExportPolicy |  | enabled, rules | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
 | `POST /servers` | New-PfbServer | create_ds, create_local_directory_service |  | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
-| `POST /smb-client-policies` | New-PfbSmbClientPolicy | context_names | access_based_enumeration_enabled, enabled, location, name, rules | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
-| `POST /smb-client-policies/rules` | New-PfbSmbClientRule | context_names |  | `high` |  |
-| `POST /smb-share-policies` | New-PfbSmbSharePolicy | context_names | enabled, location, name, rules | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
-| `POST /smb-share-policies/rules` | New-PfbSmbShareRule | context_names |  | `high` |  |
+| `POST /smb-client-policies` | New-PfbSmbClientPolicy |  | access_based_enumeration_enabled, enabled, location, name, rules | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
+| `POST /smb-client-policies/rules` | New-PfbSmbClientRule |  |  | `high` |  |
+| `POST /smb-share-policies` | New-PfbSmbSharePolicy |  | enabled, location, name, rules | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
+| `POST /smb-share-policies/rules` | New-PfbSmbShareRule |  |  | `high` |  |
 | `POST /snmp-managers` | New-PfbSnmpManager | names | host, notification, v2c, v3, version | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
 | `POST /software-check` | New-PfbSoftwareCheck | software_names, software_versions |  | `high` |  |
 | `POST /ssh-certificate-authority-policies` | New-PfbSshCaPolicy | names | enabled, location, name, signing_authority, static_authorized_principals | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
-| `POST /ssh-certificate-authority-policies/admins` | New-PfbSshCaPolicyAdmin | context_names |  | `high` |  |
-| `POST /ssh-certificate-authority-policies/arrays` | New-PfbSshCaPolicyArray | context_names |  | `high` |  |
 | `POST /sso/oidc/idps` | New-PfbOidcIdp |  | enabled, idp, services | `high` |  |
 | `POST /sso/saml2/idps` | New-PfbSaml2Idp |  | array_url, binding, enabled, idp, management, services, sp | `high` |  |
 | `POST /storage-class-tiering-policies` | New-PfbStorageClassTieringPolicy | names | archival_rules, enabled, location, name, retrieval_rules | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
@@ -506,14 +427,12 @@ Endpoints an existing cmdlet already calls, where the capability map knows of a 
 | `POST /syslog-servers` | New-PfbSyslogServer | names | services, sources, uri | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
 | `POST /targets` | New-PfbTarget | names | address | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
 | `POST /tls-policies` | New-PfbTlsPolicy | names | appliance_certificate, client_certificates_required, disabled_tls_ciphers, enabled, enabled_tls_ciphers, location, min_tls_version, name, trusted_client_certificate_authority, verify_client_certificate_trust | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
-| `POST /user-group-quota-policies` | New-PfbUserGroupQuotaPolicy | context_names | enabled, name | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
-| `POST /user-group-quota-policies/file-systems` | New-PfbUserGroupQuotaPolicyFileSystem | context_names |  | `high` |  |
-| `POST /user-group-quota-policies/rules` | New-PfbUserGroupQuotaPolicyRule | context_names | enforced | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
-| `POST /workloads` | New-PfbWorkload | context_names |  | `high` |  |
-| `POST /workloads/placement-recommendations` | New-PfbWorkloadPlacementRecommendation | context_names | additional_constraints, parameters, preset, projection_months, recommendation_engine, results_limit | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
-| `POST /worm-data-policies` | New-PfbWormPolicy | context_names, names | default_retention, enabled, location, max_retention, min_retention, mode, retention_lock | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
-| `PUT /presets/workload` | Set-PfbPresetWorkload | context_names | description, directory_configurations, export_configurations, name, parameters, periodic_replication_configurations, placement_configurations, platform_features, qos_configurations, quota_configurations, snapshot_configurations, volume_configurations, workload_tags, workload_type | `high` |  |
-| `PUT /workloads/tags/batch` | Set-PfbWorkloadTag | context_names | copyable, key, namespace, resource, value | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
+| `POST /user-group-quota-policies` | New-PfbUserGroupQuotaPolicy |  | enabled, name | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
+| `POST /user-group-quota-policies/rules` | New-PfbUserGroupQuotaPolicyRule |  | enforced | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
+| `POST /workloads/placement-recommendations` | New-PfbWorkloadPlacementRecommendation |  | additional_constraints, parameters, preset, projection_months, recommendation_engine, results_limit | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
+| `POST /worm-data-policies` | New-PfbWormPolicy | names | default_retention, enabled, location, max_retention, min_retention, mode, retention_lock | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
+| `PUT /presets/workload` | Set-PfbPresetWorkload |  | description, directory_configurations, export_configurations, name, parameters, periodic_replication_configurations, placement_configurations, platform_features, qos_configurations, quota_configurations, snapshot_configurations, volume_configurations, workload_tags, workload_type | `high` |  |
+| `PUT /workloads/tags/batch` | Set-PfbWorkloadTag |  | copyable, key, namespace, resource, value | `partial` -- /!\ 1 unresolved param (see Partial-confidence detail below) |  |
 
 ### Partial-confidence detail
 
@@ -521,9 +440,6 @@ Per the decision-6 procedure above: open each parameter at its `file:line` and f
 
 | Endpoint | Parameter | Surface | File:Line | Caveat |
 |---|---|---|---|---|
-| `DELETE /buckets` | `-Eradicate` | TypedUnresolved | `Public/Bucket/Remove-PfbBucket.ps1:27` | one or more parameters could not be traced to a wire name and have no -Attributes escape hatch; lists reflect typed-parameter coverage only, not full wire reachability |
-| `DELETE /file-system-snapshots` | `-Eradicate` | TypedUnresolved | `Public/FileSystemSnapshot/Remove-PfbFileSystemSnapshot.ps1:24` | one or more parameters could not be traced to a wire name and have no -Attributes escape hatch; lists reflect typed-parameter coverage only, not full wire reachability |
-| `DELETE /file-systems` | `-Eradicate` | TypedUnresolved | `Public/FileSystem/Remove-PfbFileSystem.ps1:38` | one or more parameters could not be traced to a wire name and have no -Attributes escape hatch; lists reflect typed-parameter coverage only, not full wire reachability |
 | `DELETE /file-systems/sessions` | `-Force` | TypedUnresolved | `Public/FileSystem/Remove-PfbFileSystemSession.ps1:59` | one or more parameters could not be traced to a wire name and have no -Attributes escape hatch; lists reflect typed-parameter coverage only, not full wire reachability |
 | `DELETE /quotas/groups` | `-FileSystemName` | TypedUnresolved | `Public/Quota/Remove-PfbQuotaGroup.ps1:35` | one or more parameters could not be traced to a wire name and have no -Attributes escape hatch; lists reflect typed-parameter coverage only, not full wire reachability |
 | `DELETE /quotas/groups` | `-GroupId` | TypedUnresolved | `Public/Quota/Remove-PfbQuotaGroup.ps1:37` | one or more parameters could not be traced to a wire name and have no -Attributes escape hatch; lists reflect typed-parameter coverage only, not full wire reachability |

--- a/Tests/Build-PfbApiDriftReport.Tests.ps1
+++ b/Tests/Build-PfbApiDriftReport.Tests.ps1
@@ -491,8 +491,17 @@ Describe 'Build-PfbApiDriftReport (real generated artifacts, skips gracefully if
         # rather than "the detail rows currently total exactly N", which breaks the instant
         # an unrelated PR adds or removes one endpoint missing context_names/allow_errors.
         # See docs/superpowers/plans/2026-07-30-drift-report-acceptance-figure-invariants.md.
+        #
+        # context_names was asserted here alongside allow_errors until issue #113 taught the
+        # injection detector to resolve a $script:-held wire key. The module has injected it
+        # centrally since Fusion Phase 1, so it is no longer a gap, and requiring it to still
+        # be one would pin the very defect that fix removed. Its ABSENCE is asserted here
+        # rather than the name merely dropped, because "the field correctly disappeared" and
+        # "the aggregation silently broke" are indistinguishable from a missing assertion.
         $highConfidenceGaps = @($realManifest.parameterGaps | Where-Object { $_.confidence.level -eq 'high' })
-        foreach ($fieldName in @('context_names', 'allow_errors')) {
+        @($realManifest.systemicGaps | Where-Object { $_.name -eq 'context_names' }) |
+            Should -BeNullOrEmpty -Because 'context_names is centrally injected, so it must no longer be reported as a systemic gap (#113)'
+        foreach ($fieldName in @('allow_errors')) {
             $finding = $realManifest.systemicGaps | Where-Object { $_.name -eq $fieldName }
             $finding | Should -Not -BeNullOrEmpty -Because "$fieldName is expected to still be a systemic gap in the real API surface"
             $recount = Get-RealRecountedEndpointCount -Gaps $highConfidenceGaps -FieldName $fieldName
@@ -519,12 +528,20 @@ Describe 'Build-PfbApiDriftReport (real generated artifacts, skips gracefully if
             $entry.cmdletCount | Should -BeGreaterThan 0 -Because "$fieldName is a widely-adopted convention; a drop to zero would be a real regression worth failing loudly for"
         }
 
-        # context_names is the ONE name this report expects to have NO adopting cmdlets --
-        # Get-PfbConventionStrength's own docstring: "that zero IS the finding for names like
-        # context_names". This is an architectural fact (see the Fusion context_names design
-        # conclusion), not a live-count regression canary -- it stays an exact pin
-        # deliberately, unlike names/ids above.
-        ($realManifest.conventionStrength | Where-Object { $_.name -eq 'context_names' }).cmdletCount | Should -Be 0
+        # context_names used to be pinned here at cmdletCount 0 -- Get-PfbConventionStrength's
+        # "that zero IS the finding" case. It is no longer present at all, and that is correct
+        # rather than a loss: conventionStrength is computed over the systemicGaps NAMES
+        # (tools/Build-PfbApiDriftReport.ps1 passes `-Names @($systemicGapsRaw.Name)`), and
+        # issue #113 removed context_names from systemicGaps because the module injects it
+        # centrally. A field that is no longer a gap has no convention strength to report.
+        #
+        # The architectural fact the old pin encoded -- that no cmdlet exposes context_names as
+        # a typed parameter, by design -- has not changed and is still asserted directly, on
+        # Get-PfbConventionStrength itself rather than on this manifest, in
+        # Tests/PfbApiDriftTools.Tests.ps1 ('convention strength: names/ids have a non-vacuous,
+        # established convention; context_names has none'), which passes the name in explicitly
+        # and so does not depend on it being a gap.
+        $realManifest.conventionStrength.name | Should -Not -Contain 'context_names' -Because 'it is no longer a systemic gap, so it is not scored for convention strength (#113)'
     }
 
     It 'Task 7: carries every field annotation from docs/drift-annotations.json onto its systemic-gap finding, verbatim' {

--- a/Tests/PfbApiDriftTools.Tests.ps1
+++ b/Tests/PfbApiDriftTools.Tests.ps1
@@ -1018,15 +1018,21 @@ Describe 'Get-PfbDriftAnnotations / Find-PfbDriftAnnotation (Task 6: recorded de
         @(Find-PfbDriftAnnotation -Annotations $null -FieldName 'context_names').Count | Should -Be 0
     }
 
-    It 'the real checked-in docs/drift-annotations.json loads and carries both required seed entries' {
+    It 'the real checked-in docs/drift-annotations.json loads and carries its required seed entries' {
         $realPath = Join-Path $repoRoot 'docs/drift-annotations.json'
         Test-Path $realPath | Should -BeTrue
         # @(...) wraps each call itself -- see the file-keyed test above for why a bare
         # single-match result silently fails .Count on Windows PowerShell 5.1.
         $realAnnotations = Get-PfbDriftAnnotations -Path $realPath
-        @(Find-PfbDriftAnnotation -Annotations $realAnnotations -FieldName 'context_names').Count | Should -Be 1
         @(Find-PfbDriftAnnotation -Annotations $realAnnotations -FieldName 'allow_errors').Count | Should -Be 1
         @(Find-PfbDriftAnnotation -Annotations $realAnnotations -Endpoint 'DELETE /management-access-policies').Count | Should -Be 1
+
+        # The context_names annotation existed only to explain why a DELIVERED feature was
+        # still being reported as a gap, and it named issue #113 as the reason. With #113
+        # fixed the gap is gone, so the note has nothing left to annotate -- an annotation for
+        # a field that is no longer reported is dead config that silently never matches.
+        # Asserted as an absence so it cannot be reintroduced without a deliberate decision.
+        @(Find-PfbDriftAnnotation -Annotations $realAnnotations -FieldName 'context_names').Count | Should -Be 0
     }
 }
 
@@ -1162,6 +1168,162 @@ function Test-PfbFixtureMixed {
         $injectionSites | Where-Object { $_.Key -eq 'X-Request-ID' } | Should -BeNullOrEmpty
         $injectionSites | Where-Object { $_.Key -eq 'offset' } | Should -BeNullOrEmpty
     }
+
+    It 'records a literal key as KeySource literal, so issue #113''s constant resolution does not reclassify existing sites' {
+        ($injectionSites | Where-Object { $_.Key -eq 'continuation_token' }).KeySource | Should -Be 'literal'
+    }
+}
+
+Describe 'Private callers are not public surface (issue #113)' {
+    It 'Get-PfbModuleCalledEndpoints records which tree each calling function came from' {
+        $pub = @($script:calledEndpoints | Where-Object { $_.IsPublic })
+        $priv = @($script:calledEndpoints | Where-Object { -not $_.IsPublic })
+        $pub | Should -Not -BeNullOrEmpty
+        $priv | Should -Not -BeNullOrEmpty
+        $priv | ForEach-Object { $_.File | Should -Match 'Private' }
+    }
+
+    It 'the real GET /admins gap omits Resolve-PfbAdminLocality while the endpoint stays covered' -Skip:($PSVersionTable.PSVersion.Major -lt 7) {
+        # Asserted against the REAL capability map rather than a synthetic one: this is the
+        # single occurrence the issue was raised for, and hand-building a stand-in map only
+        # tests my model of its shape. Both halves are asserted together because dropping the
+        # private caller from COVERAGE as well would turn a presentation fix into a
+        # manufactured uncovered-endpoint finding.
+        $capMapPath = Join-Path $repoRoot 'Data/PfbCapabilityMap.json'
+        if (-not (Test-Path $capMapPath)) { Set-ItResult -Skipped -Because 'Data/PfbCapabilityMap.json not present locally'; return }
+
+        $capMap = Get-Content -Path $capMapPath -Raw | ConvertFrom-Json -Depth 20
+        $called = @(Get-PfbModuleCalledEndpoints -PublicDirectory (Join-Path $repoRoot 'Public') -PrivateDirectory (Join-Path $repoRoot 'Private'))
+        $inventory = @(Get-PfbCmdletParameterInventory -PublicDirectory (Join-Path $repoRoot 'Public'))
+
+        $gaps = @(Get-PfbParameterCoverageGaps -CapabilityMap $capMap -CalledEndpoints $called -CmdletInventory $inventory)
+        $adminGap = $gaps | Where-Object { $_.Endpoint -eq 'GET /admins' }
+        if (-not $adminGap) { Set-ItResult -Skipped -Because 'GET /admins currently has no parameter gap to attribute'; return }
+        $adminGap.Cmdlets | Should -Contain 'Get-PfbAdmin'
+        $adminGap.Cmdlets | Should -Not -Contain 'Resolve-PfbAdminLocality'
+
+        $uncovered = @(Get-PfbEndpointCoverageGaps -CapabilityMap $capMap -CalledEndpoints $called)
+        $uncovered.Endpoint | Should -Not -Contain 'GET /admins'
+    }
+
+    It 'the real GET /admins gap no longer credits Resolve-PfbAdminLocality' -Skip:($PSVersionTable.PSVersion.Major -lt 7) {
+        $real = @(Get-PfbModuleCalledEndpoints -PublicDirectory (Join-Path $repoRoot 'Public') -PrivateDirectory (Join-Path $repoRoot 'Private'))
+        $adminCalls = @($real | Where-Object { $_.Key -eq 'GET /admins' })
+        # Still SCANNED -- the private caller is recorded, just not presented as a cmdlet.
+        $adminCalls.Cmdlet | Should -Contain 'Resolve-PfbAdminLocality'
+        ($adminCalls | Where-Object { $_.Cmdlet -eq 'Resolve-PfbAdminLocality' }).IsPublic | Should -BeFalse
+        ($adminCalls | Where-Object { $_.Cmdlet -eq 'Get-PfbAdmin' }).IsPublic | Should -BeTrue
+    }
+}
+
+Describe 'Get-PfbCentralInjectionSites: variable-keyed injection (issue #113)' {
+    # The detector originally required the index to be a literal StringConstantExpressionAst,
+    # so `$QueryParams[$script:PfbContextParameterName] = ...` was invisible and context_names
+    # stayed a 268-endpoint systemic gap for the whole of Fusion Phase 1 while the module was
+    # in fact injecting it on every request. `continuation_token` is injected a few lines away
+    # in the same real function and WAS detected -- the only difference was the literal key.
+    #
+    # Resolving the constant is deliberately preferred over adding context_names to the
+    # hand-written $script:PfbNonActionableParameters list: it generalises to the next key
+    # injected the same way, and it keeps allow_errors (declared in the same constants file
+    # but injected nowhere) correctly reported as the still-open gap it is.
+    BeforeAll {
+        $script:constKeyDir = Join-Path $TestDrive 'ConstKeyPrivate'
+        New-Item -ItemType Directory -Path $constKeyDir -Force | Out-Null
+
+        # Mirrors the real Private/PfbContextConstants.ps1 + Private/Invoke-PfbApiRequest.ps1
+        # pair: the constant is defined at file scope in one file and used as an index
+        # expression in another, so resolution cannot be function-local.
+        Set-Content -Path (Join-Path $constKeyDir 'PfbFixtureConstants.ps1') -Value @'
+$script:PfbFixtureContextParameterName = 'fixture_context_names'
+$script:PfbFixtureAllowErrorsName       = 'fixture_allow_errors'
+'@
+
+        Set-Content -Path (Join-Path $constKeyDir 'Invoke-PfbFixtureContextRequest.ps1') -Value @'
+function Invoke-PfbFixtureContextRequest {
+    [CmdletBinding()]
+    param([hashtable]$QueryParams)
+    $hasContext = $true
+    $resolvedContext = [PSCustomObject]@{ Entries = @('a') }
+    if ($hasContext) {
+        $QueryParams[$script:PfbFixtureContextParameterName] = @($resolvedContext.Entries) -join ','
+    }
+}
+'@
+
+        $script:constKeySites = Get-PfbCentralInjectionSites -PrivateDirectory $constKeyDir
+    }
+
+    It 'resolves a $script: constant used as the index and records the constant''s VALUE as the key' {
+        $site = @($constKeySites | Where-Object { $_.Key -eq 'fixture_context_names' })
+        $site.Count | Should -Be 1
+    }
+
+    It 'records how the key was obtained, so a resolved key is distinguishable from a literal one' {
+        ($constKeySites | Where-Object { $_.Key -eq 'fixture_context_names' }).KeySource | Should -Be 'constant'
+    }
+
+    It 'never records the variable NAME as the key' {
+        # The failure this guards is silent and plausible-looking: a key of
+        # 'PfbFixtureContextParameterName' would match no capability-map field, so it would
+        # simply never intersect a gap and the fix would read as working.
+        $constKeySites.Key | Should -Not -Contain 'PfbFixtureContextParameterName'
+    }
+
+    It 'classifies the resolved site by the same rules as a literal one -- here server-or-internal-derived' {
+        # RHS references $resolvedContext (a local, not a parameter) and the guard is the bare
+        # local $hasContext, so neither tracing rule fires. Same shape as the real injection.
+        ($constKeySites | Where-Object { $_.Key -eq 'fixture_context_names' }).Classification |
+            Should -Be 'server-or-internal-derived'
+    }
+
+    It 'a constant that is DEFINED but never used as an index produces no site' {
+        # allow_errors' real situation: it lives in the same constants file as context_names
+        # and is genuinely unimplemented, so it must stay a reported gap. Resolving constants
+        # must not conjure a site out of a mere definition.
+        $constKeySites.Key | Should -Not -Contain 'fixture_allow_errors'
+    }
+
+    It 'derives the resolved key as a non-actionable parameter' {
+        $derived = Get-PfbDerivedNonActionableParameters -InjectionSites $constKeySites
+        $derived.Name | Should -Contain 'fixture_context_names'
+        $derived.Name | Should -Not -Contain 'fixture_allow_errors'
+    }
+
+    It 'refuses to resolve a variable index that is not a known constant, rather than guessing' {
+        $unknownDir = Join-Path $TestDrive 'UnknownKeyPrivate'
+        New-Item -ItemType Directory -Path $unknownDir -Force | Out-Null
+        Set-Content -Path (Join-Path $unknownDir 'Invoke-PfbFixtureUnknownKey.ps1') -Value @'
+function Invoke-PfbFixtureUnknownKey {
+    [CmdletBinding()]
+    param([hashtable]$QueryParams, [string]$KeyName)
+    $QueryParams[$KeyName] = 'x'
+}
+'@
+        $sites = @(Get-PfbCentralInjectionSites -PrivateDirectory $unknownDir)
+        $sites.Count | Should -Be 0
+    }
+
+    It 'refuses a constant whose name is assigned two different literals' {
+        # Never-guess, matching the rest of these scanners: an ambiguous constant resolves to
+        # nothing rather than to whichever assignment the file walk happened to reach last,
+        # which would make the result depend on filesystem enumeration order.
+        $ambiguousDir = Join-Path $TestDrive 'AmbiguousConstPrivate'
+        New-Item -ItemType Directory -Path $ambiguousDir -Force | Out-Null
+        Set-Content -Path (Join-Path $ambiguousDir 'PfbFixtureAmbiguous.ps1') -Value @'
+$script:PfbFixtureAmbiguousKey = 'first_value'
+$script:PfbFixtureAmbiguousKey = 'second_value'
+function Invoke-PfbFixtureAmbiguous {
+    [CmdletBinding()]
+    param([hashtable]$QueryParams)
+    $QueryParams[$script:PfbFixtureAmbiguousKey] = 'x'
+}
+'@
+        $sites = @(Get-PfbCentralInjectionSites -PrivateDirectory $ambiguousDir)
+        $sites.Key | Should -Not -Contain 'first_value'
+        $sites.Key | Should -Not -Contain 'second_value'
+    }
+
 }
 
 Describe 'Central-injection detection against the REAL Private/ tree (confirms the acceptance-critical claims for real)' -Skip:($PSVersionTable.PSVersion.Major -lt 7) {
@@ -1212,6 +1374,30 @@ Describe 'Central-injection detection against the REAL Private/ tree (confirms t
         foreach ($key in @('filter', 'sort', 'limit', 'total_only', 'names', 'ids')) {
             $merged | Should -Not -Contain $key
         }
+    }
+
+    It 'context_names is detected in the real tree via its $script: constant, and allow_errors is not (issue #113)' {
+        # The pair is the whole point, which is why they are asserted together rather than in
+        # two tests. Both names live in Private/PfbContextConstants.ps1; only context_names is
+        # actually injected (Private/Invoke-PfbApiRequest.ps1). A fix that resolved constants
+        # by DEFINITION rather than by USE would drop both, silently deleting the 118-endpoint
+        # allow_errors gap that Phase 2 still owes -- and the report would look tidier for it.
+        $sites = Get-PfbCentralInjectionSites -PrivateDirectory $realPrivateDirectory
+
+        $contextSites = @($sites | Where-Object { $_.Key -eq 'context_names' })
+        $contextSites | Should -Not -BeNullOrEmpty
+        $contextSites | ForEach-Object { $_.KeySource | Should -Be 'constant' }
+        $contextSites | ForEach-Object { $_.Classification | Should -Be 'server-or-internal-derived' }
+
+        $sites | Where-Object { $_.Key -eq 'allow_errors' } | Should -BeNullOrEmpty
+
+        $derived = Get-PfbDerivedNonActionableParameters -InjectionSites $sites
+        $derived.Name | Should -Contain 'context_names'
+        $derived.Name | Should -Not -Contain 'allow_errors'
+
+        $merged = Get-PfbNonActionableParameters -PrivateDirectory $realPrivateDirectory
+        $merged | Should -Contain 'context_names'
+        $merged | Should -Not -Contain 'allow_errors'
     }
 }
 
@@ -1285,15 +1471,35 @@ Describe 'Task 6 real-data invariants (systemic gaps + convention strength, skip
     # value AT THE TIME -- kept here as institutional memory, not as a hardcoded expectation.
     # See docs/superpowers/plans/2026-07-30-drift-report-acceptance-figure-invariants.md for
     # why exact real-data counts are the wrong assertion for an ever-growing API surface.
-    It 'systemic-gaps EndpointCount for allow_errors/context_names matches an independent recount straight from the same $realGaps2 fed to Get-PfbSystemicGaps' {
+    It 'systemic-gaps EndpointCount for allow_errors matches an independent recount straight from the same $realGaps2 fed to Get-PfbSystemicGaps' {
         if (-not $hasRealData) { Set-ItResult -Skipped -Because 'Data/PfbCapabilityMap.json not present locally'; return }
-        foreach ($fieldName in @('allow_errors', 'context_names')) {
+        # context_names was asserted here alongside allow_errors until issue #113. It is no
+        # longer a systemic gap -- the module injects it centrally, and the detector can now
+        # see that -- so requiring it to still be one would pin the very defect #113 fixed.
+        # Its absence is asserted as its own expectation in the test below rather than merely
+        # dropped, because "the name disappeared" and "the aggregation broke" look identical
+        # from here otherwise.
+        foreach ($fieldName in @('allow_errors')) {
             $finding = $realSystemicGaps2 | Where-Object { $_.Name -eq $fieldName }
             $finding | Should -Not -BeNullOrEmpty -Because "$fieldName is expected to still be a systemic gap in the real API surface"
             $recount = Get-RealRecountedEndpointCount2 -Gaps $realGaps2 -FieldName $fieldName
             $finding.EndpointCount | Should -Be $recount -Because 'EndpointCount must equal a fresh tally over the same input gaps, independent of Get-PfbSystemicGaps'' own aggregation'
             $finding.EndpointCount | Should -BeGreaterThan 0 -Because 'a vacuous/zero count would mean the field silently stopped being a systemic gap without anyone noticing here'
         }
+    }
+
+    It 'context_names is NO LONGER a systemic gap, while allow_errors still is (issue #113)' {
+        if (-not $hasRealData) { Set-ItResult -Skipped -Because 'Data/PfbCapabilityMap.json not present locally'; return }
+        # The asymmetry is the assertion. Both names are declared in the same file
+        # (Private/PfbContextConstants.ps1); only context_names is actually injected. A
+        # regression in either direction is a real defect with a different cause:
+        #   context_names reappears -> the constant stopped resolving, and the module's
+        #                              delivered Fusion targeting is being reported as missing
+        #                              on 268 endpoints again.
+        #   allow_errors disappears  -> something started crediting a name from its DEFINITION
+        #                              rather than its USE, silently deleting a Phase 2 gap.
+        $realSystemicGaps2.Name | Should -Not -Contain 'context_names'
+        $realSystemicGaps2.Name | Should -Contain 'allow_errors'
     }
 
     It 'convention strength: names/ids have a non-vacuous, established convention; context_names has none (0 cmdlets, by design)' {

--- a/Tests/coverage-baseline.psd1
+++ b/Tests/coverage-baseline.psd1
@@ -242,7 +242,10 @@
             # is a real signal rather than noise.
             'Build-PfbValueEnumMap.Tests.ps1'                    = 14
             'Build-PfbCapabilityMap.ContextScopeDrift.Tests.ps1' = 13
-            'PfbApiDriftTools.Tests.ps1'                         = 8
+            # 8 -> 12 for issue #113: four new tests assert against the REAL Public/Private
+            # tree and the real capability map, so they carry the file's existing PS7 gate.
+            # Measured on Windows PowerShell 5.1, not inferred -- 125 passed / 12 skipped.
+            'PfbApiDriftTools.Tests.ps1'                         = 12
             'PfbValueEnumTools.Tests.ps1'                        = 8
             'PfbSpecTools.Tests.ps1'                             = 6
             'PfbSpecTools.ContextScope.Tests.ps1'                = 4

--- a/docs/drift-annotations.json
+++ b/docs/drift-annotations.json
@@ -4,13 +4,6 @@
   "annotations": [
     {
       "matchType": "field",
-      "match": "context_names",
-      "kind": "designDecision",
-      "note": "implemented in Phase 1 via central injection; still listed as a gap because the drift detector does not resolve the variable-keyed injection site (issue #113)",
-      "reference": "docs/design/fusion-context-phase-1-spec.md"
-    },
-    {
-      "matchType": "field",
       "match": "allow_errors",
       "kind": "designDecision",
       "note": "not yet implemented; deferred to Phase 2",

--- a/tools/Build-PfbApiDriftReport.ps1
+++ b/tools/Build-PfbApiDriftReport.ps1
@@ -476,9 +476,12 @@ $systemicGaps = @($systemicGapsRaw | ForEach-Object {
 # a table built ONCE (Get-PfbWireNameCmdletCounts), so every systemic-gap name gets ranked
 # here -- nothing is silently dropped from this list. Re-sorted by CmdletCount descending
 # (Get-PfbConventionStrength itself preserves -Names' input order, ranking is this script's
-# own choice) since a mechanical batch-fix candidate (high CmdletCount, e.g. `names` at
-# 306) and an architectural gap (zero CmdletCount, e.g. `context_names`) are the two ends
-# of this ranking a reader most wants surfaced first/last.
+# own choice) since a mechanical batch-fix candidate (high CmdletCount, e.g. `names`, in the
+# hundreds) and an architectural gap (zero CmdletCount, e.g. `allow_errors`) are the two ends
+# of this ranking a reader most wants surfaced first/last. `context_names` was the standing
+# example of the architectural end until issue #113 removed it from systemicGaps entirely --
+# which makes a coupling worth stating explicit: this list is built from the systemicGaps
+# NAMES, so a name that stops being a gap stops being scored here at all.
 $conventionStrengthRaw = @(if ($systemicGapsRaw.Count -gt 0) { Get-PfbConventionStrength -CmdletInventory $inventory -Names @($systemicGapsRaw.Name) } else { @() })
 $conventionStrength = @($conventionStrengthRaw | Sort-Object -Property @{ Expression = 'CmdletCount'; Descending = $true }, Name |
         ForEach-Object { [ordered]@{ name = $_.Name; cmdletCount = $_.CmdletCount; cmdlets = @($_.Cmdlets) } })

--- a/tools/README.md
+++ b/tools/README.md
@@ -334,14 +334,22 @@ Run in this order:
    would overstate a confidence the endpoint's own row already warns against). Each finding is
    `{ name, endpointCount, queryEndpointCount, bodyEndpointCount, endpoints, annotations }` --
    turning hundreds of per-endpoint rows into a handful of real, actionable decisions: e.g.
-   `context_names` and `allow_errors` are each one decision, not one finding per affected
-   endpoint. `conventionStrength` then ranks each systemic-gap name by how many existing `Public/`
+   `allow_errors` is one decision, not one finding per affected endpoint.
+   `conventionStrength` then ranks each systemic-gap name by how many existing `Public/`
    cmdlets already expose it as a `Typed` parameter somewhere in the module (`Get-PfbConventionStrength`),
-   sorted by that count descending: a high count (`names` at 306 cmdlets) means closing the
-   remaining gaps for that name is a mechanical batch fix; a count of zero (`context_names`, 0 --
+   sorted by that count descending: a high count (`names`, in the hundreds) means closing the
+   remaining gaps for that name is a mechanical batch fix; a count of zero (`allow_errors`, 0 --
    no cmdlet anywhere in the module has ever exposed this name as a `Typed` parameter) means no
    established convention exists to extend at all, and closing it is an architectural decision,
-   not a mechanical one. Both keys read `docs/drift-annotations.json` (via
+   not a mechanical one.
+
+   `context_names` was this section's running example of both until issue #113, and is no longer a
+   systemic gap at all: the module injects it centrally in `Private/Invoke-PfbApiRequest.ps1`, and
+   the injection detector now resolves the `$script:` constant holding the key, so there is nothing
+   left to report. Worth keeping as a worked example of the failure mode -- the detector matched
+   only literal keys, so a delivered feature read as missing on 268 endpoints for the whole life of
+   Fusion Phase 1, while `continuation_token`, injected a few lines away with an inline key, was
+   detected correctly the entire time. Both keys read `docs/drift-annotations.json` (via
    `Get-PfbDriftAnnotations`/`Find-PfbDriftAnnotation`) for recorded design decisions, prior
    conclusions, or live-testing hazards matched by field name (`systemicGaps[].annotations`) or by
    endpoint (`parameterGaps[].annotations`) -- the file is optional; its absence degrades every
@@ -356,7 +364,7 @@ Run in this order:
    partial-confidence rows and are therefore absent from both `systemicGaps` and
    `conventionStrength` entirely** (e.g. `base_dn`, `bind_password`, `domain`, `nameservers`,
    `qos_policy`, `storage_class`, `owner`, ...), and a name that DOES appear can still undercount:
-   `context_names`'s high-confidence-only `systemicGaps` figure is smaller than its true
+   `allow_errors`'s high-confidence-only `systemicGaps` figure is smaller than its true
    cross-confidence total across every endpoint, by design (that's the limitation described
    above, not a discrepancy worth investigating). No individual endpoint's own
    `missingQueryParameters`/`missingBodyProperties` row is affected -- this is purely a gap in the

--- a/tools/lib/PfbApiDriftTools.ps1
+++ b/tools/lib/PfbApiDriftTools.ps1
@@ -98,10 +98,20 @@ function Get-PfbModuleCalledEndpoints {
         "<METHOD> /<endpoint>" key format Data/PfbCapabilityMap.json uses (see
         Private/Assert-PfbApiCapability.ps1:40-41).
     .OUTPUTS
-        [PSCustomObject]@{ Key; Method; Endpoint; Resolved; Cmdlet; File }[] -- Resolved
-        is $false (Key/Method/Endpoint all $null) when a call's -Endpoint isn't a plain
-        string literal (built dynamically via interpolation or a variable), never
+        [PSCustomObject]@{ Key; Method; Endpoint; Resolved; Cmdlet; IsPublic; File }[] --
+        Resolved is $false (Key/Method/Endpoint all $null) when a call's -Endpoint isn't a
+        plain string literal (built dynamically via interpolation or a variable), never
         silently dropped or guessed at.
+
+        IsPublic (issue #113) says which tree the calling FUNCTION was found in. A function
+        under Private/ genuinely calls the endpoint, so it belongs in a scan of what the
+        module touches -- but it is not a cmdlet, is not exported, and cannot be invoked by a
+        user, so it must not be presented as the public surface covering that endpoint. The
+        real case is Resolve-PfbAdminLocality reading is_local from GET /admins, which the
+        report listed next to Get-PfbAdmin as though the two were peers. Consumers that mean
+        "public surface" filter on this; consumers that mean "anything that touches the wire"
+        do not. Get-PfbEndpointCoverageGaps deliberately still counts BOTH, since an endpoint
+        a private helper reaches is not an uncovered endpoint.
     #>
     [CmdletBinding()]
     param(
@@ -113,10 +123,20 @@ function Get-PfbModuleCalledEndpoints {
     # Belt-and-braces only -- the load-bearing sort is on the records at the end of this
     # function (issue #85). Public/ and Private/ are sorted separately, preserving the
     # Public-then-Private grouping this scan has always emitted in.
-    $files = @(Get-ChildItem -Path $PublicDirectory -Filter '*.ps1' -Recurse -File | Sort-Object -Property FullName -Culture '') +
-             @(Get-ChildItem -Path $PrivateDirectory -Filter '*.ps1' -Recurse -File | Sort-Object -Property FullName -Culture '')
+    #
+    # Provenance is carried per file rather than re-derived from the path afterwards (issue
+    # #113): a path regex would have to cope with both separators and with a repo checked out
+    # under a directory that itself contains 'Private', whereas the caller has already told us
+    # which tree each file came from.
+    $publicFiles = @(Get-ChildItem -Path $PublicDirectory -Filter '*.ps1' -Recurse -File | Sort-Object -Property FullName -Culture '')
+    $privateFiles = @(Get-ChildItem -Path $PrivateDirectory -Filter '*.ps1' -Recurse -File | Sort-Object -Property FullName -Culture '')
+    $isPublicByPath = @{}
+    foreach ($f in $publicFiles) { $isPublicByPath[$f.FullName] = $true }
+    foreach ($f in $privateFiles) { if (-not $isPublicByPath.ContainsKey($f.FullName)) { $isPublicByPath[$f.FullName] = $false } }
+    $files = $publicFiles + $privateFiles
 
     foreach ($file in $files) {
+        $isPublicFile = $isPublicByPath[$file.FullName]
         $tokens = $null; $parseErrors = $null
         $ast = [System.Management.Automation.Language.Parser]::ParseFile($file.FullName, [ref]$tokens, [ref]$parseErrors)
         $functionAsts = $ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.FunctionDefinitionAst] }, $true)
@@ -152,6 +172,7 @@ function Get-PfbModuleCalledEndpoints {
                         Endpoint = $normalizedEndpoint
                         Resolved = $true
                         Cmdlet   = $funcAst.Name
+                        IsPublic = $isPublicFile
                         File     = $file.FullName
                     })
                 }
@@ -162,6 +183,7 @@ function Get-PfbModuleCalledEndpoints {
                         Endpoint = $null
                         Resolved = $false
                         Cmdlet   = $funcAst.Name
+                        IsPublic = $isPublicFile
                         File     = $file.FullName
                     })
                 }
@@ -325,11 +347,26 @@ function Get-PfbParameterCoverageGaps {
         $entry = $CapabilityMap.endpoints.$key
         if (-not $entry) { continue }
 
+        # Public callers only (issue #113). This field is read as "the public surface covering
+        # this endpoint", and a Private/ helper is not that -- it is unexported and a user
+        # cannot invoke it. Listing Resolve-PfbAdminLocality beside Get-PfbAdmin under
+        # GET /admins made one field mean two things, and only one of them is what a coverage
+        # report is read for. The filter is on the whole gap's cmdlet list, NOT on the endpoint
+        # grouping above: an endpoint a private helper reaches is still a reached endpoint, so
+        # Get-PfbEndpointCoverageGaps must keep counting it or this fix would manufacture
+        # uncovered-endpoint findings out of a presentation problem.
+        #
         # Sort-Object -Unique, not Select-Object -Unique: the latter preserves INPUT order and
         # does not sort, which is the intra-row cmdlet flip observed in issue #85
         # (`Get-PfbArray, Test-PfbConnection` becoming `Test-PfbConnection, Get-PfbArray`).
         # Matches the already-correct pattern in Get-PfbConventionStrength below.
-        $cmdlets = @($group.Group.Cmdlet | Sort-Object -Unique -Culture '')
+        #
+        # `-ne $false` rather than `-eq $true`: a caller passing hand-built call records that
+        # predate IsPublic leaves it $null, and treating an unknown provenance as private
+        # would silently empty this list. Records from Get-PfbModuleCalledEndpoints always
+        # carry the real boolean.
+        $cmdlets = @($group.Group | Where-Object { $_.IsPublic -ne $false } |
+                ForEach-Object { $_.Cmdlet } | Sort-Object -Unique -Culture '')
 
         $exposedWireNames = [System.Collections.Generic.HashSet[string]]::new()
         $unresolved = [System.Collections.Generic.List[object]]::new()
@@ -1235,6 +1272,114 @@ function Test-PfbGuardedByParameterCondition {
     return $false
 }
 
+function Get-PfbPrivateScriptConstant {
+    <#
+    .SYNOPSIS
+        Maps every unambiguous `$script:Name = '<literal>'` in -PrivateDirectory to its string
+        value, so Get-PfbCentralInjectionSites can resolve a wire key held in a constant
+        instead of written inline.
+    .DESCRIPTION
+        Exists because of issue #113. The injection detector originally required the index of
+        `$Var[<index>] = <rhs>` to be a literal string, so
+        `$QueryParams[$script:PfbContextParameterName] = ...`
+        (Private/Invoke-PfbApiRequest.ps1, the Fusion Phase 1 central injection) was invisible
+        to it, and `context_names` stayed a 268-endpoint systemic gap for the entire life of a
+        feature that was already injecting it on every request. `continuation_token` is
+        injected a few lines away in the same function and WAS detected -- the only difference
+        was the literal key.
+
+        Keys are the AST's own `VariablePath.UserPath`, which retains the `script:` prefix
+        (`script:PfbContextParameterName`). That is deliberate: the definition site and the use
+        site produce the identical string, so no normalisation step can drift between them.
+
+        Never guesses, matching every other scanner in this file and in
+        tools/lib/PfbCmdletParamTools.ps1:
+
+          - only `$script:`-scoped targets, since a function-local of the same name is a
+            different variable and this walk has no scope model to tell them apart;
+          - only a right-hand side that is a single string literal. An expression, a
+            concatenation or an array is not a constant this scan can safely evaluate, and
+            evaluating it would mean executing module code from a report generator;
+          - a name assigned two DIFFERENT literals resolves to nothing. Taking the last one
+            would make the result depend on filesystem enumeration order, which is the same
+            defect class as issue #85. Re-assigning the same literal twice is harmless and
+            stays resolved.
+
+        Note the scan is over definitions only. A constant that is defined but never used as
+        an index yields no injection site, which is load-bearing rather than incidental:
+        `allow_errors` sits in Private/PfbContextConstants.ps1 next to `context_names` and is
+        genuinely unimplemented (deferred to Phase 2). Resolving by definition rather than by
+        use would silently delete its 118-endpoint gap.
+    .OUTPUTS
+        [hashtable] -- VariablePath.UserPath -> [string] value. Ambiguous names are absent.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$PrivateDirectory
+    )
+
+    $values = @{}
+    $ambiguous = [System.Collections.Generic.HashSet[string]]::new([string[]]@(), [System.StringComparer]::Ordinal)
+
+    # Sorted for the same reason as every other walk in this file (#85): an unsorted recursive
+    # Get-ChildItem is filesystem-ordered, and while the ambiguity rule below makes the RESULT
+    # order-independent, the walk itself should still be reproducible for debugging.
+    $files = @(Get-ChildItem -Path $PrivateDirectory -Filter '*.ps1' -Recurse -File | Sort-Object -Property FullName -Culture '')
+
+    foreach ($file in $files) {
+        $ast = [System.Management.Automation.Language.Parser]::ParseFile($file.FullName, [ref]$null, [ref]$null)
+
+        foreach ($assign in $ast.FindAll({
+                    param($n)
+                    $n -is [System.Management.Automation.Language.AssignmentStatementAst] -and
+                    $n.Left -is [System.Management.Automation.Language.VariableExpressionAst]
+                }, $true)) {
+
+            $target = $assign.Left -as [System.Management.Automation.Language.VariableExpressionAst]
+            if (-not $target.VariablePath.IsScript) { continue }
+            $name = $target.VariablePath.UserPath
+
+            # The parser wraps a bare expression right-hand side in a CommandExpressionAst,
+            # sometimes inside a single-element PipelineAst. Casting without peeling yields
+            # $null, which reads as "not a literal" rather than "wrong layer" -- the same trap
+            # documented on Resolve-PfbSingleExpression in tools/lib/PfbCmdletParamTools.ps1,
+            # peeled inline here because this file does not dot-source that one.
+            $node = $assign.Right
+            for ($i = 0; $i -lt 3; $i++) {
+                if ($node -is [System.Management.Automation.Language.PipelineAst]) {
+                    if ($node.PipelineElements.Count -ne 1) { break }
+                    $node = $node.PipelineElements[0]
+                    continue
+                }
+                if ($node -is [System.Management.Automation.Language.CommandExpressionAst]) {
+                    $node = $node.Expression
+                    continue
+                }
+                break
+            }
+
+            $literal = $node -as [System.Management.Automation.Language.StringConstantExpressionAst]
+            if (-not $literal) {
+                # A non-literal assignment to a name makes that name unresolvable, rather than
+                # leaving an earlier literal standing: the later assignment is what the module
+                # would actually be holding by the time the injection runs.
+                [void]$ambiguous.Add($name)
+                continue
+            }
+
+            if ($values.ContainsKey($name) -and $values[$name] -cne $literal.Value) {
+                [void]$ambiguous.Add($name)
+                continue
+            }
+            $values[$name] = $literal.Value
+        }
+    }
+
+    foreach ($name in $ambiguous) { $values.Remove($name) }
+    return $values
+}
+
 function Get-PfbCentralInjectionSites {
     <#
     .SYNOPSIS
@@ -1281,9 +1426,14 @@ function Get-PfbCentralInjectionSites {
         to Assert-PfbApiCapability (the module's actual parameter-support gate) -- an
         assignment could in principle run before or after that gate in a way this scan
         does not model.
+        The index is read as a literal string, or -- issue #113 -- as a `$script:` constant
+        resolved by Get-PfbPrivateScriptConstant, which is how the Fusion central injection
+        `$QueryParams[$script:PfbContextParameterName] = ...` is seen at all. KeySource records
+        which of the two applied. Any other index shape is skipped rather than guessed at.
     .OUTPUTS
-        [PSCustomObject]@{ Key; File; Function; Line; TargetVariable; ParameterTraced;
-        Classification; Caveat }[] -- Classification is 'parameter-sourced' (traces to a
+        [PSCustomObject]@{ Key; KeySource; File; Function; Line; TargetVariable;
+        ParameterTraced; Classification; Caveat }[] -- KeySource is 'literal' or 'constant'.
+        Classification is 'parameter-sourced' (traces to a
         cmdlet/caller parameter; must NEVER become a candidate for
         $script:PfbNonActionableParameters) or 'server-or-internal-derived' (a candidate --
         see Get-PfbDerivedNonActionableParameters for how candidates are reduced to a final
@@ -1297,6 +1447,12 @@ function Get-PfbCentralInjectionSites {
 
     $targetVarNames = @('queryparams', 'body', 'into')
     $coverageCaveat = 'coverage claim only -- this AST scan cannot verify injection ordering relative to Assert-PfbApiCapability'
+
+    # Issue #113: the key may be held in a $script: constant rather than written inline. Built
+    # once for the whole directory because the constant and its use site live in different
+    # files (Private/PfbContextConstants.ps1 defines it, Private/Invoke-PfbApiRequest.ps1 uses
+    # it), so this cannot be resolved per-file or per-function.
+    $scriptConstants = Get-PfbPrivateScriptConstant -PrivateDirectory $PrivateDirectory
 
     $results = [System.Collections.Generic.List[object]]::new()
     # Belt-and-braces only -- see the record-level sort at the end of this function (#85).
@@ -1326,8 +1482,26 @@ function Get-PfbCentralInjectionSites {
                 if (-not $targetVar) { continue }
                 if ($targetVarNames -notcontains $targetVar.VariablePath.UserPath.ToLowerInvariant()) { continue }
 
+                # Two key shapes, in order. A literal index is the common case; a $script:
+                # constant is the Fusion central-injection case (#113). Anything else -- a
+                # local, a parameter, an expression -- resolves to nothing and the site is
+                # skipped, because a key this scan cannot name is a key it cannot intersect
+                # against the capability map, and guessing would invent a field.
                 $keyExpr = $indexExpr.Index -as [System.Management.Automation.Language.StringConstantExpressionAst]
-                if (-not $keyExpr) { continue }
+                $keyName = $null
+                $keySource = $null
+                if ($keyExpr) {
+                    $keyName = $keyExpr.Value
+                    $keySource = 'literal'
+                }
+                else {
+                    $indexVar = $indexExpr.Index -as [System.Management.Automation.Language.VariableExpressionAst]
+                    if ($indexVar -and $scriptConstants.ContainsKey($indexVar.VariablePath.UserPath)) {
+                        $keyName = $scriptConstants[$indexVar.VariablePath.UserPath]
+                        $keySource = 'constant'
+                    }
+                }
+                if ($null -eq $keyName) { continue }
 
                 $rhsTraced = Test-PfbExpressionReferencesParameter -ExpressionAst $assign.Right -ParameterNames $paramNames
                 $conditionTraced = Test-PfbGuardedByParameterCondition -Assignment $assign -ParameterNames $paramNames
@@ -1335,7 +1509,8 @@ function Get-PfbCentralInjectionSites {
                 $classification = if ($traced) { 'parameter-sourced' } else { 'server-or-internal-derived' }
 
                 $results.Add([PSCustomObject]@{
-                        Key             = $keyExpr.Value
+                        Key             = $keyName
+                        KeySource       = $keySource
                         File            = $file.FullName
                         Function        = $funcAst.Name
                         Line            = $assign.Extent.StartLineNumber


### PR DESCRIPTION
# fix: drift AST scanners miscount coverage (#113)

Closes #113.

The drift report's two AST scanners each had a defect that moved coverage numbers in the wrong
direction. Both are in `tools/lib/PfbApiDriftTools.ps1`; no cmdlet source changes.

## 1. Variable-keyed central injection was invisible

`Get-PfbCentralInjectionSites` only recognised a literal index — `$QueryParams['names'] = ...`. The
real `context_names` injection is written as `$QueryParams[$script:PfbContextNamesKey] = ...`, with
the key held in a `$script:` constant in a *different file* from its use site, so the scanner saw
nothing and the report claimed a 269-endpoint `context_names` gap for a feature that shipped in
Phase 1.

New helper `Get-PfbPrivateScriptConstant` maps `$script:Name = '<literal>'` across `Private/`, built
once for the whole directory because the definition and the use site cannot be resolved per-file.
Deliberately narrow, and the header says why:

- keys are `VariablePath.UserPath`, which retains the `script:` prefix, so definition and use
  produce identical strings;
- only `$script:`-scoped targets, and only single string literals;
- a name assigned two *different* literals resolves to nothing — order-independence, the same defect
  class as #85;
- it scans **definitions only**, so a defined-but-unused constant yields no injection site.

Injection records now carry `KeySource` (`literal` or `constant`) so the two paths stay
distinguishable in tests and in triage.

That last point is load-bearing and is asserted directly: `context_names` is detected in the real
tree via its constant, and `allow_errors` — defined as a constant but not centrally injected — is
still correctly *absent*. Getting either direction wrong is a regression, so both are pinned.

## 2. Private helpers were credited as public surface

`Get-PfbModuleCalledEndpoints` walked `Public/` and `Private/` into one list with no provenance, so
a private helper that issues a request (`Resolve-PfbAdminLocality`) was attributed as a cmdlet
covering that endpoint. The file walk now carries `IsPublic`, and
`Get-PfbParameterCoverageGaps` filters the *cmdlet attribution list* on it.

Two scoping decisions, both commented in place:

- the filter is `-ne $false`, not `-eq $true`, so hand-built records predating the field are not
  silently reclassified as private;
- it applies to the cmdlet list only, **not** to the endpoint grouping —
  `Get-PfbEndpointCoverageGaps` still counts both, because an endpoint the module calls from a
  private helper is genuinely covered. Only the "which cmdlet" answer was wrong.

## Effect on the committed report

| | before | after |
|---|---|---|
| `systemicGaps` | 241 | 240 (`context_names` gone; `allow_errors` intact at 118) |
| `parameterGaps` | 439 | 358 (81 endpoints whose only gap was `context_names`) |
| `confidence` = `partial` | 61 | 58 |
| `GET /admins` gap `cmdlets` | `Get-PfbAdmin`, `Resolve-PfbAdminLocality` | `Get-PfbAdmin` |

`GET /admins` stays out of `uncoveredEndpoints`, which is the point of the endpoint/cmdlet split
above.

The `context_names` entry in `docs/drift-annotations.json` is deleted — it existed only to explain
away this defect, and an annotation that survives its cause becomes a permanent excuse. Four tests
hardcoded `context_names` as a live systemic gap; each now asserts the corrected state rather than
merely dropping the name, and `tools/README.md` and the generator header use `allow_errors` as the
running "architectural gap, zero cmdletCount" example, with `context_names` retained as a worked
example of the failure mode itself.

`Tests/coverage-baseline.psd1` re-pins `PfbApiDriftTools.Tests.ps1` 8 → 12 for the new PS7-gated
tests (per-file `ExpectedSkips`, from PR #135).

The Task 6 aggregation-ratio invariant moved 55.72% → 39.97%, inside its existing `>0.30 / <0.60`
bounds. That is a re-verify, not a re-tune: the bounds were not touched.

## Verification

- Dual-edition scoped Pester over the 16 drift / dead-key / derived-artifact / coverage-gate test
  files: **pwsh 7 — 492 passed, 0 failed; Windows PowerShell 5.1 — 342 passed, 0 failed, 150
  skipped.** Containers healthy under both.
- `scripts/Assert-PfbDerivedArtifacts.ps1`: all 11 checked artifacts up to date. Only the
  drift-report pair moved.
- **Live-FlashBlade verification does not apply to this PR.** The diff is `tools/`, `Tests/`,
  `docs/` and `Reports/` only — nothing in `Public/`, `Private/`,
  `PureStorageFlashBladePowerShell.psd1` or `.psm1` — so it cannot change what goes on the wire.

## Related

Filed while measuring the same accounting question from the other scanner
(`tools/lib/PfbCmdletParamTools.ps1`), and *not* fixed here: **#141** (the wire-name resolver misses
three assignment shapes, leaving 126 parameters skipped rather than measured) and **#142** (two
genuine dead keys those skips were hiding). Same question, different file, no shared code — which is
why they are separate issues rather than part of this one.
